### PR TITLE
Add deprecation notice of django 1.6

### DIFF
--- a/djstripe/__init__.py
+++ b/djstripe/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+import warnings
+
+from django import get_version as get_django_version
 
 __title__ = "dj-stripe"
 __summary__ = "Django + Stripe Made Easy"
@@ -12,3 +15,9 @@ __email__ = "pydanny@gmail.com"
 __license__ = "BSD"
 __license__ = "License :: OSI Approved :: BSD License"
 __copyright__ = "Copyright 2015 Daniel Greenfeld"
+
+if get_django_version() <= '1.6.x':
+    msg = "dj-stripe deprecation notice: Django 1.6 and lower are deprecated\n" \
+            "and will be removed in dj-stripe 0.5.0.\n" \
+            "Reference: https://github.com/pydanny/dj-stripe/issues/173"
+    warnings.warn(msg)

--- a/djstripe/__init__.py
+++ b/djstripe/__init__.py
@@ -18,6 +18,6 @@ __copyright__ = "Copyright 2015 Daniel Greenfeld"
 
 if get_django_version() <= '1.6.x':
     msg = "dj-stripe deprecation notice: Django 1.6 and lower are deprecated\n" \
-            "and will be removed in dj-stripe 0.5.0.\n" \
+            "and will be removed in dj-stripe 0.6.0.\n" \
             "Reference: https://github.com/pydanny/dj-stripe/issues/173"
     warnings.warn(msg)


### PR DESCRIPTION
Purpose: Provide warning for users of dj-stripe about the pending deprecation of Django 1.6 from the project.
Reference:  Issue #173
