### PR TITLE
Fix status message when on a free trial with plan selected

### DIFF
--- a/djstripe/templates/djstripe/includes/_subscription_status.html
+++ b/djstripe/templates/djstripe/includes/_subscription_status.html
@@ -5,7 +5,7 @@
         </div>
     {% else %}
         {% if subscription.status == subscription.STATUS_TRIALING %}
-            {% if customer.plan and customer.card_kind %}
+            {% if subscription.plan and customer.card_kind %}
                 <div class="alert alert-info lead">
                     Your free trial will end in <strong>{{ subscription.current_period_end|timeuntil }}</strong> after which you commence a <strong>{{ subscription.plan_display }}</strong> plan.
                 </div>


### PR DESCRIPTION
"plan" attribute is on the subscription not the customer, old version would always display the "..you will need to get a subscription to continue using the site" version of the message even if a plan was already selected.
