### PR TITLE
Add action to be able to send emails from admin panel of charges

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -87,6 +87,15 @@ class CustomerSubscriptionStatusListFilter(admin.SimpleListFilter):
             return queryset.filter(current_subscription__status=self.value())
 
 
+def send_charge_receipt(modeladmin, request, queryset):
+    """
+    Function for sending receipts from the admin if a receipt is not sent for
+    a specific charge.
+    """
+    for charge in queryset:
+        charge.send_receipt()
+
+
 admin.site.register(
     Charge,
     readonly_fields = ('created',),
@@ -121,6 +130,7 @@ admin.site.register(
         "customer",
         "invoice"
     ],
+    actions=(send_charge_receipt,),
 )
 
 admin.site.register(


### PR DESCRIPTION
If for some reason an receipt email isn't sent, or needs to be resent, this lets be done based on the charge from the admin panel. Is useful so you don't have into production server shell and resend through command line.
