### PR TITLE
Isolate stripe fields and code into separate module

### DIFF
--- a/djstripe/managers.py
+++ b/djstripe/managers.py
@@ -18,6 +18,15 @@ class StripeObjectManager(models.Manager):
         """
         return self.filter(stripe_id=data["id"]).exists()
 
+    def get_by_json(self, data, field_name="id"):
+        """
+        Retreive a matching stripe object based on a Stripe object
+        received from Stripe in JSON format
+        :param data: Stripe event object parsed from a JSON string into an object
+        :type data: dict
+        """
+        return self.get(stripe_id=data[field_name])
+
 
 class CustomerManager(models.Manager):
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -137,6 +137,7 @@ class Transfer(StripeTransfer):
         transfer.event = event
 
         if created:
+            transfer.save()
             for fee in stripe_object["summary"]["charge_fee_details"]:
                 transfer.charge_fee_details.create(
                     amount=fee["amount"] / decimal.Decimal("100"),
@@ -146,11 +147,11 @@ class Transfer(StripeTransfer):
                 )
         else:
             transfer.status = stripe_object["status"]
+            transfer.save()
 
         if event and event.kind == "transfer.updated":
             transfer.update_status()
-
-        transfer.save()
+            transfer.save()
 
 
 class TransferChargeFee(TimeStampedModel):

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -519,7 +519,7 @@ class Invoice(StripeInvoice):
 
         if not created:
             # update all fields using the stripe data
-            invoice.sync(cls.stripe_obj_to_record(stripe_invoice))
+            invoice.sync(cls.stripe_object_to_record(stripe_invoice))
 
         invoice.save()
 
@@ -568,11 +568,11 @@ class Invoice(StripeInvoice):
         invoice.save()
 
         if stripe_invoice.get("charge"):
-            obj = customer.record_charge(stripe_invoice["charge"])
-            obj.invoice = invoice
-            obj.save()
+            recorded_charge = customer.record_charge(stripe_invoice["charge"])
+            recorded_charge.invoice = invoice
+            recorded_charge.save()
             if send_receipt:
-                obj.send_receipt()
+                recorded_charge.send_receipt()
         return invoice
 
 
@@ -627,7 +627,7 @@ class Charge(StripeCharge):
 
         try:
             charge = cls.stripe_objects.get_by_json(data)
-            charge.sync(cls.stripe_obj_to_record(data))
+            charge.sync(cls.stripe_object_to_record(data))
         except cls.DoesNotExist:
             charge = cls.create_from_stripe_object(data)
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from contextlib import contextmanager
 
 import datetime
 import decimal
@@ -22,82 +21,20 @@ from model_utils.models import TimeStampedModel
 import stripe
 
 from . import settings as djstripe_settings
-from djstripe.managers import StripeObjectManager
+from djstripe.stripe_objects import convert_tstamp
 from .exceptions import SubscriptionCancellationFailure, SubscriptionUpdateFailure
 from .managers import CustomerManager, ChargeManager, TransferManager
 from .signals import WEBHOOK_SIGNALS
 from .signals import subscription_made, cancelled, card_changed
 from .signals import webhook_processing_error
 from . import webhooks
+from .stripe_objects import *
+
 
 logger = logging.getLogger(__name__)
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
 stripe.api_version = getattr(settings, "STRIPE_API_VERSION", "2012-11-07")
-
-
-@contextmanager
-def stripe_temporary_api_key(temp_key):
-    """
-    A contextmanager
-
-    Temporarily replace the global api_key used in stripe API calls with the given value
-    the original value is restored as soon as context exits
-    """
-    import stripe
-    bkp_key = stripe.api_key
-    stripe.api_key = temp_key
-    yield
-    stripe.api_key = bkp_key
-
-
-def convert_tstamp(response, field_name=None):
-    # Overrides the set timezone to UTC - I think...
-    tz = timezone.utc if settings.USE_TZ else None
-
-    if not field_name:
-        return datetime.datetime.fromtimestamp(response, tz)
-    else:
-        if field_name in response and response[field_name]:
-            return datetime.datetime.fromtimestamp(response[field_name], tz)
-
-
-class StripeObject(TimeStampedModel):
-    # This must be defined in descendants of this model/mixin
-    # e.g. "Event", "Charge", "Customer", etc.
-    stripe_api_name = None
-    stripe_objects = StripeObjectManager()
-
-    stripe_id = models.CharField(max_length=50, unique=True)
-
-    class Meta:
-        abstract = True
-
-    @classmethod
-    def api(cls):
-        """
-        Get the api object for this type of stripe object (requires
-        stripe_api_name attribute to be set on model).
-        """
-        if cls.stripe_api_name is None:
-            raise NotImplementedError("StripeObject descendants are required to define "
-                                      "the stripe_api_name attribute")
-        # e.g. stripe.Event, stripe.Charge, etc
-        return getattr(stripe, cls.stripe_api_name)
-
-    def api_retrieve(self):
-        """
-        Implement very commonly used API function 'retrieve'
-        """
-        # Run stripe.X.retreive(id)
-        return type(self).api().retrieve(self.stripe_id)
-
-    @classmethod
-    def api_create(cls, **kwargs):
-        """
-        Call the stripe API's create operation for this model
-        """
-        return cls.api().create(**kwargs)
 
 
 @python_2_unicode_compatible
@@ -122,13 +59,9 @@ class EventProcessingException(TimeStampedModel):
 
 
 @python_2_unicode_compatible
-class Event(StripeObject):
-    stripe_api_name = "Event"
+class Event(StripeEvent):
     objects = models.Manager()
-    kind = models.CharField(max_length=250)
-    livemode = models.BooleanField(default=False)
     customer = models.ForeignKey("Customer", null=True)
-    webhook_message = JSONField()
     validated_message = JSONField(null=True)
     valid = models.NullBooleanField(null=True)
     processed = models.BooleanField(default=False)
@@ -136,23 +69,6 @@ class Event(StripeObject):
     @property
     def message(self):
         return self.validated_message
-
-    def __str__(self):
-        return "<{kind}, stripe_id={stripe_id}>".format(kind=self.kind, stripe_id=self.stripe_id)
-
-    @classmethod
-    def create_from_stripe_object(cls, data):
-        """
-        Create an Event object with the provided decoded JSON object received from Stripe
-        :type data: dict
-        :rtype: Event
-        """
-        return Event.objects.create(
-            stripe_id=data["id"],
-            kind=data["type"],
-            livemode=data["livemode"],
-            webhook_message=data
-        )
 
     def validate(self):
         evt = self.api_retrieve()
@@ -206,91 +122,39 @@ class Event(StripeObject):
             return signal.send(sender=Event, event=self)
 
 
-class Transfer(StripeObject):
-    stripe_api_name = "Transfer"
-
+class Transfer(StripeTransfer):
     event = models.ForeignKey(Event, related_name="transfers")
-    amount = models.DecimalField(decimal_places=2, max_digits=7)
-    status = models.CharField(max_length=25)
-    date = models.DateTimeField()
-    description = models.TextField(null=True, blank=True)
-    adjustment_count = models.IntegerField()
-    adjustment_fees = models.DecimalField(decimal_places=2, max_digits=7)
-    adjustment_gross = models.DecimalField(decimal_places=2, max_digits=7)
-    charge_count = models.IntegerField()
-    charge_fees = models.DecimalField(decimal_places=2, max_digits=7)
-    charge_gross = models.DecimalField(decimal_places=2, max_digits=7)
-    collected_fee_count = models.IntegerField()
-    collected_fee_gross = models.DecimalField(decimal_places=2, max_digits=7)
-    net = models.DecimalField(decimal_places=2, max_digits=7)
-    refund_count = models.IntegerField()
-    refund_fees = models.DecimalField(decimal_places=2, max_digits=7)
-    refund_gross = models.DecimalField(decimal_places=2, max_digits=7)
-    validation_count = models.IntegerField()
-    validation_fees = models.DecimalField(decimal_places=2, max_digits=7)
 
     objects = TransferManager()
 
-    def __str__(self):
-        return "<amount={amount}, status={status}, stripe_id={stripe_id}>".format(amount=self.amount, status=self.status, stripe_id=self.stripe_id)
-
-    def update_status(self):
-        self.status = self.api_retrieve().status
-        self.save()
-
     @classmethod
-    def process_transfer(cls, event, transfer):
-        defaults = {
-            "amount": transfer["amount"] / decimal.Decimal("100"),
-            "status": transfer["status"],
-            "date": convert_tstamp(transfer, "date"),
-            "description": transfer.get("description", ""),
-            "adjustment_count": transfer["summary"]["adjustment_count"],
-            "adjustment_fees": transfer["summary"]["adjustment_fees"],
-            "adjustment_gross": transfer["summary"]["adjustment_gross"],
-            "charge_count": transfer["summary"]["charge_count"],
-            "charge_fees": transfer["summary"]["charge_fees"],
-            "charge_gross": transfer["summary"]["charge_gross"],
-            "collected_fee_count": transfer["summary"]["collected_fee_count"],
-            "collected_fee_gross": transfer["summary"]["collected_fee_gross"],
-            "net": transfer["summary"]["net"] / decimal.Decimal("100"),
-            "refund_count": transfer["summary"]["refund_count"],
-            "refund_fees": transfer["summary"]["refund_fees"],
-            "refund_gross": transfer["summary"]["refund_gross"],
-            "validation_count": transfer["summary"]["validation_count"],
-            "validation_fees": transfer["summary"]["validation_fees"],
-        }
-        for field in defaults:
-            if field.endswith("fees") or field.endswith("gross"):
-                defaults[field] = defaults[field] / decimal.Decimal("100")
+    def process_transfer(cls, event, stripe_object):
+        try:
+            transfer = cls.stripe_objects.get_by_json(stripe_object)
+            created = False
+        except cls.DoesNotExist:
+            transfer = cls.create_from_stripe_object(stripe_object)
+            created = True
 
-        if event.kind == "transfer.paid":
-            defaults.update({"event": event})
-            obj, created = Transfer.objects.get_or_create(
-                stripe_id=transfer["id"],
-                defaults=defaults
-            )
-        else:
-            obj, created = Transfer.objects.get_or_create(
-                stripe_id=transfer["id"],
-                event=event,
-                defaults=defaults
-            )
+        if event:
+            transfer.event = event
 
         if created:
-            for fee in transfer["summary"]["charge_fee_details"]:
-                obj.charge_fee_details.create(
+            transfer.save()
+            for fee in stripe_object["summary"]["charge_fee_details"]:
+                event.charge_fee_details.create(
                     amount=fee["amount"] / decimal.Decimal("100"),
                     application=fee.get("application", ""),
                     description=fee.get("description", ""),
                     kind=fee["type"]
                 )
         else:
-            obj.status = transfer["status"]
-            obj.save()
+            transfer.status = transfer["status"]
+            transfer.save()
 
-        if event.kind == "transfer.updated":
-            obj.update_status()
+        if event and event.kind == "transfer.updated":
+            transfer.update_status()
+            transfer.save()
 
 
 class TransferChargeFee(TimeStampedModel):
@@ -302,25 +166,11 @@ class TransferChargeFee(TimeStampedModel):
 
 
 @python_2_unicode_compatible
-class Customer(StripeObject):
-    stripe_api_name = "Customer"
-
+class Customer(StripeCustomer):
     subscriber = models.OneToOneField(getattr(settings, 'DJSTRIPE_SUBSCRIBER_MODEL', settings.AUTH_USER_MODEL), null=True)
-    card_fingerprint = models.CharField(max_length=200, blank=True)
-    card_last_4 = models.CharField(max_length=4, blank=True)
-    card_kind = models.CharField(max_length=50, blank=True)
-    card_exp_month = models.PositiveIntegerField(blank=True, null=True)
-    card_exp_year = models.PositiveIntegerField(blank=True, null=True)
     date_purged = models.DateTimeField(null=True, editable=False)
 
     objects = CustomerManager()
-
-    def __str__(self):
-        return "<{subscriber}, stripe_id={stripe_id}>".format(subscriber=smart_text(self.subscriber), stripe_id=self.stripe_id)
-
-    @property
-    def stripe_customer(self):
-        return self.api_retrieve()
 
     def purge(self):
         try:
@@ -334,23 +184,19 @@ class Customer(StripeObject):
                 # The exception was raised for another reason, re-raise it
                 raise
         self.subscriber = None
-        self.card_fingerprint = ""
-        self.card_last_4 = ""
-        self.card_kind = ""
-        self.card_exp_month = None
-        self.card_exp_year = None
+        super(Customer, self).purge()
         self.date_purged = timezone.now()
         self.save()
+
+    def str_parts(self):
+        return [smart_text(self.subscriber)] + super(Customer, self).str_parts()
 
     def delete(self, using=None):
         # Only way to delete a customer is to use SQL
         self.purge()
 
     def can_charge(self):
-        return self.card_fingerprint and \
-            self.card_last_4 and \
-            self.card_kind and \
-            self.date_purged is None
+        return self.has_valid_card() and self.date_purged is None
 
     def has_active_subscription(self):
         try:
@@ -409,14 +255,14 @@ class Customer(StripeObject):
         return customer
 
     def update_card(self, token):
+        # send new token to Stripe
         stripe_customer = self.stripe_customer
         stripe_customer.card = token
         stripe_customer.save()
-        self.card_fingerprint = stripe_customer.active_card.fingerprint
-        self.card_last_4 = stripe_customer.active_card.last4
-        self.card_kind = stripe_customer.active_card.type
-        self.card_exp_month = stripe_customer.active_card.exp_month
-        self.card_exp_year = stripe_customer.active_card.exp_year
+
+        # Download new card details from Stripe
+        self.sync_card()
+
         self.save()
         card_changed.send(sender=self, stripe_response=stripe_customer)
 
@@ -439,17 +285,27 @@ class Customer(StripeObject):
 
     # TODO refactor, deprecation on cu parameter -> stripe_customer
     def sync(self, cu=None):
-        stripe_customer = cu or self.stripe_customer
-        if getattr(stripe_customer, 'deleted', False):
-            # Customer was deleted from stripe
-            self.purge()
-        elif getattr(stripe_customer, 'active_card', None):
-            self.card_fingerprint = stripe_customer.active_card.fingerprint
-            self.card_last_4 = stripe_customer.active_card.last4
-            self.card_kind = stripe_customer.active_card.type
-            self.card_exp_month = stripe_customer.active_card.exp_month
-            self.card_exp_year = stripe_customer.active_card.exp_year
-            self.save()
+        super(Customer, self).sync(cu)
+        self.save()
+
+    def charge(self, amount, currency="usd", description=None, send_receipt=True, **kwargs):
+        """
+        This method expects `amount` to be a Decimal type representing a
+        dollar amount. It will be converted to cents so any decimals beyond
+        two will be ignored.
+        """
+        if not isinstance(amount, decimal.Decimal):
+            raise ValueError(
+                "You must supply a decimal value representing dollars."
+            )
+        resp = Charge.api_create(
+            amount=int(amount * 100),  # Convert dollars into cents
+            currency=currency,
+            customer=self.stripe_id,
+            description=description,
+            **kwargs
+        )
+        return resp["id"]
 
     # TODO refactor, deprecation on cu parameter -> stripe_customer
     def sync_invoices(self, cu=None, **kwargs):
@@ -573,55 +429,11 @@ class Customer(StripeObject):
         dollar amount. It will be converted to cents so any decimals beyond
         two will be ignored.
         """
-        if not isinstance(amount, decimal.Decimal):
-            raise ValueError(
-                "You must supply a decimal value representing dollars."
-            )
-        resp = Charge.api_create(
-            amount=int(amount * 100),  # Convert dollars into cents
-            currency=currency,
-            customer=self.stripe_id,
-            description=description,
-            **kwargs
-        )
-        obj = self.record_charge(resp["id"])
+        charge_id = super(Customer, self).charge(amount, currency, description, send_receipt, **kwargs)
+        obj = self.record_charge(charge_id)
         if send_receipt:
             obj.send_receipt()
         return obj
-
-    def add_invoice_item(self, amount, currency="usd", invoice_id=None, description=None):
-        """
-        Adds an arbitrary charge or credit to the customer's upcoming invoice.
-        Different than creating a charge. Charges are separate bills that get
-        processed immediately. Invoice items are appended to the customer's next
-        invoice. This is extremely useful when adding surcharges to subscriptions.
-
-        This method expects `amount` to be a Decimal type representing a
-        dollar amount. It will be converted to cents so any decimals beyond
-        two will be ignored.
-
-        Note: Since invoice items are appended to invoices, a record will be stored
-        in dj-stripe when invoices are pulled.
-
-        :param invoice:
-            The ID of an existing invoice to add this invoice item to.
-            When left blank, the invoice item will be added to the next upcoming
-            scheduled invoice. Use this when adding invoice items in response
-            to an invoice.created webhook. You cannot add an invoice item to
-            an invoice that has already been paid, attempted or closed.
-        """
-
-        if not isinstance(amount, decimal.Decimal):
-            raise ValueError(
-                "You must supply a decimal value representing dollars."
-            )
-        stripe.InvoiceItem.create(
-            amount=int(amount * 100),  # Convert dollars into cents
-            currency=currency,
-            customer=self.stripe_id,
-            description=description,
-            invoice=invoice_id,
-        )
 
     def record_charge(self, charge_id):
         data = Charge.api().retrieve(charge_id)
@@ -708,34 +520,16 @@ class CurrentSubscription(TimeStampedModel):
         self.customer.sync_current_subscription()
 
 
-class Invoice(StripeObject):
-    stripe_api_name = "Invoice"
+class Invoice(StripeInvoice):
     objects = models.Manager()
 
     customer = models.ForeignKey(Customer, related_name="invoices")
-    attempted = models.NullBooleanField()
-    attempts = models.PositiveIntegerField(null=True)
-    closed = models.BooleanField(default=False)
-    paid = models.BooleanField(default=False)
-    period_end = models.DateTimeField()
-    period_start = models.DateTimeField()
-    subtotal = models.DecimalField(decimal_places=2, max_digits=7)
-    total = models.DecimalField(decimal_places=2, max_digits=7)
-    date = models.DateTimeField()
-    charge = models.CharField(max_length=50, blank=True)
 
     class Meta:
         ordering = ["-date"]
 
     def __str__(self):
         return "<total={total}, paid={paid}, stripe_id={stripe_id}>".format(total=self.total, paid=smart_text(self.paid), stripe_id=self.stripe_id)
-
-    def retry(self):
-        if not self.paid and not self.closed:
-            inv = self.api_retrieve()
-            inv.pay()
-            return True
-        return False
 
     def status(self):
         if self.paid:
@@ -747,35 +541,18 @@ class Invoice(StripeObject):
     @classmethod
     def sync_from_stripe_data(cls, stripe_invoice, send_receipt=True):
         c = Customer.objects.get(stripe_id=stripe_invoice["customer"])
-        period_end = convert_tstamp(stripe_invoice, "period_end")
-        period_start = convert_tstamp(stripe_invoice, "period_start")
-        date = convert_tstamp(stripe_invoice, "date")
 
-        invoice, created = cls.objects.get_or_create(
-            stripe_id=stripe_invoice["id"],
-            defaults=dict(
-                customer=c,
-                attempted=stripe_invoice["attempted"],
-                closed=stripe_invoice["closed"],
-                paid=stripe_invoice["paid"],
-                period_end=period_end,
-                period_start=period_start,
-                subtotal=stripe_invoice["subtotal"] / decimal.Decimal("100"),
-                total=stripe_invoice["total"] / decimal.Decimal("100"),
-                date=date,
-                charge=stripe_invoice.get("charge") or ""
-            )
-        )
+        try:
+            invoice = Invoice.stripe_objects.get_by_json(stripe_invoice)
+            created = False
+        except Invoice.DoesNotExist:
+            invoice = Invoice.create_from_stripe_object(stripe_invoice)
+            invoice.customer = c
+            created = True
+
         if not created:
-            invoice.attempted = stripe_invoice["attempted"]
-            invoice.closed = stripe_invoice["closed"]
-            invoice.paid = stripe_invoice["paid"]
-            invoice.period_end = period_end
-            invoice.period_start = period_start
-            invoice.subtotal = stripe_invoice["subtotal"] / decimal.Decimal("100")
-            invoice.total = stripe_invoice["total"] / decimal.Decimal("100")
-            invoice.date = date
-            invoice.charge = stripe_invoice.get("charge") or ""
+            # update all fields using the stripe data
+            invoice.sync(stripe_invoice)
             invoice.save()
 
         for item in stripe_invoice["lines"].get("data", []):
@@ -856,7 +633,7 @@ class InvoiceItem(TimeStampedModel):
         return djstripe_settings.PAYMENTS_PLANS[self.plan]["name"]
 
 
-class Charge(StripeObject):
+class Charge(StripeCharge):
     stripe_api_name = "Charge"
 
     customer = models.ForeignKey(Customer, related_name="charges")
@@ -888,9 +665,7 @@ class Charge(StripeObject):
         return int(amount_to_refund * 100)
 
     def refund(self, amount=None):
-        charge_obj = self.api_retrieve().refund(
-            amount=self.calculate_refund_amount(amount=amount)
-        )
+        charge_obj = super(Charge, self).refund(amount)
         return Charge.sync_from_stripe_data(charge_obj)
 
     def capture(self):
@@ -899,33 +674,28 @@ class Charge(StripeObject):
         where first you created a charge with the capture option set to false.
         See https://stripe.com/docs/api#capture_charge
         """
-        charge_obj = self.api_retrieve().capture()
+        charge_obj = super(Charge, self).capture()
         return Charge.sync_from_stripe_data(charge_obj)
 
     @classmethod
     def sync_from_stripe_data(cls, data):
-        customer = Customer.objects.get(stripe_id=data["customer"])
-        obj, _ = customer.charges.get_or_create(stripe_id=data["id"])
-        invoice_id = data.get("invoice", None)
-        if obj.customer.invoices.filter(stripe_id=invoice_id).exists():
-            obj.invoice = obj.customer.invoices.get(stripe_id=invoice_id)
-        obj.card_last_4 = data["card"]["last4"]
-        obj.card_kind = data["card"]["type"]
-        obj.amount = (data["amount"] / decimal.Decimal("100"))
-        obj.paid = data["paid"]
-        obj.refunded = data["refunded"]
-        obj.captured = data["captured"]
-        obj.fee = (data["fee"] / decimal.Decimal("100"))
-        obj.disputed = data["dispute"] is not None
-        obj.charge_created = convert_tstamp(data, "created")
-        if data.get("description"):
-            obj.description = data["description"]
-        if data.get("amount_refunded"):
-            obj.amount_refunded = (data["amount_refunded"] / decimal.Decimal("100"))
-        if data["refunded"]:
-            obj.amount_refunded = (data["amount"] / decimal.Decimal("100"))
-        obj.save()
-        return obj
+        customer = cls.obj_to_customer(Customer.stripe_objects, data)
+        invoice = cls.obj_to_invoice(Invoice.stripe_objects, data)
+
+        try:
+            charge = cls.stripe_objects.get_by_json(data)
+            charge.sync(data)
+            created = False
+        except cls.DoesNotExist:
+            charge = cls.create_from_stripe_object(data)
+            created = True
+
+        if invoice:
+            charge.invoice = invoice
+        if customer:
+            charge.customer = customer
+        charge.save()
+        return charge
 
     def send_receipt(self):
         if not self.receipt_sent:
@@ -956,9 +726,8 @@ INTERVALS = (
 
 
 @python_2_unicode_compatible
-class Plan(StripeObject):
+class Plan(StripePlan):
     """A Stripe Plan."""
-    stripe_api_name = "Plan"
     objects = models.Manager()
 
     name = models.CharField(max_length=100, null=False)
@@ -980,8 +749,8 @@ class Plan(StripeObject):
                                  null=False)
     trial_period_days = models.IntegerField(null=True)
 
-    def __str__(self):
-        return "<{name}, stripe_id={stripe_id}>".format(name=smart_text(self.name), stripe_id=self.stripe_id)
+    def str_parts(self):
+        return [smart_text(self.name)] + super(Plan, self).str_parts()
 
     @classmethod
     def create(cls, **kwargs):
@@ -1029,7 +798,7 @@ class Plan(StripeObject):
         return self.api_retrieve()
 
 
-class Account(StripeObject):
+class Account(StripeAccount):
     """
     For now, this is an abstract class, it is here just to provide an interface to the stripe API
     for a few stripe.Account operations we need
@@ -1037,18 +806,6 @@ class Account(StripeObject):
     class Meta:
         abstract = True
 
-    @staticmethod
-    def get_supported_currencies(api_key):
-        """
-        Stripe accounts have a list of currencies they support. Get that list for the Stripe account
-        corresponding to the api key provided
-        :return: list of currency codes
-        :rtype: list of str
-        """
-        # TODO: someday, this will prob be an instance method and we will just have an Account
-        # record for "our account"
-        with stripe_temporary_api_key(api_key):
-            return stripe.Account.retrieve()["currencies_supported"]
 
 # Much like registering signal handlers. We import this module so that its registrations get picked up
 # the NO QA directive tells flake8 to not complain about the unused import

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -58,7 +58,6 @@ class EventProcessingException(TimeStampedModel):
         return "<{message}, pk={pk}, Event={event}>".format(message=self.message, pk=self.pk, event=self.event)
 
 
-@python_2_unicode_compatible
 class Event(StripeEvent):
     objects = models.Manager()
     customer = models.ForeignKey("Customer", null=True)
@@ -165,7 +164,6 @@ class TransferChargeFee(TimeStampedModel):
     kind = models.CharField(max_length=150)
 
 
-@python_2_unicode_compatible
 class Customer(StripeCustomer):
     subscriber = models.OneToOneField(getattr(settings, 'DJSTRIPE_SUBSCRIBER_MODEL', settings.AUTH_USER_MODEL), null=True)
     date_purged = models.DateTimeField(null=True, editable=False)
@@ -638,18 +636,6 @@ class Charge(StripeCharge):
 
     customer = models.ForeignKey(Customer, related_name="charges")
     invoice = models.ForeignKey(Invoice, null=True, related_name="charges")
-    card_last_4 = models.CharField(max_length=4, blank=True)
-    card_kind = models.CharField(max_length=50, blank=True)
-    amount = models.DecimalField(decimal_places=2, max_digits=7, null=True)
-    amount_refunded = models.DecimalField(decimal_places=2, max_digits=7, null=True)
-    description = models.TextField(blank=True)
-    paid = models.NullBooleanField(null=True)
-    disputed = models.NullBooleanField(null=True)
-    refunded = models.NullBooleanField(null=True)
-    captured = models.NullBooleanField(null=True)
-    fee = models.DecimalField(decimal_places=2, max_digits=7, null=True)
-    receipt_sent = models.BooleanField(default=False)
-    charge_created = models.DateTimeField(null=True, blank=True)
 
     objects = ChargeManager()
 
@@ -725,7 +711,6 @@ INTERVALS = (
     ('year', 'Year',))
 
 
-@python_2_unicode_compatible
 class Plan(StripePlan):
     """A Stripe Plan."""
     objects = models.Manager()

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -64,6 +64,7 @@ def convert_tstamp(response, field_name=None):
             return datetime.datetime.fromtimestamp(response[field_name], tz)
 
 
+@python_2_unicode_compatible
 class StripeObject(TimeStampedModel):
     # This must be defined in descendants of this model/mixin
     # e.g. "Event", "Charge", "Customer", etc.
@@ -82,7 +83,7 @@ class StripeObject(TimeStampedModel):
     field_name_map = {}
 
     stripe_id = models.CharField(max_length=50, unique=True)
-    livemode = models.BooleanField(default=False)
+    # livemode = models.BooleanField(default=False)
 
     class Meta:
         abstract = True
@@ -137,9 +138,12 @@ class StripeObject(TimeStampedModel):
 
 
 
-@python_2_unicode_compatible
 class StripeEvent(StripeObject):
     stripe_api_name = "Event"
+
+    class Meta:
+        abstract = True
+    livemode = models.BooleanField(default=False)
 
     # This is "type" in Stripe
     kind = models.CharField(max_length=250)
@@ -160,6 +164,9 @@ class StripeEvent(StripeObject):
 
 
 class StripeTransfer(StripeObject):
+    class Meta:
+        abstract = True
+
     stripe_api_name = "Transfer"
     currency_fields = ['amount', '']
 
@@ -225,8 +232,10 @@ class StripeTransfer(StripeObject):
         return result
 
 
-@python_2_unicode_compatible
 class StripeCustomer(StripeObject):
+    class Meta:
+        abstract = True
+
     stripe_api_name = "Customer"
 
     card_fingerprint = models.CharField(max_length=200, blank=True)
@@ -310,6 +319,9 @@ class StripeCustomer(StripeObject):
 
 
 class StripeInvoice(StripeObject):
+    class Meta:
+        abstract = True
+
     stripe_api_name = "Invoice"
 
     attempted = models.NullBooleanField()
@@ -367,6 +379,9 @@ class StripeInvoice(StripeObject):
 
 
 class StripeCharge(StripeObject):
+    class Meta:
+        abstract = True
+
     stripe_api_name = "Charge"
 
     card_last_4 = models.CharField(max_length=4, blank=True)
@@ -482,8 +497,10 @@ INTERVALS = (
     ('year', 'Year',))
 
 
-@python_2_unicode_compatible
 class StripePlan(StripeObject):
+    class Meta:
+        abstract = True
+
     """A Stripe Plan."""
     stripe_api_name = "Plan"
 
@@ -513,7 +530,3 @@ class StripeAccount(StripeObject):
         # record for "our account"
         with stripe_temporary_api_key(api_key):
             return stripe.Account.retrieve()["currencies_supported"]
-
-# Much like registering signal handlers. We import this module so that its registrations get picked up
-# the NO QA directive tells flake8 to not complain about the unused import
-from . import event_handlers  # NOQA

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -1,0 +1,519 @@
+# -*- coding: utf-8 -*-
+"""
+.. module:: djstripe.stripe_objects
+   :synopsis: dj-stripe - Abstract model definitions to provide our view of Stripe's objects
+
+.. moduleauthor:: Bill Huneke (@wahuneke)
+
+This module is an effort to isolate (as much as possible) the API dependent code in one
+place. Primarily this is:
+
+1) create models containing the fields that we care about, mapping to Stripe's fields
+2) create routines for consistently syncing our database with Stripe's version of the objects
+3) centralized routines for creating new database records to match incoming Stripe objects
+
+This module defines abstract models which are then extended in models.py to provide the remaining
+dj-stripe functionality.
+"""
+from contextlib import contextmanager
+import datetime
+import decimal
+
+from django.conf import settings
+from django.db import models
+from django.utils import timezone
+from django.utils.encoding import python_2_unicode_compatible, smart_text
+from jsonfield import JSONField
+
+from model_utils.models import TimeStampedModel
+import stripe
+from djstripe.managers import TransferManager, StripeObjectManager
+
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = getattr(settings, "STRIPE_API_VERSION", "2012-11-07")
+
+
+__all__ = ['StripeEvent', 'StripeTransfer', 'StripeCustomer', 'StripeInvoice', 'StripeCharge', 'StripePlan',
+           'StripeAccount', ]
+
+
+@contextmanager
+def stripe_temporary_api_key(temp_key):
+    """
+    A contextmanager
+
+    Temporarily replace the global api_key used in stripe API calls with the given value
+    the original value is restored as soon as context exits
+    """
+    import stripe
+    bkp_key = stripe.api_key
+    stripe.api_key = temp_key
+    yield
+    stripe.api_key = bkp_key
+
+
+def convert_tstamp(response, field_name=None):
+    # Overrides the set timezone to UTC - I think...
+    tz = timezone.utc if settings.USE_TZ else None
+
+    if not field_name:
+        return datetime.datetime.fromtimestamp(response, tz)
+    else:
+        if field_name in response and response[field_name]:
+            return datetime.datetime.fromtimestamp(response[field_name], tz)
+
+
+class StripeObject(TimeStampedModel):
+    # This must be defined in descendants of this model/mixin
+    # e.g. "Event", "Charge", "Customer", etc.
+    stripe_api_name = None
+    stripe_objects = StripeObjectManager()
+    #
+    # Field names in the lists below are 'database field' names, not necessarily stripe object field names
+    #
+    # List field names here to take advantage of automatic multiply/divide by 100
+    # (ie, fields named here are stored locally in dollars and cents, but the Stripe json object is cents)
+    currency_fields = []
+    # List field names here to take advantage of automatic timestamp conversion
+    timestamp_fields = []
+    # Map fields here from their local name (db field name), the key to their stripe name, the value.
+    # This is only necessary if names are different
+    field_name_map = {}
+
+    stripe_id = models.CharField(max_length=50, unique=True)
+    livemode = models.BooleanField(default=False)
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def api(cls):
+        """
+        Get the api object for this type of stripe object (requires
+        stripe_api_name attribute to be set on model).
+        """
+        if cls.stripe_api_name is None:
+            raise NotImplementedError("StripeObject descendants are required to define "
+                                      "the stripe_api_name attribute")
+        # e.g. stripe.Event, stripe.Charge, etc
+        return getattr(stripe, cls.stripe_api_name)
+
+    def api_retrieve(self):
+        """
+        Implement very commonly used API function 'retrieve'
+        """
+        # Run stripe.X.retreive(id)
+        return type(self).api().retrieve(self.stripe_id)
+
+    @classmethod
+    def api_create(cls, **kwargs):
+        """
+        Call the stripe API's create operation for this model
+        """
+        return cls.api().create(**kwargs)
+
+    def str_parts(self):
+        """
+        extend this to add information to the string representation of the object
+        :rtype: list of str
+        """
+        return ["id={id}".format(id=self.stripe_id)]
+
+    @classmethod
+    def stripe_obj_to_record(cls, data):
+        raise NotImplemented()
+
+    @classmethod
+    def create_from_stripe_object(cls, data):
+        """
+        Create a model instance (not saved to db), using the given data object from Stripe
+        :type data: dict
+        """
+        return cls(**cls.stripe_obj_to_record(data))
+
+    def __str__(self):
+        return "<{list}>".format(list=", ".join(self.str_parts()))
+
+
+
+@python_2_unicode_compatible
+class StripeEvent(StripeObject):
+    stripe_api_name = "Event"
+
+    # This is "type" in Stripe
+    kind = models.CharField(max_length=250)
+    # This is "data" in Stripe
+    webhook_message = JSONField()
+
+    @classmethod
+    def stripe_obj_to_record(cls, data):
+        return {
+            'stripe_id': data["id"],
+            'kind': data["type"],
+            'livemode': data["livemode"],
+            'webhook_message': data,
+            }
+
+    def str_parts(self):
+        return [self.kind] + super(StripeEvent, self).str_parts()
+
+
+class StripeTransfer(StripeObject):
+    stripe_api_name = "Transfer"
+    currency_fields = ['amount', '']
+
+    amount = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    status = models.CharField(max_length=25)
+    date = models.DateTimeField()
+    description = models.TextField(null=True, blank=True)
+
+    # The following fields are nested in the "summary" object
+    adjustment_count = models.IntegerField()
+    adjustment_fees = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    adjustment_gross = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    charge_count = models.IntegerField()
+    charge_fees = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    charge_gross = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    collected_fee_count = models.IntegerField()
+    collected_fee_gross = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    net = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    refund_count = models.IntegerField()
+    refund_fees = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    refund_gross = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+    validation_count = models.IntegerField()
+    validation_fees = models.DecimalField(decimal_places=2, max_digits=7)  # Stripe = cents, djstripe = dollars
+
+    objects = TransferManager()
+
+    def str_parts(self):
+        return [
+            "amount={amount}".format(self.amount),
+            "status={status}".format(self.status),
+        ] + super(StripeTransfer, self).str_parts()
+
+    def update_status(self):
+        self.status = self.api_retrieve().status
+        self.save()
+
+    @classmethod
+    def stripe_obj_to_record(cls, data):
+        result = {
+            "amount": data["amount"] / decimal.Decimal("100"),
+            "status": data["status"],
+            "date": convert_tstamp(data, "date"),
+            "description": data.get("description", ""),
+            "adjustment_count": data["summary"]["adjustment_count"],
+            "adjustment_fees": data["summary"]["adjustment_fees"],
+            "adjustment_gross": data["summary"]["adjustment_gross"],
+            "charge_count": data["summary"]["charge_count"],
+            "charge_fees": data["summary"]["charge_fees"],
+            "charge_gross": data["summary"]["charge_gross"],
+            "collected_fee_count": data["summary"]["collected_fee_count"],
+            "collected_fee_gross": data["summary"]["collected_fee_gross"],
+            "net": data["summary"]["net"] / decimal.Decimal("100"),
+            "refund_count": data["summary"]["refund_count"],
+            "refund_fees": data["summary"]["refund_fees"],
+            "refund_gross": data["summary"]["refund_gross"],
+            "validation_count": data["summary"]["validation_count"],
+            "validation_fees": data["summary"]["validation_fees"],
+        }
+        for field in result:
+            if field.endswith("fees") or field.endswith("gross"):
+                result[field] = result[field] / decimal.Decimal("100")
+
+        return result
+
+
+@python_2_unicode_compatible
+class StripeCustomer(StripeObject):
+    stripe_api_name = "Customer"
+
+    card_fingerprint = models.CharField(max_length=200, blank=True)
+    card_last_4 = models.CharField(max_length=4, blank=True)
+    card_kind = models.CharField(max_length=50, blank=True)
+    card_exp_month = models.PositiveIntegerField(blank=True, null=True)
+    card_exp_year = models.PositiveIntegerField(blank=True, null=True)
+
+    @property
+    def stripe_customer(self):
+        return self.api_retrieve()
+
+    def purge(self):
+        """
+        Delete all identifying information we have in this record
+        """
+        self.card_fingerprint = ""
+        self.card_last_4 = ""
+        self.card_kind = ""
+        self.card_exp_month = None
+        self.card_exp_year = None
+
+    def has_valid_card(self):
+        return all([self.card_fingerprint, self.card_last_4, self.card_kind])
+
+    def sync_card(self):
+        stripe_customer = self.stripe_customer
+
+        self.card_fingerprint = stripe_customer.active_card.fingerprint
+        self.card_last_4 = stripe_customer.active_card.last4
+        self.card_kind = stripe_customer.active_card.type
+        self.card_exp_month = stripe_customer.active_card.exp_month
+        self.card_exp_year = stripe_customer.active_card.exp_year
+
+    # TODO refactor, deprecation on cu parameter -> stripe_customer
+    def sync(self, cu=None):
+        stripe_customer = cu or self.stripe_customer
+        if getattr(stripe_customer, 'deleted', False):
+            # Customer was deleted from stripe
+            self.purge()
+        elif getattr(stripe_customer, 'active_card', None):
+            self.card_fingerprint = stripe_customer.active_card.fingerprint
+            self.card_last_4 = stripe_customer.active_card.last4
+            self.card_kind = stripe_customer.active_card.type
+            self.card_exp_month = stripe_customer.active_card.exp_month
+            self.card_exp_year = stripe_customer.active_card.exp_year
+
+    def add_invoice_item(self, amount, currency="usd", invoice_id=None, description=None):
+        """
+        Adds an arbitrary charge or credit to the customer's upcoming invoice.
+        Different than creating a charge. Charges are separate bills that get
+        processed immediately. Invoice items are appended to the customer's next
+        invoice. This is extremely useful when adding surcharges to subscriptions.
+
+        This method expects `amount` to be a Decimal type representing a
+        dollar amount. It will be converted to cents so any decimals beyond
+        two will be ignored.
+
+        Note: Since invoice items are appended to invoices, a record will be stored
+        in dj-stripe when invoices are pulled.
+
+        :param invoice:
+            The ID of an existing invoice to add this invoice item to.
+            When left blank, the invoice item will be added to the next upcoming
+            scheduled invoice. Use this when adding invoice items in response
+            to an invoice.created webhook. You cannot add an invoice item to
+            an invoice that has already been paid, attempted or closed.
+        """
+
+        if not isinstance(amount, decimal.Decimal):
+            raise ValueError(
+                "You must supply a decimal value representing dollars."
+            )
+        stripe.InvoiceItem.create(
+            amount=int(amount * 100),  # Convert dollars into cents
+            currency=currency,
+            customer=self.stripe_id,
+            description=description,
+            invoice=invoice_id,
+        )
+
+
+class StripeInvoice(StripeObject):
+    stripe_api_name = "Invoice"
+
+    attempted = models.NullBooleanField()
+    attempts = models.PositiveIntegerField(null=True)
+    closed = models.BooleanField(default=False)
+    paid = models.BooleanField(default=False)
+    period_end = models.DateTimeField()
+    period_start = models.DateTimeField()
+    subtotal = models.DecimalField(decimal_places=2, max_digits=7)
+    total = models.DecimalField(decimal_places=2, max_digits=7)
+    date = models.DateTimeField()
+    charge = models.CharField(max_length=50, blank=True)
+
+    def str_parts(self):
+        return ["total={total}".format(total=self.total), "paid={paid}".format(paid=smart_text(self.paid))] + \
+               super(StripeInvoice, self).str_parts()
+
+    def retry(self):
+        if not self.paid and not self.closed:
+            inv = self.api_retrieve()
+            inv.pay()
+            return True
+        return False
+
+    def status(self):
+        if self.paid:
+            return "Paid"
+        if self.closed:
+            return "Closed"
+        return "Open"
+
+    @classmethod
+    def stripe_obj_to_record(cls, data):
+        period_end = convert_tstamp(data, "period_end")
+        period_start = convert_tstamp(data, "period_start")
+        date = convert_tstamp(data, "date")
+
+        return {
+            "attempted": data["attempted"],
+            "closed": data["closed"],
+            "paid": data["paid"],
+            "period_end": period_end,
+            "period_start": period_start,
+            "subtotal": data["subtotal"] / decimal.Decimal("100"),
+            "total": data["total"] / decimal.Decimal("100"),
+            "date": date,
+            "charge": data.get("charge") or "",
+        }
+
+    def sync(self, data=None):
+        if data is None:
+            data = self.stripe_obj_to_record(self.api_retrieve())
+        for attr, value in data.items():
+            setattr(self, attr, value)
+
+
+class StripeCharge(StripeObject):
+    stripe_api_name = "Charge"
+
+    card_last_4 = models.CharField(max_length=4, blank=True)
+    card_kind = models.CharField(max_length=50, blank=True)
+    amount = models.DecimalField(decimal_places=2, max_digits=7, null=True)
+    amount_refunded = models.DecimalField(decimal_places=2, max_digits=7, null=True)
+    description = models.TextField(blank=True)
+    paid = models.NullBooleanField(null=True)
+    disputed = models.NullBooleanField(null=True)
+    refunded = models.NullBooleanField(null=True)
+    captured = models.NullBooleanField(null=True)
+    fee = models.DecimalField(decimal_places=2, max_digits=7, null=True)
+    receipt_sent = models.BooleanField(default=False)
+    charge_created = models.DateTimeField(null=True, blank=True)
+
+    def str_parts(self):
+        return [
+            "amount={amount}".format(amount=self.amount),
+            "paid={paid}".format(paid=smart_text(self.paid)),
+        ] + super(StripeCharge, self).str_parts()
+
+    def calculate_refund_amount(self, amount=None):
+        """
+        :rtype: int
+        :return: amount that can be refunded, in CENTS
+        """
+        eligible_to_refund = self.amount - (self.amount_refunded or 0)
+        if amount:
+            amount_to_refund = min(eligible_to_refund, amount)
+        else:
+            amount_to_refund = eligible_to_refund
+        return int(amount_to_refund * 100)
+
+    def refund(self, amount=None):
+        """
+        Initiate a refund. If amount is not provided, then this will be a full refund
+        :return: Stripe charge object
+        :rtype: dict
+        """
+        charge_obj = self.api_retrieve().refund(
+            amount=self.calculate_refund_amount(amount=amount)
+        )
+        return charge_obj
+
+    def capture(self):
+        """
+        Capture the payment of an existing, uncaptured, charge. This is the second half of the two-step payment flow,
+        where first you created a charge with the capture option set to false.
+        See https://stripe.com/docs/api#capture_charge
+        """
+        return self.api_retrieve().capture()
+
+    @classmethod
+    def obj_to_customer(cls, manager, data):
+        """
+        Search the given manager for the customer matching this StripeCharge object
+        :param manager: stripe_objects manager for a table of StripeCustomers
+        :type manager: StripeObjectManager
+        :param data: stripe object
+        :type data: dict
+        """
+        try:
+            return manager.get_by_json(data, "customer")
+        except models.Model.DoesNotExist:
+            pass
+
+    @classmethod
+    def obj_to_invoice(cls, manager, data):
+        """
+        Search the given manager for the invoice matching this StripeCharge object
+        :param manager: stripe_objects manager for a table of StripeInvoice
+        :type manager: StripeObjectManager
+        :param data: stripe object
+        :type data: dict
+        """
+        try:
+            return manager.get_by_json(data, "invoice")
+        except models.Model.DoesNotExist:
+            pass
+
+    @classmethod
+    def stripe_obj_to_record(cls, data):
+        result = {
+            "card_last_4": data["card"]["last4"],
+            "card_kind": data["card"]["type"],
+            "amount": (data["amount"] / decimal.Decimal("100")),
+            "paid": data["paid"],
+            "refunded": data["refunded"],
+            "captured": data["captured"],
+            "fee": (data["fee"] / decimal.Decimal("100")),
+            "disputed": data["dispute"] is not None,
+            "charge_created": convert_tstamp(data, "created"),
+        }
+        if data.get("description"):
+            result["description"] = data["description"]
+        if data.get("amount_refunded"):
+            result["amount_refunded"] = (data["amount_refunded"] / decimal.Decimal("100"))
+        if data["refunded"]:
+            result["amount_refunded"] = (data["amount"] / decimal.Decimal("100"))
+
+        return result
+
+    def sync(self, data=None):
+        if data is None:
+            data = self.stripe_obj_to_record(self.api_retrieve())
+        for attr, value in data.items():
+            setattr(self, attr, value)
+
+
+INTERVALS = (
+    ('week', 'Week',),
+    ('month', 'Month',),
+    ('year', 'Year',))
+
+
+@python_2_unicode_compatible
+class StripePlan(StripeObject):
+    """A Stripe Plan."""
+    stripe_api_name = "Plan"
+
+    @property
+    def stripe_plan(self):
+        """Return the plan data from Stripe."""
+        return self.api_retrieve()
+
+
+class StripeAccount(StripeObject):
+    """
+    For now, this is an abstract class, it is here just to provide an interface to the stripe API
+    for a few stripe.Account operations we need
+    """
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def get_supported_currencies(api_key):
+        """
+        Stripe accounts have a list of currencies they support. Get that list for the Stripe account
+        corresponding to the api key provided
+        :return: list of currency codes
+        :rtype: list of str
+        """
+        # TODO: someday, this will prob be an instance method and we will just have an Account
+        # record for "our account"
+        with stripe_temporary_api_key(api_key):
+            return stripe.Account.retrieve()["currencies_supported"]
+
+# Much like registering signal handlers. We import this module so that its registrations get picked up
+# the NO QA directive tells flake8 to not complain about the unused import
+from . import event_handlers  # NOQA

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -108,7 +108,7 @@ class StripeObject(TimeStampedModel):
 
     @classmethod
     def stripe_obj_to_record(cls, data):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def create_from_stripe_object(cls, data):
@@ -378,8 +378,6 @@ class StripeInvoice(StripeObject):
         }
 
     def sync(self, data=None):
-        if data is None:
-            data = self.stripe_obj_to_record(self.api_retrieve())
         for attr, value in data.items():
             setattr(self, attr, value)
 
@@ -486,8 +484,6 @@ class StripeCharge(StripeObject):
         return result
 
     def sync(self, data=None):
-        if data is None:
-            data = self.stripe_obj_to_record(self.api_retrieve())
         for attr, value in data.items():
             setattr(self, attr, value)
 

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -108,7 +108,7 @@ class StripeObject(TimeStampedModel):
         return ["stripe_id={id}".format(id=self.stripe_id)]
 
     @classmethod
-    def stripe_obj_to_record(cls, data):
+    def stripe_object_to_record(cls, data):
         """
         This takes an object, as it is formatted in Stripe's current API for our object
         type. In return, it provides a dict. The dict can be used to create a record or
@@ -131,7 +131,7 @@ class StripeObject(TimeStampedModel):
         Create a model instance (not saved to db), using the given data object from Stripe
         :type data: dict
         """
-        return cls(**cls.stripe_obj_to_record(data))
+        return cls(**cls.stripe_object_to_record(data))
 
     def __str__(self):
         return "<{list}>".format(list=", ".join(self.str_parts()))
@@ -151,7 +151,7 @@ class StripeEvent(StripeObject):
     webhook_message = JSONField()
 
     @classmethod
-    def stripe_obj_to_record(cls, data):
+    def stripe_object_to_record(cls, data):
         return {
             'stripe_id': data["id"],
             'kind': data["type"],
@@ -203,7 +203,7 @@ class StripeTransfer(StripeObject):
         self.save()
 
     @classmethod
-    def stripe_obj_to_record(cls, data):
+    def stripe_object_to_record(cls, data):
         result = {
             'stripe_id': data["id"],
             "amount": data["amount"] / decimal.Decimal("100"),
@@ -375,7 +375,7 @@ class StripeInvoice(StripeObject):
         return "Open"
 
     @classmethod
-    def stripe_obj_to_record(cls, data):
+    def stripe_object_to_record(cls, data):
         period_end = convert_tstamp(data, "period_end")
         period_start = convert_tstamp(data, "period_start")
         date = convert_tstamp(data, "date")
@@ -478,7 +478,7 @@ class StripeCharge(StripeObject):
         return manager.get_by_json(data, "invoice") if "invoice" in data else None
 
     @classmethod
-    def stripe_obj_to_record(cls, data):
+    def stripe_object_to_record(cls, data):
         result = {
             "stripe_id": data["id"],
             "card_last_4": data["card"]["last4"],

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -13,12 +13,20 @@ from mock import patch, PropertyMock
 from djstripe.stripe_objects import StripeObject
 
 
-class StripeObjectTest(TestCase):
-    def test_bad_impl(self):
+class StripeObjectExceptionsTest(TestCase):
+    def test_missing_apiname(self):
         # This class fails to provide a stripe_api_name attribute
-        class BadBad(StripeObject):
+        class MissingApiName(StripeObject):
             pass
 
         with self.assertRaises(NotImplementedError):
-            BadBad.api()
+            MissingApiName.api()
+
+    def test_missing_obj_to_record(self):
+        # This class fails to provide a stripe_api_name attribute
+        class MissingObjToRecord(StripeObject):
+            stripe_api_name = "hello"
+
+        with self.assertRaises(NotImplementedError):
+            MissingObjToRecord.create_from_stripe_object({})
 

--- a/tests/test_stripe_object.py
+++ b/tests/test_stripe_object.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 
 from mock import patch, PropertyMock
 
-from djstripe.models import StripeObject
+from djstripe.stripe_objects import StripeObject
 
 
 class StripeObjectTest(TestCase):


### PR DESCRIPTION
To support the major API review and overhaul, happening in #162, this PR splits up all the models.

All fields and code related to Stripe's API is moved to a separate module called "stripe_objects". That module defines a bunch of abstract models, for example "StripeCharge".  Then, in models, we inherit from StripeCharge which provides all the stripe api fields and code and isolates API-dependent stuff to another module.

This is a big refactor! It was done with care to ensure that all behaviors remained the same as before. The effort here was really just to move code around.

This change needs a review. Though, I think it is a good sign that after the refactor, I had very few errors and test errors to fix (see commit logs to see the exact quantity).  This, I think, speaks to the fact that this change really just moved code around and it was not too hard to avoid mistakes (i.e. there were ultimately only a few).

This is a big change. I will take it upon myself to merge this into @ctrengove multiple-subscription code in a separate branch. As much as possible, I don't want to ask other contributors to have to do a lot of extra work just because of my big commit.

Same goes for @aliev work on db-based plans pr #174 ... I should probably take a stab at merging this refactor into that branch. Again, will put the merged version in my repo which can become a PR to @aliev once this PR is merged to master
