### PR TITLE
add check for 'fee' in data before assigning to avoid KeyError

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -844,7 +844,8 @@ class Charge(StripeObject):
         obj.amount = (data["amount"] / decimal.Decimal("100"))
         obj.paid = data["paid"]
         obj.refunded = data["refunded"]
-        obj.fee = (data["fee"] / decimal.Decimal("100"))
+        if data.get("fee"):
+            obj.fee = (data["fee"] / decimal.Decimal("100"))
         obj.disputed = data["dispute"] is not None
         obj.charge_created = convert_tstamp(data, "created")
         if data.get("description"):


### PR DESCRIPTION
In models.charge. sync_from_stripe_data, check for existence of 'fee' key in data before assigning to avoid KeyError
