### PR TITLE
Feature: add tag support on pricing plans

### DIFF
--- a/djstripe/mixins.py
+++ b/djstripe/mixins.py
@@ -38,11 +38,20 @@ class PaymentsContextMixin(object):
 
     def get_context_data(self, **kwargs):
         context = super(PaymentsContextMixin, self).get_context_data(**kwargs)
+        selected_tag = context.get('selected_tag', False)
+        if selected_tag:
+            plan_list = [x for x in djstripe_settings.PLAN_LIST if x['tag'] == selected_tag]
+        else:
+            plan_list = djstripe_settings.PLAN_LIST
+
         context.update({
             "STRIPE_PUBLIC_KEY": settings.STRIPE_PUBLIC_KEY,
             "PLAN_CHOICES": djstripe_settings.PLAN_CHOICES,
-            "PLAN_LIST": djstripe_settings.PLAN_LIST,
-            "PAYMENT_PLANS": djstripe_settings.PAYMENTS_PLANS
+            "PLAN_LIST": plan_list,
+            "PAYMENT_PLANS": djstripe_settings.PAYMENTS_PLANS,
+            "PLAN_TAGS": djstripe_settings.DJSTRIPE_PLANS_TAGS,
+            "PLAN_TAGS_DEFAULT": djstripe_settings.DJSTRIPE_PLANS_TAGS_DEFAULT,
+            "SELECTED_TAG": selected_tag,
         })
         return context
 

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -16,6 +16,11 @@ INVOICE_FROM_EMAIL = getattr(settings, "DJSTRIPE_INVOICE_FROM_EMAIL", "billing@e
 PAYMENTS_PLANS = getattr(settings, "DJSTRIPE_PLANS", {})
 PLAN_HIERARCHY = getattr(settings, "DJSTRIPE_PLAN_HIERARCHY", {})
 
+# For tag support
+DJSTRIPE_PLANS_TAGS = getattr(settings, "DJSTRIPE_PLANS_TAGS", {})
+DJSTRIPE_PLANS_TAGS_DEFAULT = getattr(settings, "DJSTRIPE_PLANS_TAGS_DEFAULT", None)
+DJSTRIPE_PLANS_LOGIN_URL = getattr(settings, "DJSTRIPE_PLANS_LOGIN_URL", 'None')
+
 # Sort the PAYMENT_PLANS dictionary ascending by price.
 PAYMENT_PLANS = OrderedDict(sorted(PAYMENTS_PLANS.items(), key=lambda t: t[1]['price']))
 PLAN_CHOICES = [(plan, PAYMENTS_PLANS[plan].get("name", plan)) for plan in PAYMENTS_PLANS]

--- a/djstripe/templates/djstripe/subscribe_form.html
+++ b/djstripe/templates/djstripe/subscribe_form.html
@@ -37,7 +37,7 @@
 <div class="row">
     {% for plan in PLAN_LIST %}
       {% with plan_count=PLAN_LIST|length %}
-        <div class="col-xs-{{ 12|djdiv:plan_count|floatformat }}">
+        <div class="col-sm-4 col-md-4 col-lg-3 div_{{ plan.tag }}">
       {% endwith %}
             <form
               {% if not customer.current_subscription or customer.current_subscription.status == CurrentSubscription.STATUS_CANCELLED %}

--- a/djstripe/templates/djstripe/subscribe_form.html
+++ b/djstripe/templates/djstripe/subscribe_form.html
@@ -18,6 +18,22 @@
     <div class="alert alert-error">{{ view.error }}</div>
 {% endif %}
 
+{% if PLAN_TAGS and not SELECTED_TAG %}
+<div class="row">
+    <div class="col-xs-12">
+    <h4>Select your subscription type:</h4>
+    {% for plan_tag_k, plan_tag_v in PLAN_TAGS.items %}
+        <div class="col-sm-4 col-md-4 col-lg-3">
+            <button type="button" class="btn btn-info" id="button_{{ plan_tag_k }}">{{ plan_tag_v.button_description }}</button>
+            <br/>
+            {{ plan_tag_v.full_description }}
+        </div>
+    {% endfor %}
+    </div>
+</div>
+<hr/>
+{% endif %}
+
 <div class="row">
     {% for plan in PLAN_LIST %}
       {% with plan_count=PLAN_LIST|length %}
@@ -25,21 +41,21 @@
       {% endwith %}
             <form
               {% if not customer.current_subscription or customer.current_subscription.status == CurrentSubscription.STATUS_CANCELLED %}
-                  action="{% url 'djstripe:subscribe' %}" class="djstripe-subscribe"  
+                  action="{% url 'djstripe:subscribe' %}" class="djstripe-subscribe"
                   data-key="{{ STRIPE_PUBLIC_KEY }}"
                   data-amount="{{ plan.price }}"
                   data-name="{{ plan.name }}"
                   data-description="{{ plan.description }}"
               {% else %}
-                  data-stripe-key="{{ STRIPE_PUBLIC_KEY }}" 
+                  data-stripe-key="{{ STRIPE_PUBLIC_KEY }}"
                   action="{% url 'djstripe:change_plan' %}" class="djstripe-change-plan"
               {% endif %}
             method="POST">
 
-               
+
                 {% csrf_token %}
                 <input type="hidden" name="plan" value="{{ plan.plan }}" />
-                <input name="stripe_token" type="hidden" /> 
+                <input name="stripe_token" type="hidden" />
 
                 <!-- disable this when clicked -->
                 <button
@@ -70,12 +86,15 @@
 
 {% endblock content %}
 
+{% block footer %}
+{% endblock footer %}
+
 {% block javascript %}
 {{ block.super }}
 <script src="https://checkout.stripe.com/v2/checkout.js"></script>
 <script text="text/javascript">
     $(function() {
-        
+
         $('body').on("click", '.djstripe-subscribe button[type=submit]', function(e) {
           e.preventDefault();
           // retrieve current $(".djstripe-subscribe")
@@ -107,5 +126,31 @@
         {% endif %}
 
     });
+
+    // Code to show/hide tags div
+    {% if PLAN_TAGS and not SELECTED_TAG %}
+    $(function() {
+      // start by showing the default
+      {% for plan_tag_k in PLAN_TAGS %}
+        {% if plan_tag_k == PLAN_TAGS_DEFAULT %}
+          $(".div_{{ plan_tag_k }}").show();
+        {% else %}
+          $(".div_{{ plan_tag_k }}").hide();
+        {% endif %}
+      {% endfor %}
+      // main loop for tags
+      {% for plan_tag in PLAN_TAGS %}
+        $("#button_{{ plan_tag }}").click(function () {
+          {% for plan_tag_k in PLAN_TAGS %}
+            {% if plan_tag_k == plan_tag %}
+              $(".div_{{ plan_tag_k }}").show();
+            {% else %}
+              $(".div_{{ plan_tag_k }}").hide();
+            {% endif %}
+          {% endfor %}
+        });
+      {% endfor %}
+    });
+    {% endif %}
 </script>
 {% endblock javascript %}

--- a/djstripe/urls.py
+++ b/djstripe/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
         name="account"
     ),
     url(
+        r'^subscribe/(?P<selected_tag>[a-z_]+)/$',
+        views.SubscriptionView.as_view(),
+        name="subscribe_tag"
+    ),
+    url(
         r"^subscribe/$",
         views.SubscribeFormView.as_view(),
         name="subscribe"

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -5,7 +5,7 @@ Settings
 DJSTRIPE_DEFAULT_PLAN (=None)
 ====================================
 
-Payment plans default. 
+Payment plans default.
 
 Possibly deprecated in favor of model based plans.
 
@@ -17,7 +17,7 @@ Invoice emails come from this address.
 DJSTRIPE_PLANS (={})
 ===========================
 
-Payment plans. 
+Payment plans.
 
 Possibly deprecated in favor of model based plans.
 
@@ -33,6 +33,7 @@ Example:
             "price": 2499,  # $24.99
             "currency": "usd",
             "interval": "month",
+            "tag": "category1",
             "image": "img/pro-monthly.png"
         },
         "yearly": {
@@ -42,6 +43,7 @@ Example:
             "price": 19900,  # $199.00
             "currency": "usd",
             "interval": "year",
+            "tag": "category1",
             "image": "img/pro-yearly.png"
         }
     }
@@ -50,6 +52,8 @@ Example:
 
     Not all properties listed in the plans above are used by Stripe - i.e 'description' and 'image',
     which are used to display the plans description and related image within specific templates.
+    The setting 'tag' is used to filter and display categories for plans, 'tag' will show useful if you
+    have numerous plans and/or some are relevant for some specific users.
 
     Although any arbitrary property you require can be added to each plan listed in DJ_STRIPE_PLANS,
     only specific properties are used by Stripe. The full list of required and optional arguments can
@@ -60,7 +64,7 @@ Example:
 DJSTRIPE_PLAN_HIERARCHY (={})
 ===========================
 
-Payment plans levels. 
+Payment plans levels.
 
 Allows you to set levels of access to the plans.
 
@@ -130,11 +134,11 @@ Example:
     {% elif customer.current_subscription|djstripe_plan_level > plan.plan|djstripe_plan_level %}
         <h4>Downgrade</h4>
     {% endif %}
-    
+
 DJSTRIPE_PRORATION_POLICY (=False)
 ====================================
 
-By default, plans are not prorated in dj-stripe. Concretely, this is how this translates: 
+By default, plans are not prorated in dj-stripe. Concretely, this is how this translates:
 
 1) If a customer cancels their plan during a trial, the cancellation is effective right away.
 2) If a customer cancels their plan outside of a trial, their subscription remains active until the subscription's period end, and they do not receive a refund.
@@ -207,7 +211,7 @@ Example Model:
         name = CharField(max_length=200, unique=True)
         subdomain = CharField(max_length=63, unique=True, verbose_name="Organization Subdomain")
         owner = ForeignKey(settings.AUTH_USER_MODEL, related_name="organization_owner", verbose_name="Organization Owner")
-        
+
         @property
         def email(self):
             return self.owner.email
@@ -227,7 +231,7 @@ Examples:
 
     class DynamicOrganizationIDMiddleware(object):
         """ Adds the current organization's ID based on the subdomain."""
-    
+
         def process_request(self, request):
             subdomain = parse_subdomain(request.get_host())
 
@@ -237,7 +241,7 @@ Examples:
                 return TemplateResponse(request=request, template='404.html', status=404)
             else:
                 organization_id = organization.id
-    
+
             request.organization_id = organization_id
 
 `settings.py`
@@ -272,7 +276,7 @@ Examples:
         Adds a static trial period of 7 days to each subscriber's plan,
         unless they've accepted our month-long promotion.
         """
-        
+
         if subscriber.coupons.get(slug="monthlongtrial"):
             return 30
         else:
@@ -292,3 +296,57 @@ DJSTRIPE_CURRENCIES (=(('usd', 'U.S. Dollars',), ('gbp', 'Pounds (GBP)',), ('eur
 ==============================================================================================
 
 A Field.choices list of allowed currencies for Plan models.
+
+
+DJSTRIPE_PLANS_TAGS (={})
+===========================
+
+Provide full description and the button text for the payment plans tags.
+
+Example:
+
+.. code-block:: python
+
+    DJSTRIPE_PLANS_TAGS = {
+        "category1": {
+            "button_description": "Cat1",
+            "full_description": "This is a description of the first category",
+        },
+        "category2": {
+            "button_description": "Cat2",
+            "full_description": "This is a description of the second category",
+        },
+    }
+
+
+.. note:: Plan tags
+
+    Tagging on plans is useful if you have many plans and you want to provide to your user
+    an easy way to select subsets of your plans.
+
+
+DJSTRIPE_PLANS_TAGS_DEFAULT (=None)
+=============================================
+
+This setting allows to select the first plans that will be display on the subscribe views.
+
+Accepted values for DJSTRIPE_PLANS_TAGS_DEFAULT are the keys of 'DJSTRIPE_PLANS_TAGS'
+dictionary, e.g. 'category1', in this case only the 'DJSTRIPE_PLANS' with tag equal to
+'DJSTRIPE_PLANS_TAGS_DEFAULT' will be displayed.
+
+Example:
+
+.. code-block:: python
+
+    DJSTRIPE_PLANS_TAGS = "category1"
+
+
+DJSTRIPE_PLANS_LOGIN_URL (=None)
+=============================================
+
+This allows to set login url when landing on subscribe view without being logged.
+Example:
+
+.. code-block:: python
+
+    DJSTRIPE_PLANS_LOGIN_URL = "/login/"

--- a/runtests.py
+++ b/runtests.py
@@ -39,8 +39,8 @@ def run_test_suite(args):
         USE_TZ=True,
         DATABASES={
             "default": {
-                "ENGINE": "django.db.backends.postgresql_psycopg2",
-                "NAME": "djstripe",
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': 'testdb.sqlite3',
                 "USER": "",
                 "PASSWORD": "",
                 "HOST": "",
@@ -74,7 +74,8 @@ def run_test_suite(args):
                 "description": "A test plan",
                 "price": 1000,  # $10.00
                 "currency": "usd",
-                "interval": "month"
+                "interval": "month",
+                "tag": "category1"
             },
             "test": {
                 "stripe_plan_id": "test_id",
@@ -82,7 +83,8 @@ def run_test_suite(args):
                 "description": "Another test plan",
                 "price": 2500,  # $25.00
                 "currency": "usd",
-                "interval": "month"
+                "interval": "month",
+                "tag": "category1"
             },
             "test2": {
                 "stripe_plan_id": "test_id_2",
@@ -90,7 +92,8 @@ def run_test_suite(args):
                 "description": "Yet Another test plan",
                 "price": 5000,  # $50.00
                 "currency": "usd",
-                "interval": "month"
+                "interval": "month",
+                "tag": "category1"
             },
             "test_deletion": {
                 "stripe_plan_id": "test_id_3",
@@ -98,7 +101,8 @@ def run_test_suite(args):
                 "description": "Test plan for deletion.",
                 "price": 5000,  # $50.00
                 "currency": "usd",
-                "interval": "month"
+                "interval": "month",
+                "tag": "category2"
             },
             "test_trial": {
                 "stripe_plan_id": "test_id_4",
@@ -107,6 +111,7 @@ def run_test_suite(args):
                 "price": 7000,  # $70.00
                 "currency": "usd",
                 "interval": "month",
+                "tag": "category2",
                 "trial_period_days": 7
             },
             "unidentified_test_plan": {
@@ -114,10 +119,11 @@ def run_test_suite(args):
                 "description": "A test plan with no ID.",
                 "price": 2500,  # $25.00
                 "currency": "usd",
-                "interval": "month"
+                "interval": "month",
+                "tag": "category2"
             }
         },
-        DJSTRIPE_PLAN_HIERARCHY = {
+        DJSTRIPE_PLAN_HIERARCHY={
             "bronze": {
                 "level": 1,
                 "plans": [
@@ -145,6 +151,18 @@ def run_test_suite(args):
             "test_url_name",
             "testapp_namespaced:test_url_namespaced",
         ),
+        DJSTRIPE_PLANS_TAGS={
+            "category1": {
+                "button_description": "Cat1",
+                "full_description": "This is a description of the first category",
+            },
+            "category2": {
+                "button_description": "Cat2",
+                "full_description": "This is a description of the second category",
+            },
+        },
+        DJSTRIPE_PLANS_TAGS_DEFAULT="category1",
+        DJSTRIPE_PLANS_LOGIN_URL="/login/",
     )
 
     # Avoid AppRegistryNotReady exception

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -54,7 +54,14 @@ class TestPaymentsContextMixin(TestCase):
             def get_context_data(self):
                 return {}
 
+        class TestSuperViewTag(object):
+            def get_context_data(self):
+                return {'selected_tag': 'test_zyz'}
+
         class TestView(PaymentsContextMixin, TestSuperView):
+            pass
+
+        class TestViewTag(PaymentsContextMixin, TestSuperViewTag):
             pass
 
         context = TestView().get_context_data()
@@ -69,6 +76,17 @@ class TestPaymentsContextMixin(TestCase):
 
         self.assertIn("PAYMENT_PLANS", context, "PAYMENT_PLANS missing from context.")
         self.assertEqual(context["PAYMENT_PLANS"], djstripe_settings.PAYMENT_PLANS, "Incorrect PAYMENT_PLANS.")
+
+        self.assertIn("PLAN_TAGS", context, "PLAN_TAGS missing from context.")
+        self.assertEqual(context["PLAN_TAGS"], djstripe_settings.DJSTRIPE_PLANS_TAGS, "Incorrect PLAN_TAGS.")
+
+        self.assertIn("PLAN_TAGS_DEFAULT", context, "PLAN_TAGS_DEFAULT missing from context.")
+        self.assertEqual(context["PLAN_TAGS_DEFAULT"], djstripe_settings.DJSTRIPE_PLANS_TAGS_DEFAULT, "Incorrect PLAN_TAGS_DEFAULT.")
+
+        self.assertIn("SELECTED_TAG", context, "SELECTED_TAG missing from context.")
+
+        context = TestViewTag().get_context_data()
+        self.assertEqual("test_zyz", context['SELECTED_TAG'], "Incorrect selected_tag from context.")
 
 
 class TestSubscriptionMixin(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -182,6 +182,23 @@ class SyncHistoryViewTest(TestCase):
         self.assertEqual("pie", response.context["customer"].subscriber)
 
 
+class SubscriptionViewTest(TestCase):
+    fake_stripe_customer_id = "cus_xxx1234567890"
+
+    def setUp(self):
+        self.url = reverse("djstripe:subscribe_tag", args=['test_zyz'])
+        self.user = get_user_model().objects.create_user(username="testuser",
+                                                         email="test@example.com",
+                                                         password="123")
+        self.assertTrue(self.client.login(username="testuser", password="123"))
+
+    @patch("stripe.Customer.create", return_value=PropertyMock(id=fake_stripe_customer_id))
+    def test_get(self, sync_subscriber_mock):
+        response = self.client.get(self.url)
+        self.assertEqual("test_zyz", response.context['SELECTED_TAG'])
+        self.assertEqual("category1", response.context['PLAN_TAGS_DEFAULT'])
+
+
 class SubscribeFormViewTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
In the case where you have numerous amount of plans (>6-8), displaying them on a single page will end up to be quite complex for the customer to signup. This PR intend to introduce a tag/filter feature to make the subscription to plans simpler. The PR also contact a new subscription URL to display only plan for a given tag.

See attached screen-shot to have an idea of the end result.
![djstripe-plans](https://cloud.githubusercontent.com/assets/53455/11192978/52f42cce-8ca4-11e5-80c9-f1be898d817d.png)

Comments are welcome!
