### PR TITLE
centralize stripe API-dependent code out of: utils and views modules

### DIFF
--- a/djstripe/managers.py
+++ b/djstripe/managers.py
@@ -7,6 +7,18 @@ import decimal
 from django.db import models
 
 
+class StripeObjectManager(models.Manager):
+    def exists_by_json(self, data):
+        """
+        Search for a matching stripe object based on a Stripe object
+        received from Stripe in JSON format
+        :param data: Stripe event object parsed from a JSON string into an object
+        :type data: dict
+        :rtype: bool
+        """
+        return self.filter(stripe_id=data["id"]).exists()
+
+
 class CustomerManager(models.Manager):
 
     def started_during(self, year, month):

--- a/djstripe/managers.py
+++ b/djstripe/managers.py
@@ -12,9 +12,11 @@ class StripeObjectManager(models.Manager):
         """
         Search for a matching stripe object based on a Stripe object
         received from Stripe in JSON format
+
         :param data: Stripe event object parsed from a JSON string into an object
         :type data: dict
         :rtype: bool
+        :returns: True if the requested object exists, False otherwise
         """
         return self.filter(stripe_id=data["id"]).exists()
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -1030,27 +1030,6 @@ class Plan(StripeObject):
         return self.api_retrieve()
 
 
-class Account(StripeObject):
-    """
-    For now, this is an abstract class, it is here just to provide an interface to the stripe API
-    for a few stripe.Account operations we need
-    """
-    class Meta:
-        abstract = True
-
-    @staticmethod
-    def get_supported_currencies(api_key):
-        """
-        Stripe accounts have a list of currencies they support. Get that list for the Stripe account
-        corresponding to the api key provided
-        :return: list of currency codes
-        :rtype: list of str
-        """
-        # TODO: someday, this will prob be an instance method and we will just have an Account
-        # record for "our account"
-        with stripe_temporary_api_key(api_key):
-            return stripe.Account.retrieve()["currencies_supported"]
-
 # Much like registering signal handlers. We import this module so that its registrations get picked up
 # the NO QA directive tells flake8 to not complain about the unused import
 from . import event_handlers  # NOQA

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -65,6 +65,7 @@ class StripeObject(TimeStampedModel):
     # This must be defined in descendants of this model/mixin
     # e.g. "Event", "Charge", "Customer", etc.
     stripe_api_name = None
+    objects = models.Manager()
     stripe_objects = StripeObjectManager()
 
     stripe_id = models.CharField(max_length=50, unique=True)
@@ -123,7 +124,6 @@ class EventProcessingException(TimeStampedModel):
 @python_2_unicode_compatible
 class Event(StripeObject):
     stripe_api_name = "Event"
-    objects = models.Manager()
     kind = models.CharField(max_length=250)
     livemode = models.BooleanField(default=False)
     customer = models.ForeignKey("Customer", null=True)
@@ -711,7 +711,6 @@ class CurrentSubscription(TimeStampedModel):
 
 class Invoice(StripeObject):
     stripe_api_name = "Invoice"
-    objects = models.Manager()
 
     customer = models.ForeignKey(Customer, related_name="invoices")
     attempted = models.NullBooleanField()
@@ -960,7 +959,6 @@ INTERVALS = (
 class Plan(StripeObject):
     """A Stripe Plan."""
     stripe_api_name = "Plan"
-    objects = models.Manager()
 
     name = models.CharField(max_length=100, null=False)
     currency = models.CharField(

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 
-from .models import Customer
+from .models import Customer, Account
 
 
 ANONYMOUS_USER_ERROR_MSG = (
@@ -59,9 +58,4 @@ def get_supported_currency_choices(api_key):
     :param api_key: The api key associated with the account from which to pull data.
     :type api_key: str
     """
-
-    import stripe
-    stripe.api_key = api_key
-
-    account = stripe.Account.retrieve()
-    return [(currency, currency.upper()) for currency in account["currencies_supported"]]
+    return [(currency, currency.upper()) for currency in Account.get_supported_currencies(api_key)]

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -58,4 +58,9 @@ def get_supported_currency_choices(api_key):
     :param api_key: The api key associated with the account from which to pull data.
     :type api_key: str
     """
-    return [(currency, currency.upper()) for currency in Account.get_supported_currencies(api_key)]
+
+    import stripe
+    stripe.api_key = api_key
+
+    account = stripe.Account.retrieve()
+    return [(currency, currency.upper()) for currency in account["currencies_supported"]]

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 
-from .models import Customer, Account
+from .models import Customer
 
 
 ANONYMOUS_USER_ERROR_MSG = (

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -247,19 +247,14 @@ class WebHook(CsrfExemptMixin, View):
     def post(self, request, *args, **kwargs):
         body = smart_str(request.body)
         data = json.loads(body)
-        if Event.objects.filter(stripe_id=data["id"]).exists():
+        if Event.stripe_objects.exists_by_json(data):
             EventProcessingException.objects.create(
                 data=data,
                 message="Duplicate event record",
                 traceback=""
             )
         else:
-            event = Event.objects.create(
-                stripe_id=data["id"],
-                kind=data["type"],
-                livemode=data["livemode"],
-                webhook_message=data
-            )
+            event = Event.create_from_stripe_object(data)
             event.validate()
             event.process()
         return HttpResponse()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -10,7 +10,7 @@ from django.test.client import RequestFactory
 from django.utils import timezone
 
 from djstripe.decorators import subscription_payment_required
-from djstripe.models import Customer, CurrentSubscription
+from djstripe.models import Customer, CurrentSubscription, stripe_temporary_api_key
 
 from unittest2 import TestCase as AssertWarnsEnabledTestCase
 
@@ -27,6 +27,17 @@ class TestDeprecationWarning(AssertWarnsEnabledTestCase):
 
             test_func = (lambda subscriber: True)
             user_passes_pay_test(test_func=test_func)
+
+
+class TestTemporaryKey(TestCase):
+    def test_basic(self):
+        import stripe
+        key = stripe.api_key
+
+        with stripe_temporary_api_key("newkey"):
+            self.assertEqual(stripe.api_key, "newkey")
+
+        self.assertEqual(stripe.api_key, key)
 
 
 class TestSubscriptionPaymentRequired(TestCase):


### PR DESCRIPTION
A modest PR, just a few simple changes.

This was following a full audit for stripe or stripe-api dependent code. Other than the stuff refactored here, I found nothing except in:

models, sync, event_handlers, managers

I think those are reasonable places for stripe code, for now
