### PR TITLE
Explicitly specify tox's virtual environment names.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py27, py33
 
-[testenv]
+[testenv:py27, py33]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/dj-stripe
     


### PR DESCRIPTION
I was getting this error locally:

```
$ tox -e py27
GLOB sdist-make: /Users/audreyr/code/dj-stripe/setup.py
py27 inst-nodeps: /Users/audreyr/code/dj-stripe/.tox/dist/dj-stripe-0.3.6.zip
py27 runtests: commands[0] | python runtests.py
Traceback (most recent call last):
  File "runtests.py", line 47, in <module>
    from django_nose import NoseTestSuiteRunner
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django_nose/__init__.py", line 4, in <module>
    from django_nose.runner import *
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django_nose/runner.py", line 20, in <module>
    from django.core.management.commands.loaddata import Command
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 11, in <module>
    from django.core import serializers
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/core/serializers/__init__.py", line 22, in <module>
    from django.core.serializers.base import SerializerDoesNotExist
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/core/serializers/base.py", line 5, in <module>
    from django.db import models
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/__init__.py", line 40, in <module>
    backend = load_backend(connection.settings_dict['ENGINE'])
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/__init__.py", line 34, in __getattr__
    return getattr(connections[DEFAULT_DB_ALIAS], item)
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/utils.py", line 93, in __getitem__
    backend = load_backend(db['ENGINE'])
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/utils.py", line 27, in load_backend
    return import_module('.base', backend_name)
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/backends/postgresql_psycopg2/base.py", line 14, in <module>
    from django.db.backends.postgresql_psycopg2.creation import DatabaseCreation
  File "/Users/audreyr/code/dj-stripe/.tox/py27/lib/python2.7/site-packages/django/db/backends/postgresql_psycopg2/creation.py", line 1, in <module>
    import psycopg2.extensions
ImportError: No module named psycopg2.extensions
ERROR: InvocationError: '/Users/audreyr/code/dj-stripe/.tox/py27/bin/python runtests.py'
__________________________________________________________________ summary __________________________________________________________________
ERROR:   py27: commands failed
```

Explicitly specifying `NAME` as per http://tox.readthedocs.org/en/latest/config.html fixed it for me:

```
$ tox -e py27
GLOB sdist-make: /Users/audreyr/code/dj-stripe/setup.py
py27 recreate: /Users/audreyr/code/dj-stripe/.tox/py27
py27 inst: /Users/audreyr/code/dj-stripe/.tox/dist/dj-stripe-0.3.6.zip
__________________________________________________________________ summary __________________________________________________________________
  py27: commands succeeded
  congratulations :)
```
