### PR TITLE
Improve windows compatability for runtests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,3 +1,19 @@
+"""
+If having trouble due to system clock not being UTC, set this env before running runtests:
+       DJS_SKIP_UTC_TESTS="True"
+
+If you need to skip the coverage test (e.g. it apparently interferes with the debugger in PyCharm):
+       DJS_SKIP_COVERAGE="True"
+
+
+Rather than making these options permanent in your environment, it is recommended you run like this (which sets env
+for just one command):
+
+   DJS_SKIP_COVERAGE=True python runtests.py
+"""
+
+from distutils.util import strtobool
+
 import os
 import sys
 
@@ -7,9 +23,12 @@ from django.conf import settings
 from coverage import coverage
 from termcolor import colored
 
-cov = coverage(config_file=True)
-cov.erase()
-cov.start()
+disable_coverage = strtobool(os.environ.get('DJS_SKIP_COVERAGE', "False"))
+
+if not disable_coverage:
+    cov = coverage(config_file=True)
+    cov.erase()
+    cov.start()
 
 TESTS_THRESHOLD = 100
 TESTS_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -45,6 +64,7 @@ settings.configure(
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware"
     ),
+    NOSE_PLUGINS = ['nose.plugins.skip.Skip', ],
     SITE_ID=1,
     STRIPE_PUBLIC_KEY=os.environ.get("STRIPE_PUBLIC_KEY", ""),
     STRIPE_SECRET_KEY=os.environ.get("STRIPE_SECRET_KEY", ""),
@@ -149,19 +169,24 @@ failures = test_runner.run_tests(["."])
 if failures:
     sys.exit(failures)
 
-# Announce coverage run
-sys.stdout.write(colored(text="\nStep 2: Generating coverage results.\n\n", color="yellow", attrs=["bold"]))
+if not disable_coverage:
+    # Announce coverage run
+    sys.stdout.write(colored(text="\nStep 2: Generating coverage results.\n\n", color="yellow", attrs=["bold"]))
 
-cov.stop()
-percentage = round(cov.report(show_missing=True), 2)
-cov.html_report(directory='cover')
-cov.save()
+    cov.stop()
+    percentage = round(cov.report(show_missing=True), 2)
+    cov.html_report(directory='cover')
+    cov.save()
 
-if percentage < TESTS_THRESHOLD:
-            sys.stderr.write(colored(text="YOUR CHANGES HAVE CAUSED TEST COVERAGE TO DROP. " +
-                                     "WAS {old}%, IS NOW {new}%.\n\n".format(old=TESTS_THRESHOLD, new=percentage),
-                                     color="red", attrs=["bold"]))
-            sys.exit(1)
+    if percentage < TESTS_THRESHOLD:
+                sys.stderr.write(colored(text="YOUR CHANGES HAVE CAUSED TEST COVERAGE TO DROP. " +
+                                         "WAS {old}%, IS NOW {new}%.\n\n".format(old=TESTS_THRESHOLD, new=percentage),
+                                         color="red", attrs=["bold"]))
+                sys.exit(1)
+else:
+    sys.stdout.write(colored(text="\nStep 2: Generating coverage results: SKIPPED due to environment variable setting! "
+                                  "[Do not submit code without running coverage].\n\n",
+                             color="yellow", attrs=["bold"]))
 
 # Announce flake8 run
 sys.stdout.write(colored(text="\nStep 3: Checking for pep8 errors.\n\n", color="yellow", attrs=["bold"]))

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -509,7 +509,7 @@ class TestCustomer(TestCase):
         _, call_kwargs = update_subscription_mock.call_args
 
         self.assertIn("trial_end", call_kwargs)
-        self.assertLess(call_kwargs["trial_end"], timezone.now() + datetime.timedelta(days=trial_days))
+        self.assertLessEqual(call_kwargs["trial_end"], timezone.now() + datetime.timedelta(days=trial_days))
 
     @patch("djstripe.models.Customer.send_invoice")
     @patch("djstripe.models.Customer.sync_current_subscription")
@@ -525,7 +525,7 @@ class TestCustomer(TestCase):
         _, call_kwargs = update_subscription_mock.call_args
 
         self.assertIn("trial_end", call_kwargs)
-        self.assertLess(call_kwargs["trial_end"], timezone.now() + datetime.timedelta(days=trial_days))
+        self.assertLessEqual(call_kwargs["trial_end"], timezone.now() + datetime.timedelta(days=trial_days))
 
     @patch("djstripe.models.Customer.send_invoice")
     @patch("djstripe.models.Customer.sync_current_subscription")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,8 +23,18 @@ from djstripe.utils import subscriber_has_active_subscription, get_supported_cur
 from unittest2 import TestCase as AssertWarnsEnabledTestCase
 from mock import patch
 from stripe import api_key
+from nose.plugins.skip import SkipTest
 
 from tests.apps.testapp.models import Organization
+import os
+from distutils.util import strtobool
+
+# Some tests will always fail if test is run on a computer whose clock is not in UTC. Skip those tests
+# rather than failing, so that coverage and other data can still be collated in runtests.py
+#
+# Not sure how to automatically detect UTC reliably (across Windows and Unix). So, you'll just
+# have to set a special ENV if you want to skip utc tests
+skip_utc_tests = strtobool(os.environ.get('DJS_SKIP_UTC_TESTS', "False"))
 
 
 class TestDeprecationWarning(AssertWarnsEnabledTestCase):
@@ -78,6 +88,8 @@ class TestTimestampConversion(TestCase):
 
     @override_settings(USE_TZ=False)
     def test_conversion_without_field_name_no_tz(self):
+        if skip_utc_tests:
+            raise SkipTest()
         stamp = convert_tstamp(1365567407)
         self.assertEquals(
             stamp,
@@ -86,6 +98,8 @@ class TestTimestampConversion(TestCase):
 
     @override_settings(USE_TZ=False)
     def test_conversion_with_field_name_no_tz(self):
+        if skip_utc_tests:
+            raise SkipTest()
         stamp = convert_tstamp({"my_date": 1365567407}, "my_date")
         self.assertEquals(
             stamp,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,7 +34,7 @@ from distutils.util import strtobool
 #
 # Not sure how to automatically detect UTC reliably (across Windows and Unix). So, you'll just
 # have to set a special ENV if you want to skip utc tests
-skip_utc_tests = strtobool(os.environ.get('DJS_SKIP_UTC_TESTS', "False"))
+skip_utc_tests = strtobool(os.environ.get('DJSTRIPE_TESTS_SKIP_UTC_TESTS', "False"))
 
 
 class TestDeprecationWarning(AssertWarnsEnabledTestCase):


### PR DESCRIPTION
A few minor things came up while developing in Windows (and with Pycharm 4.0.6)
- clock resolution - race condition
- system not UTC
- coverage interfere with Pycharm debugger (all debuggers??)

re: UTC issue - did some research into cleaner fixes for this. Did not find anything. Not deeming it worthy of more wasted time. Need this in order to keep developing and remain in sync with upstream/pydanny djstripe
