### PR TITLE
Fix admin typo & timezone issue. 

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -221,7 +221,7 @@ customer_has_card.short_description = "Customer Has Card"
 
 
 def customer_user(obj):
-    if hasattr(User, 'USERNAME_FIELD'):
+    if hasattr(obj, 'USERNAME_FIELD'):
         # Using a Django 1.5 User model
         username = getattr(obj, obj.USERNAME_FIELD)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ stripe>=1.9.2
 django-model-utils>=1.4.0
 django-braces>=1.2.1
 django-jsonfield>=0.9.10
+pytz>=2013.9


### PR DESCRIPTION
1) The first change set is to fix an obvious typo which leads to exception when visiting /admin/djstripe/invoice/ .

2) Timezone issue could be reproduced by changing the timezone of the local system to utf+n timezone (n>0, eg: utf+8), then the logic covered by tests/test_managers.py:test_started_during_has_records will failed. Install pytz will ensure the test timezone neutral. 
