### PR TITLE
Add email to Customer str representation

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -183,7 +183,10 @@ class Customer(StripeCustomer):
         self.save()
 
     def str_parts(self):
-        return [smart_text(self.subscriber)] + super(Customer, self).str_parts()
+        return [
+            smart_text(self.subscriber),
+            "email={email}".format(email=self.subscriber.email),
+        ] + super(Customer, self).str_parts()
 
     def delete(self, using=None):
         # Only way to delete a customer is to use SQL

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -45,7 +45,7 @@ class TestCustomer(TestCase):
         )
 
     def test_tostring(self):
-        self.assertEquals("<patrick, stripe_id=cus_xxxxxxxxxxxxxxx>", str(self.customer))
+        self.assertEquals("<patrick, email=patrick@gmail.com, stripe_id=cus_xxxxxxxxxxxxxxx>", str(self.customer))
 
     @patch("stripe.Customer.retrieve")
     def test_customer_purge_leaves_customer_record(self, customer_retrieve_fake):


### PR DESCRIPTION
It's much more easy to assign customer in the backend if we have their email representation the stripe_id and username is not very representative of the customer.
