### PR TITLE
Remove Python 2.6 from Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - 3.3
   - 2.7
-  - 2.6
 
 env:
   - DJANGO=1.4


### PR DESCRIPTION
This PR is in preparation for getting dj-stripe working with Django 1.7.

> Django 1.6 will be the final release series to support Python 2.6; beginning with Django 1.7, the minimum supported Python version will be 2.7.
