### PR TITLE
Check for Stripe subscription when calling update_plan_quantity

### DIFF
--- a/djstripe/exceptions.py
+++ b/djstripe/exceptions.py
@@ -4,3 +4,7 @@ from __future__ import unicode_literals
 
 class SubscriptionCancellationFailure(Exception):
     pass
+
+
+class SubscriptionUpdateFailure(Exception):
+    pass

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -499,6 +499,7 @@ class Customer(StripeObject):
     def update_plan_quantity(self, quantity, charge_immediately=False):
         stripe_subscription = self.stripe_customer.subscription
         if not stripe_subscription:
+            self.sync_current_subscription()
             raise SubscriptionUpdateFailure("Customer does not have a subscription with Stripe")
         self.subscribe(
             plan=djstripe_settings.plan_from_stripe_id(stripe_subscription.plan.id),

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -497,11 +497,11 @@ class Customer(StripeObject):
             return sub_obj
 
     def update_plan_quantity(self, quantity, charge_immediately=False):
-        sub = self.stripe_customer.subscription
-        if not sub:
+        stripe_subscription = self.stripe_customer.subscription
+        if not stripe_subscription:
             raise SubscriptionUpdateFailure("Customer does not have a subscription with Stripe")
         self.subscribe(
-            plan=djstripe_settings.plan_from_stripe_id(sub.plan.id),
+            plan=djstripe_settings.plan_from_stripe_id(stripe_subscription.plan.id),
             quantity=quantity,
             charge_immediately=charge_immediately
         )


### PR DESCRIPTION
I believe as things currently stand, calling update_plan_quantity without an existing Stripe subscription (but with a current_subscription) will raise an AttributeError, since stripe_customer.subscription will be None. This PR just provides an explicit test for that edge case.
