### PR TITLE
Drop Django 1.4 support in prep for merging #107.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 2.7
 
 env:
-  - DJANGO=1.4
   - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7


### PR DESCRIPTION
Doing this will allow us to support 1.5+ custom User models.
