### PR TITLE
Fix logic for subscription redirect in docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,7 +83,7 @@ If you want to quickly constrain a single Class-Based View, the ``djstripe.decor
 * **authenticated** users are redirected to ``djstripe.views.SubscribeFormView`` unless they...:
 
     * ... have a valid subscription --or--
-    * ... are not ``user.is_staff==True``.
+    * ... are ``user.is_staff==True``.
 
 * **anonymous** users always raise a ``django.core.exceptions.ImproperlyConfigured`` exception when they encounter these systems. This is done because dj-stripe is not an authentication system.
 


### PR DESCRIPTION
Fix for logic for documentation of when a redirect to DJSTRIPE_SUBSCRIPTION_REDIRECT in SubscriptionPaymentMiddleware is performed. The redirect does _not_ occur when `user.is_staff==True`:

``` python
def process_request(self, request):
    if request.user.is_authenticated() and not request.user.is_staff:
        #...
        if not customer.has_active_subscription():
            return redirect(DJSTRIPE_SUBSCRIPTION_REDIRECT)
```
