### PR TITLE
Fix for issue #233

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -795,7 +795,7 @@ class Invoice(StripeObject):
 
     @classmethod
     def handle_event(cls, event):
-        valid_events = ["invoice.payment_failed", "invoice.payment_succeeded"]
+        valid_events = ["invoice.payment_failed", "invoice.payment_succeeded", "invoice.created", ]
         if event.kind in valid_events:
             invoice_data = event.message["data"]["object"]
             stripe_invoice = stripe.Invoice.retrieve(invoice_data["id"])

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -234,9 +234,9 @@ class EventTest(TestCase):
         event.process()
         self.assertFalse(event.processed)
 
-    @patch('djstripe.models.Event.link_customer')
-    @patch('djstripe.models.Invoice.handle_event')
-    def test_process_invoice_event(self, handle_event_mock, link_customer_mock):
+    @patch('stripe.Invoice.retrieve')
+    @patch('djstripe.models.Invoice.sync_from_stripe_data')
+    def test_process_invoice_event(self, stripe_sync_mock, retrieve_mock):
         event = Event.objects.create(
             stripe_id=self.message["id"],
             kind="invoice.created",
@@ -244,10 +244,8 @@ class EventTest(TestCase):
             validated_message=self.message,
             valid=True
         )
-
         event.process()
-        link_customer_mock.assert_called_once_with()
-        handle_event_mock.assert_called_once_with(event)
+        retrieve_mock.assert_called_once_with(self.message['data']['object']['id'])
         self.assertTrue(event.processed)
 
     @patch('djstripe.models.Customer.record_charge')


### PR DESCRIPTION
Actually respond to invoice.created event (was not processed before).  Also, update that test case to make it properly assert this.

Fix for #233 
