### PR TITLE
Fix AppRegistryNotReady exception at import time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO=1.4
   - DJANGO=1.5
   - DJANGO=1.6
+  - DJANGO=1.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors
 * centrove
 * Chris Halpert (@cphalpert)
 * Thomas Parslow (@almost)
+* Leonid Shvechikov (@shvechikov)

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -4,6 +4,7 @@ import sys
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import importlib
+from django.utils.functional import SimpleLazyObject
 
 from . import safe_settings
 
@@ -19,7 +20,7 @@ def get_user_model():
         from django.contrib.auth.models import User
     return User
 
-User = get_user_model()
+User = SimpleLazyObject(get_user_model)
 
 
 def plan_from_stripe_id(stripe_id):


### PR DESCRIPTION
This commit fixes an issue with loading djstripe app (after adding
'djstripe' to settings.INSTALLED_APPS) in my django project
(Django 1.7).

The problem was with using django.contrib.auth.get_user_model() inside
djstripe.settings module at import time which is not recommened
practice:

> Another common culprit is django.contrib.auth.get_user_model().
> Use the AUTH_USER_MODEL setting to reference the User model
> at import time.

https://docs.djangoproject.com/en/1.7/ref/applications/#troubleshooting

Fixed by using SimpleLazyObject.

The original traceback:

``` pytb
Traceback (most recent call last):
  File ".../my_project/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File ".../site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File ".../site-packages/django/core/management/__init__.py", line 354, in execute
    django.setup()
  File ".../site-packages/django/__init__.py", line 21, in setup
    apps.populate(settings.INSTALLED_APPS)
  File ".../site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File ".../site-packages/django/apps/config.py", line 197, in import_models
    self.models_module = import_module(models_module_name)
  File ".../python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File ".../site-packages/djstripe/models.py", line 24, in <module>
    from .settings import PAYMENTS_PLANS, INVOICE_FROM_EMAIL, SEND_INVOICE_RECEIPT_EMAILS
  File ".../site-packages/djstripe/settings.py", line 22, in <module>
    User = get_user_model()
  File ".../site-packages/djstripe/settings.py", line 17, in get_user_model
    User = get_user_model()
  File ".../site-packages/django/contrib/auth/__init__.py", line 136, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL)
  File ".../site-packages/django/apps/registry.py", line 199, in get_model
    self.check_models_ready()
  File ".../site-packages/django/apps/registry.py", line 131, in check_models_ready
    raise AppRegistryNotReady("Models aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.
```
