### PR TITLE
If running on system not in UTC, don't fail the whole test suite

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -45,6 +45,7 @@ settings.configure(
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware"
     ),
+    NOSE_PLUGINS = ['nose.plugins.skip.Skip', ],
     SITE_ID=1,
     STRIPE_PUBLIC_KEY=os.environ.get("STRIPE_PUBLIC_KEY", ""),
     STRIPE_SECRET_KEY=os.environ.get("STRIPE_SECRET_KEY", ""),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,8 +23,14 @@ from djstripe.utils import subscriber_has_active_subscription, get_supported_cur
 from unittest2 import TestCase as AssertWarnsEnabledTestCase
 from mock import patch
 from stripe import api_key
+from nose.plugins.skip import SkipTest
 
 from tests.apps.testapp.models import Organization
+from django.utils.timezone import get_current_timezone, utc
+
+# Some tests will always fail if test is run on a computer whose clock is not in UTC. Skip those tests
+# rather than failing, so that coverage and other data can still be collated in runtests.py
+system_clock_is_utc = get_current_timezone() == utc
 
 
 class TestDeprecationWarning(AssertWarnsEnabledTestCase):
@@ -78,6 +84,8 @@ class TestTimestampConversion(TestCase):
 
     @override_settings(USE_TZ=False)
     def test_conversion_without_field_name_no_tz(self):
+        if not system_clock_is_utc:
+            raise SkipTest()
         stamp = convert_tstamp(1365567407)
         self.assertEquals(
             stamp,
@@ -86,6 +94,8 @@ class TestTimestampConversion(TestCase):
 
     @override_settings(USE_TZ=False)
     def test_conversion_with_field_name_no_tz(self):
+        if not system_clock_is_utc:
+            raise SkipTest()
         stamp = convert_tstamp({"my_date": 1365567407}, "my_date")
         self.assertEquals(
             stamp,


### PR DESCRIPTION
If running on system not in UTC, don't fail the whole test suite (and skip running coverage).  Instead, raise SkipTest for tests requiring system == UTC (currently just 2 tests)

Sorry, I'm not able to test this change on a UTC box (lame I know). I assume submitting this PR I will trigger a travis run and that will tell us how it worked on a system running in UTC.
