### PR TITLE
Use AUTH_USER_MODEL from project settings

### DIFF
--- a/djstripe/management/commands/djstripe_init_customers.py
+++ b/djstripe/management/commands/djstripe_init_customers.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
 
 from djstripe.models import Customer
 
@@ -9,7 +10,7 @@ from djstripe.models import Customer
 #   seems to blow up in management commands.
 from djstripe.settings import get_user_model
 
-User = get_user_model()
+User = settings.AUTH_USER_MODEL
 
 
 class Command(BaseCommand):

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -13,7 +13,7 @@ PY3 = sys.version > "3"
 def get_user_model():
     """ Place this in a function to avoid circular imports """
     try:
-        settings.AUTH_USER_MODEL
+        User = settings.AUTH_USER_MODEL
     except ImportError:
         from django.contrib.auth.models import User
     return User

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -13,8 +13,7 @@ PY3 = sys.version > "3"
 def get_user_model():
     """ Place this in a function to avoid circular imports """
     try:
-        from django.contrib.auth import get_user_model
-        User = get_user_model()
+        settings.AUTH_USER_MODEL
     except ImportError:
         from django.contrib.auth.models import User
     return User


### PR DESCRIPTION
Referencing this: https://groups.google.com/forum/#!msg/django-developers/lmT1JxsWHPo/N2V9U5SN9gwJ

Was seeing this error: https://gist.github.com/stickwithjosh/5bbd4d6387266e8f2d32

This sorts it out. Hooray!
