### PR TITLE
Fixed admin invoice USERNAME_FIELD AttributeError

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -223,12 +223,12 @@ customer_has_card.short_description = "Customer Has Card"
 def customer_user(obj):
     if hasattr(obj, 'USERNAME_FIELD'):
         # Using a Django 1.5 User model
-        username = getattr(obj, obj.USERNAME_FIELD)
+        username = getattr(obj.customer.user, User.USERNAME_FIELD)
     else:
         # Using a pre-Django 1.5 User model
         username = obj.customer.user.username
     # In Django 1.5+ a User is not guaranteed to have an email field
-    email = getattr(obj, 'email', '')
+    email = getattr(obj.customer.user, 'email', '')
 
     return "{0} <{1}>".format(
         username,


### PR DESCRIPTION
Fixes the following error:

AttributeError at /admin/djstripe/invoice/
'Invoice' object has no attribute 'USERNAME_FIELD'
Request Method: GET
Request URL:    http://url.com/admin/djstripe/invoice/
Django Version: 1.6.2
Exception Type: AttributeError
Exception Value:  
'Invoice' object has no attribute 'USERNAME_FIELD'
Exception Location: /app/.heroku/python/lib/python2.7/site-packages/djstripe/admin.py in customer_user, line 226
Python Executable:  /app/.heroku/python/bin/python
Python Version: 2.7.4
