### PR TITLE
Use user.get_username() instead of user.username

### DIFF
--- a/djstripe/management/commands/djstripe_sync_customers.py
+++ b/djstripe/management/commands/djstripe_sync_customers.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             perc = int(round(100 * (float(count) / float(total))))
             print(
                 "[{0}/{1} {2}%] Syncing {3} [{4}]".format(
-                   count, total, perc, user.username, user.pk
+                   count, total, perc, user.get_username(), user.pk
                 )
             )
             sync_customer(user)


### PR DESCRIPTION
To support custom User models.
Now it breaks if User model doesn't have `username` field.

Custom User models was introduced in Django 1.5 release but I see 1.4 in `.travis.yml`.
Do we need to support Django 1.4?
