### PR TITLE
Add Day to Plan Intervals for API Consistency

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -668,6 +668,7 @@ class Charge(StripeCharge):
 
 
 INTERVALS = (
+    ('day', 'Day',),
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -510,6 +510,7 @@ class StripeCharge(StripeObject):
 
 
 INTERVALS = (
+    ('day', 'Day',),
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))


### PR DESCRIPTION
The Stripe API for creating plans allows for day, week, month or year. This pull request to to add "day" to the plans interval choices for consistency with stripe. Ref - https://stripe.com/docs/api#create_plan-interval
