### PR TITLE
Invoice now inherits from StripeObject model.

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -656,10 +656,9 @@ class CurrentSubscription(TimeStampedModel):
         return True
 
 
-class Invoice(TimeStampedModel):
+class Invoice(StripeObject):
     # TODO - needs tests
 
-    stripe_id = models.CharField(max_length=50)
     customer = models.ForeignKey(Customer, related_name="invoices")
     attempted = models.NullBooleanField()
     attempts = models.PositiveIntegerField(null=True)


### PR DESCRIPTION
The `Invoice` model object can inherit from the `StripeObject` because it is unique.  Unlike the invoice line items.
