### PR TITLE
Subscription status fix

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -378,7 +378,7 @@ class Customer(StripeObject):
         current_subscription.status = sub.status
         current_subscription.cancel_at_period_end = sub.cancel_at_period_end
         current_subscription.period_end = convert_tstamp(sub, "current_period_end")
-		current_subscription.canceled_at = timezone.now()
+        current_subscription.canceled_at = timezone.now()
         current_subscription.save()
         cancelled.send(sender=self, stripe_response=sub)
         return current_subscription

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -378,6 +378,7 @@ class Customer(StripeObject):
         current_subscription.status = sub.status
         current_subscription.cancel_at_period_end = sub.cancel_at_period_end
         current_subscription.period_end = convert_tstamp(sub, "current_period_end")
+		current_subscription.canceled_at = timezone.now()
         current_subscription.save()
         cancelled.send(sender=self, stripe_response=sub)
         return current_subscription

--- a/djstripe/templates/djstripe/cancel_subscription.html
+++ b/djstripe/templates/djstripe/cancel_subscription.html
@@ -15,6 +15,18 @@
 <div class="row">
     <div class="col-xs-12">
         <h2>Cancel Subscription</h2>
+        
+		{% if not customer.current_subscription %}
+			<p>You have no subscription on file.</p>
+			<p>See your <a href="{% url 'djstripe:account' %}">account status</a> or better yet, <a href="{% url 'djstripe:subscribe' %}">subscribe</a>.</p>
+
+		{% elif customer.current_subscription.canceled_at and customer.current_subscription.start < customer.current_subscription.canceled_at %}
+    		<p>Your subscription was already cancelled.</p>
+			<p>See your <a href="{% url 'djstripe:account' %}">account status</a> or better yet, get a <a href="{% url 'djstripe:subscribe' %}">fresh subscription</a>.</p>
+
+    	{% else %}        
+
+        
         <p class="lead">
           Are you sure you want to cancel your subscription?
         </p>
@@ -33,6 +45,8 @@
             <a href="{% url 'djstripe:account' %}" class="btn btn-primary">I change my mind!</a>
             <button class="btn btn-danger">Cancel my subscription!</button>
         </form>
+        
+        {% endif %}
     </div>
 </div>
 {% endblock content %}

--- a/djstripe/templates/djstripe/includes/_subscription_status.html
+++ b/djstripe/templates/djstripe/includes/_subscription_status.html
@@ -1,12 +1,12 @@
 {% if subscription %} 
-    {% if subscription.status == subscription.STATUS_ACTIVE %}
+    {% if subscription.status == subscription.STATUS_ACTIVE and not subscription.current_period_end %}
         <div class="alert alert-success lead">
             Your subscription is <strong>{{ subscription.status }}</strong>.
         </div>
     {% else %}
         {% if subscription.status == subscription.STATUS_TRIALING %}
             {% if customer.plan and customer.card_kind %}
-                <div class="alert alert-info">
+                <div class="alert alert-info lead">
                     Your free trial will end in <strong>{{ subscription.current_period_end|timeuntil }}</strong> after which you commence a <strong>{{ subscription.plan_display }}</strong> plan.
                 </div>
             {% else %}
@@ -18,6 +18,13 @@
             {% if subscription.status == subscription.STATUS_CANCELLED %}
                 <div class="alert alert-danger lead">
                     Your subscription has been <strong>canceled</strong>.
+                    {% if subscription.is_period_current %}
+                        You can continue to use the site for another <strong>{{ subscription.current_period_end|timeuntil }}.</strong>
+                    {% endif %}
+                </div>
+            {% elif subscription.canceled_at and subscription.start < subscription.canceled_at  %}
+            	<div class="alert alert-warning lead">
+                    Your subscription has been <strong>canceled</strong> on {{ subscription.canceled_at }}
                     {% if subscription.is_period_current %}
                         You can continue to use the site for another <strong>{{ subscription.current_period_end|timeuntil }}.</strong>
                     {% endif %}

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -76,9 +76,10 @@ class CancelSubscriptionView(LoginRequiredMixin, PaymentsContextMixin, FormView)
         if current_subscription.status == current_subscription.STATUS_CANCELLED:
             messages.info(self.request, "Your account is now cancelled.")
         else:
-            messages.info(self.request, "Your account status is now '{}'".format(
-                current_subscription.status)
-            )
+			messages.info(self.request, "Your account status is now '{a}' until '{b}'".format(
+				a=current_subscription.status, b=current_subscription.current_period_end) 
+			)
+
         return redirect("djstripe:account")
 
 

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -76,9 +76,9 @@ class CancelSubscriptionView(LoginRequiredMixin, PaymentsContextMixin, FormView)
         if current_subscription.status == current_subscription.STATUS_CANCELLED:
             messages.info(self.request, "Your account is now cancelled.")
         else:
-			messages.info(self.request, "Your account status is now '{a}' until '{b}'".format(
-				a=current_subscription.status, b=current_subscription.current_period_end) 
-			)
+            messages.info(self.request, "Your account status is now '{a}' until '{b}'".format(
+                    a=current_subscription.status, b=current_subscription.current_period_end)
+            )
 
         return redirect("djstripe:account")
 


### PR DESCRIPTION
Here are the changes I made (I haven't added tests, sorry!):
- models.py: assignment of current_subscription.canceled_at in Customer.cancel_subscription(),
- views.py: slight change in message info in CancelSubscriptionView when status is not canceled,
- _subscription_status.html: added the case where subscription has been canceled but is active until period_end,
- cancel_subscription.html: if subscription has already been canceled, the view does not show "Cancel my subscription" but a simpler content.
