### PR TITLE
CurrentSubscription state is not updated after users cancels and subscribes again

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -397,7 +397,7 @@ class Customer(StripeObject):
         current_subscription.status = sub.status
         current_subscription.cancel_at_period_end = sub.cancel_at_period_end
         current_subscription.period_end = convert_tstamp(sub, "current_period_end")
-        current_subscription.canceled_at = timezone.now()
+        current_subscription.canceled_at = convert_tstamp(sub, "canceled_at") or timezone.now()
         current_subscription.save()
         cancelled.send(sender=self, stripe_response=sub)
         return current_subscription
@@ -494,6 +494,7 @@ class Customer(StripeObject):
                 sub_obj.amount = (sub.plan.amount / decimal.Decimal("100"))
                 sub_obj.status = sub.status
                 sub_obj.cancel_at_period_end = sub.cancel_at_period_end
+                sub_obj.canceled_at = convert_tstamp(sub, "canceled_at")
                 sub_obj.start = convert_tstamp(sub.start)
                 sub_obj.quantity = sub.quantity
                 sub_obj.save()
@@ -510,6 +511,7 @@ class Customer(StripeObject):
                     amount=(sub.plan.amount / decimal.Decimal("100")),
                     status=sub.status,
                     cancel_at_period_end=sub.cancel_at_period_end,
+                    canceled_at=convert_tstamp(sub, "canceled_at"),
                     start=convert_tstamp(sub.start),
                     quantity=sub.quantity
                 )

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -493,7 +493,7 @@ class Customer(StripeObject):
                 )
                 sub_obj.amount = (sub.plan.amount / decimal.Decimal("100"))
                 sub_obj.status = sub.status
-                sub_obj.cancel_at_period_end = CANCELLATION_AT_PERIOD_END
+                sub_obj.cancel_at_period_end = sub.cancel_at_period_end
                 sub_obj.start = convert_tstamp(sub.start)
                 sub_obj.quantity = sub.quantity
                 sub_obj.save()
@@ -509,7 +509,7 @@ class Customer(StripeObject):
                     ),
                     amount=(sub.plan.amount / decimal.Decimal("100")),
                     status=sub.status,
-                    cancel_at_period_end=CANCELLATION_AT_PERIOD_END,
+                    cancel_at_period_end=sub.cancel_at_period_end,
                     start=convert_tstamp(sub.start),
                     quantity=sub.quantity
                 )

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -396,7 +396,7 @@ class Customer(StripeObject):
             )
         current_subscription.status = sub.status
         current_subscription.cancel_at_period_end = sub.cancel_at_period_end
-        current_subscription.period_end = convert_tstamp(sub, "current_period_end")
+        current_subscription.current_period_end = convert_tstamp(sub, "current_period_end")
         current_subscription.canceled_at = convert_tstamp(sub, "canceled_at") or timezone.now()
         current_subscription.save()
         cancelled.send(sender=self, stripe_response=sub)


### PR DESCRIPTION
There is an issue that prevents marking a cancelled subscription as active after a customer subscribes again.

The actions are properly executed using the Stripe API, but a new subscription state is not copied into the `CurrentSubscription` object.

This influence some parts of the UI and suggests the subscription is cancelled while actually the customer will be billed at the end of the period.

This patch allows the `cancel_at_period_end` and `canceled_at` fields to be updated according to Stripe API response.
Additionally it corrects the `current_period_end` attribute assignment (subscription object does not have `period_end` field).

I gave it some initial testing and it works so far, but I may not be able to predict all possible implications of this change. The remaining question is if there are any other fields that should be synchronized with Stripe data during subscription change?
