### PR TITLE
add stripe-id to class object

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -68,7 +68,7 @@ class EventProcessingException(TimeStampedModel):
         )
 
     def __str__(self):
-        return "<{0}, pk={1}, Event={2}>".format(self.message, self.pk, self.event)
+        return "<{message}, pk={pk}, Event={event}>".format(message=self.message, pk=self.pk, event=self.event)
 
 
 @python_2_unicode_compatible
@@ -87,7 +87,7 @@ class Event(StripeObject):
         return self.validated_message
 
     def __str__(self):
-        return "<{0}, stripe_id={1}>".format(self.kind, self.stripe_id)
+        return "<{kind}, stripe_id={stripe_id}>".format(kind=self.kind, stripe_id=self.stripe_id)
 
     def link_customer(self):
         stripe_customer_id = None
@@ -227,7 +227,7 @@ class Transfer(StripeObject):
     objects = TransferManager()
 
     def __str__(self):
-        return "<amount={0}, status={1}, stripe_id={2}>".format(self.amount, self.status, self.stripe_id)
+        return "<amount={amount}, status={status}, stripe_id={stripe_id}>".format(amount=self.amount, status=self.status, stripe_id=self.stripe_id)
 
     def update_status(self):
         self.status = stripe.Transfer.retrieve(self.stripe_id).status
@@ -307,7 +307,7 @@ class Customer(StripeObject):
     objects = CustomerManager()
 
     def __str__(self):
-        return "<{0}, stripe_id={1}>".format(smart_text(self.subscriber), self.stripe_id)
+        return "<{subscriber}, stripe_id={stripe_id}>".format(subscriber=smart_text(self.subscriber), stripe_id=self.stripe_id)
 
     @property
     def stripe_customer(self):
@@ -662,7 +662,7 @@ class Invoice(StripeObject):
         ordering = ["-date"]
 
     def __str__(self):
-        return "<total={0}, paid={1}, stripe_id={2}>".format(self.total, smart_text(self.paid), self.stripe_id)
+        return "<total={total}, paid={paid}, stripe_id={stripe_id}>".format(total=self.total, paid=smart_text(self.paid), stripe_id=self.stripe_id)
 
     def retry(self):
         if not self.paid and not self.closed:
@@ -792,7 +792,7 @@ class InvoiceItem(TimeStampedModel):
     quantity = models.IntegerField(null=True)
 
     def __str__(self):
-        return "<amount={0}, plan={1}, stripe_id={2}>".format(self.amount, smart_text(self.plan), self.stripe_id)
+        return "<amount={amount}, plan={plan}, stripe_id={stripe_id}>".format(amount=self.amount, plan=smart_text(self.plan), stripe_id=self.stripe_id)
 
     def plan_display(self):
         return djstripe_settings.PAYMENTS_PLANS[self.plan]["name"]
@@ -817,7 +817,7 @@ class Charge(StripeObject):
     objects = ChargeManager()
 
     def __str__(self):
-        return "<amount={0}, paid={1}, stripe_id={2}>".format(self.amount, smart_text(self.paid), self.stripe_id)
+        return "<amount={amount}, paid={paid}, stripe_id={stripe_id}>".format(amount=self.amount, paid=smart_text(self.paid), stripe_id=self.stripe_id)
 
     def calculate_refund_amount(self, amount=None):
         eligible_to_refund = self.amount - (self.amount_refunded or 0)
@@ -919,7 +919,7 @@ class Plan(StripeObject):
     trial_period_days = models.IntegerField(null=True)
 
     def __str__(self):
-        return "<{0}, stripe_id={1}>".format(smart_text(self.name), self.stripe_id)
+        return "<{name}, stripe_id={stripe_id}>".format(name=smart_text(self.name), stripe_id=self.stripe_id)
 
     @classmethod
     def create(cls, metadata={}, **kwargs):

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -68,7 +68,7 @@ class EventProcessingException(TimeStampedModel):
         )
 
     def __str__(self):
-        return "<%s, pk=%s, Event=%s>" % (self.message, self.pk, self.event)
+        return "<{0}, pk={1}, Event={2}>".format(self.message, self.pk, self.event)
 
 
 @python_2_unicode_compatible
@@ -87,7 +87,7 @@ class Event(StripeObject):
         return self.validated_message
 
     def __str__(self):
-        return "<%s, stripe_id=%s>" % (self.kind, self.stripe_id)
+        return "<{0}, stripe_id={1}>".format(self.kind, self.stripe_id)
 
     def link_customer(self):
         stripe_customer_id = None
@@ -227,7 +227,7 @@ class Transfer(StripeObject):
     objects = TransferManager()
 
     def __str__(self):
-        return "<amount=%d, status=%s, stripe_id=%s>" % (self.amount, self.status, self.stripe_id)
+        return "<amount={0}, status={1}, stripe_id={2}>".format(self.amount, self.status, self.stripe_id)
 
     def update_status(self):
         self.status = stripe.Transfer.retrieve(self.stripe_id).status
@@ -307,7 +307,7 @@ class Customer(StripeObject):
     objects = CustomerManager()
 
     def __str__(self):
-        return "<%s, stripe_id=%s>" % (smart_text(self.subscriber), self.stripe_id)
+        return "<{0}, stripe_id={1}>".format(smart_text(self.subscriber), self.stripe_id)
 
     @property
     def stripe_customer(self):
@@ -662,7 +662,7 @@ class Invoice(StripeObject):
         ordering = ["-date"]
 
     def __str__(self):
-        return "<total=%d, paid=%s, stripe_id=%s>" % (self.total, smart_text(self.paid), self.stripe_id)
+        return "<total={0}, paid={1}, stripe_id={2}>".format(self.total, smart_text(self.paid), self.stripe_id)
 
     def retry(self):
         if not self.paid and not self.closed:
@@ -792,7 +792,7 @@ class InvoiceItem(TimeStampedModel):
     quantity = models.IntegerField(null=True)
 
     def __str__(self):
-        return "<amount=%d, plan=%s, stripe_id=%s>" % (self.amount, smart_text(self.plan), self.stripe_id)
+        return "<amount={0}, plan={1}, stripe_id={2}>".format(self.amount, smart_text(self.plan), self.stripe_id)
 
     def plan_display(self):
         return djstripe_settings.PAYMENTS_PLANS[self.plan]["name"]
@@ -817,7 +817,7 @@ class Charge(StripeObject):
     objects = ChargeManager()
 
     def __str__(self):
-        return "<amount=%d, paid=%s, stripe_id=%s>" % (self.amount, smart_text(self.paid), self.stripe_id)
+        return "<amount={0}, paid={1}, stripe_id={2}>".format(self.amount, smart_text(self.paid), self.stripe_id)
 
     def calculate_refund_amount(self, amount=None):
         eligible_to_refund = self.amount - (self.amount_refunded or 0)
@@ -919,7 +919,7 @@ class Plan(StripeObject):
     trial_period_days = models.IntegerField(null=True)
 
     def __str__(self):
-        return "<%s, stripe_id=%s>" % (smart_text(self.name), self.stripe_id)
+        return "<{0}, stripe_id={1}>".format(smart_text(self.name), self.stripe_id)
 
     @classmethod
     def create(cls, metadata={}, **kwargs):

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -87,7 +87,7 @@ class Event(StripeObject):
         return self.validated_message
 
     def __str__(self):
-        return "%s - %s" % (self.kind, self.stripe_id)
+        return "<%s, stripe_id=%s>" % (self.kind, self.stripe_id)
 
     def link_customer(self):
         stripe_customer_id = None
@@ -226,6 +226,9 @@ class Transfer(StripeObject):
 
     objects = TransferManager()
 
+    def __str__(self):
+        return "<amount=%d, status=%s, stripe_id=%s>" % (self.amount, self.status, self.stripe_id)
+
     def update_status(self):
         self.status = stripe.Transfer.retrieve(self.stripe_id).status
         self.save()
@@ -304,7 +307,7 @@ class Customer(StripeObject):
     objects = CustomerManager()
 
     def __str__(self):
-        return smart_text(self.subscriber)
+        return "<%s, stripe_id=%s>" % (smart_text(self.subscriber), self.stripe_id)
 
     @property
     def stripe_customer(self):
@@ -658,6 +661,9 @@ class Invoice(StripeObject):
     class Meta:
         ordering = ["-date"]
 
+    def __str__(self):
+        return "<total=%d, paid=%s, stripe_id=%s>" % (self.total, smart_text(self.paid), self.stripe_id)
+
     def retry(self):
         if not self.paid and not self.closed:
             inv = stripe.Invoice.retrieve(self.stripe_id)
@@ -785,6 +791,9 @@ class InvoiceItem(TimeStampedModel):
     plan = models.CharField(max_length=100, null=True, blank=True)
     quantity = models.IntegerField(null=True)
 
+    def __str__(self):
+        return "<amount=%d, plan=%s, stripe_id=%s>" % (self.amount, smart_text(self.plan), self.stripe_id)
+
     def plan_display(self):
         return djstripe_settings.PAYMENTS_PLANS[self.plan]["name"]
 
@@ -806,6 +815,9 @@ class Charge(StripeObject):
     charge_created = models.DateTimeField(null=True, blank=True)
 
     objects = ChargeManager()
+
+    def __str__(self):
+        return "<amount=%d, paid=%s, stripe_id=%s>" % (self.amount, smart_text(self.paid), self.stripe_id)
 
     def calculate_refund_amount(self, amount=None):
         eligible_to_refund = self.amount - (self.amount_refunded or 0)
@@ -907,7 +919,7 @@ class Plan(StripeObject):
     trial_period_days = models.IntegerField(null=True)
 
     def __str__(self):
-        return self.name
+        return "<%s, stripe_id=%s>" % (smart_text(self.name), self.stripe_id)
 
     @classmethod
     def create(cls, metadata={}, **kwargs):

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -116,6 +116,10 @@ class ChargeTest(TestCase):
                                               date=timezone.now(),
                                               charge="ch_xxxxxxxxxxxxxxx")
 
+    def test_str(self):
+        charge = Charge(amount=50, paid=True, stripe_id='charge_xxxxxxxxxxxxxx')
+        self.assertEqual("<amount=50, paid=True, stripe_id=charge_xxxxxxxxxxxxxx>", str(charge))
+
     def test_sync_from_stripe_data(self):
         charge = Charge.sync_from_stripe_data(FAKE_CHARGE)
 

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -39,7 +39,7 @@ class TestCustomer(TestCase):
         )
 
     def test_tostring(self):
-        self.assertEquals("patrick", str(self.customer))
+        self.assertEquals("<patrick, stripe_id=cus_xxxxxxxxxxxxxxx>", str(self.customer))
 
     @patch("stripe.Customer.retrieve")
     def test_customer_purge_leaves_customer_record(self, customer_retrieve_fake):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -61,6 +61,16 @@ class EventTest(TestCase):
             subscriber=self.user
         )
 
+    def test_tostring(self):
+        event = Event.objects.create(
+            stripe_id=self.message["id"],
+            kind="eventkind",
+            webhook_message=self.message,
+            validated_message=self.message,
+            valid=True
+        )
+        self.assertEquals("<eventkind, stripe_id=evt_xxxxxxxxxxxxx>", str(event))
+
     def test_link_customer_customer_created(self):
         msg = {
             "created": 1363911708,

--- a/tests/test_event_processing_exception.py
+++ b/tests/test_event_processing_exception.py
@@ -73,19 +73,19 @@ class TestEventProcessingException(TestCase):
 
     def test_tostring(self):
         # Not sure if this is normal, but self.exception returns:
-        # AssertionError: '<IOError, pk=1, Event=ping - evt_xxxxxxxxxxxxx>' != '<Error in transmisssion., pk=1, Event=ping - evt_xxxxxxxxxxxxx>'
+        # AssertionError: '<IOError, pk=1, Event=ping - evt_xxxxxxxxxxxxx>' != '<Error in transmission., pk=1, Event=ping - evt_xxxxxxxxxxxxx>'
         # - <IOError, pk=1, Event=ping - evt_xxxxxxxxxxxxx>
         # ?  --
-        # + <Error in transmisssion., pk=1, Event=ping - evt_xxxxxxxxxxxxx>
+        # + <Error in transmission., pk=1, Event=<ping, stripe_id=evt_xxxxxxxxxxxxx>>
         # ?       ++++++++++++++++++
 
         try:
-            raise IOError("Error in transmisssion.")
+            raise IOError("Error in transmission.")
         except IOError as error:
             EventProcessingException.log(data=self.msg["data"], exception=error, event=self.event)
             exception = EventProcessingException.objects.get(event=self.event)
 
-        self.assertIn('<Error in transmisssion., pk=1, Event=ping - evt_xxxxxxxxxxxxx>', str(exception))
+        self.assertIn('<Error in transmission., pk=1, Event=<ping, stripe_id=evt_xxxxxxxxxxxxx>>', str(exception))
 
     def test_non_crud_link_customer_on_non_customer(self):
         self.assertEqual(None, self.event.link_customer())
@@ -95,4 +95,3 @@ class TestEventProcessingException(TestCase):
         event_copy.validated_message = self.invalid_customer_msg
         event_copy.save()
         self.assertEqual(None, event_copy.link_customer())
-

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -100,6 +100,9 @@ class InvoiceTest(TestCase):
                                               date=timezone.now(),
                                               charge="crg_xxxxxxxxx12345")
 
+    def test_tostring(self):
+        self.assertEquals("<total=50.00, paid=False, stripe_id=inv_xxxxxxxx123456>", str(self.invoice))
+
     @patch("stripe.Invoice.retrieve")
     def test_retry_true(self, invoice_retrieve_mock):
         return_value = self.invoice.retry()

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -16,3 +16,7 @@ class InvoiceItemTest(TestCase):
     def test_plan_display(self):
         invoiceitem = InvoiceItem(plan="test")
         self.assertEqual("Test Plan 1", invoiceitem.plan_display())
+
+    def test_tostring(self):
+        invoiceitem = InvoiceItem(plan="test", amount=50, stripe_id='inv_xxxxxxxx123456')
+        self.assertEquals("<amount=50, plan=test, stripe_id=inv_xxxxxxxx123456>", str(invoiceitem))

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -79,7 +79,7 @@ class PlanTest(TestCase):
         self.plan = Plan(name=self.test_name, stripe_id=self.test_stripe_id)
 
     def test_str(self):
-        self.assertEqual(self.test_name, str(self.plan))
+        self.assertEqual("<test_name, stripe_id=plan_xxxxxxxxxxxx>", str(self.plan))
 
     @patch("stripe.Plan.retrieve", return_value="soup")
     def test_stripe_plan(self, plan_retrieve_mock):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -141,3 +141,6 @@ class TransferTest(TestCase):
         transfer_instance = Transfer.objects.get(stripe_id="salmon")
         transfer_receive_mock.assert_called_once_with(transfer_instance.stripe_id)
         self.assertEqual(transfer_instance.status, "fish")
+
+        # Test to string
+        self.assertEquals("<amount=4.55, status=fish, stripe_id=salmon>", str(transfer_instance))


### PR DESCRIPTION
I found it handy to have stripe-id object when debugging on shell, so it's easy to cross check those objects on Stripe, here a patch that add the stripe-id to the str method
