### PR TITLE
Remove "account" bug in Middleware

### DIFF
--- a/djstripe/middleware.py
+++ b/djstripe/middleware.py
@@ -59,9 +59,6 @@ class SubscriptionPaymentMiddleware(object):
             if "({0})".format(match.app_name) in EXEMPT:
                 return
 
-            if "account" in request.path:
-                raise Exception(match)
-
             if "[{0}]".format(match.namespace) in EXEMPT:
                 return
 


### PR DESCRIPTION
Apparently a bug introduced, raising an exception when "account" is in the path most probably won't let your login/logout urls work.
