### PR TITLE
Fix for app initialization with django 1.7

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -13,8 +13,7 @@ PY3 = sys.version > "3"
 def get_user_model():
     """ Place this in a function to avoid circular imports """
     try:
-        from django.contrib.auth import get_user_model
-        User = get_user_model()
+        User = settings.AUTH_USER_MODEL
     except ImportError:
         from django.contrib.auth.models import User
     return User


### PR DESCRIPTION
With the new app loading in Django 1.7 using `get_user_mode` doesn't work when running migrations because things haven't loaded properly. The solution is to use `settings.AUTH_USER_MODEL` instead.

Doc:
https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#django.contrib.auth.get_user_model
Doc Commit:
https://github.com/django/django/pull/2416/files
