### PR TITLE
Derive from SubscriptionMixin so that customer is added to context.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
   - DJANGO=1.5
   - DJANGO=1.6
 
-before_install:
-  - export PIP_USE_MIRRORS=true
-  - export PIP_INDEX_URL=https://simple.crate.io/
-
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 
   - pip install -r requirements_test.txt

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -64,7 +64,7 @@ class ChangeCardView(LoginRequiredMixin, PaymentsContextMixin, DetailView):
         return redirect("djstripe:account")
 
 
-class CancelSubscriptionView(LoginRequiredMixin, PaymentsContextMixin, FormView):
+class CancelSubscriptionView(LoginRequiredMixin, SubscriptionMixin, FormView):
     # TODO - needs tests
     template_name = "djstripe/cancel_subscription.html"
     form_class = CancelSubscriptionForm

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ stripe>=1.9.2
 django-model-utils>=1.4.0
 django-braces>=1.2.1
 django-jsonfield>=0.9.10
+pytz>=2013.9
 coverage
 mock>=1.0.1
 nose>=1.3.0


### PR DESCRIPTION
The cancel_subscription.html template references "customer" which is not available in the context as provided by PaymentsContextMixin. Deriving from SubscriptionMixin fixes this.
