### PR TITLE
Allow passing of extra arguments to refund

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -606,8 +606,12 @@ class Charge(StripeCharge):
 
     objects = ChargeManager()
 
-    def refund(self, amount=None):
-        refunded_charge = super(Charge, self).refund(amount)
+    def refund(self, amount=None, **kwargs):
+        """
+        Refund an existing charge https://stripe.com/docs/api#create_refund
+        Stripe Connect information https://stripe.com/docs/connect/payments-fees#issuing-refunds
+        """
+        refunded_charge = super(Charge, self).refund(amount, **kwargs)
         return Charge.sync_from_stripe_data(refunded_charge)
 
     def capture(self):

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -438,14 +438,15 @@ class StripeCharge(StripeObject):
             amount_to_refund = eligible_to_refund
         return int(amount_to_refund * 100)
 
-    def refund(self, amount=None):
+    def refund(self, amount=None, **kwargs):
         """
         Initiate a refund. If amount is not provided, then this will be a full refund
         :return: Stripe charge object
         :rtype: dict
         """
         charge_obj = self.api_retrieve().refund(
-            amount=self.calculate_refund_amount(amount=amount)
+            amount=self.calculate_refund_amount(amount=amount),
+            **kwargs
         )
         return charge_obj
 


### PR DESCRIPTION
This functionality is useful for passing extra parameters to refund that are required by stripe connect
https://stripe.com/docs/api#create_refund
