### PR TITLE
Add Day to Plan Intervals for API Parity

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -173,7 +173,7 @@ class Migration(migrations.Migration):
                 ('stripe_id', models.CharField(unique=True, max_length=50)),
                 ('name', models.CharField(max_length=100)),
                 ('currency', models.CharField(max_length=10, choices=[('usd', 'U.S. Dollars'), ('gbp', 'Pounds (GBP)'), ('eur', 'Euros')])),
-                ('interval', models.CharField(max_length=10, verbose_name='Interval type', choices=[('week', 'Week'), ('month', 'Month'), ('year', 'Year')])),
+                ('interval', models.CharField(max_length=10, verbose_name='Interval type', choices=[('day', 'Day'),('week', 'Week'), ('month', 'Month'), ('year', 'Year')])),
                 ('interval_count', models.IntegerField(default=1, null=True, verbose_name='Intervals between charges')),
                 ('amount', models.DecimalField(verbose_name='Amount (per period)', max_digits=7, decimal_places=2)),
                 ('trial_period_days', models.IntegerField(null=True)),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -173,7 +173,7 @@ class Migration(migrations.Migration):
                 ('stripe_id', models.CharField(unique=True, max_length=50)),
                 ('name', models.CharField(max_length=100)),
                 ('currency', models.CharField(max_length=10, choices=[('usd', 'U.S. Dollars'), ('gbp', 'Pounds (GBP)'), ('eur', 'Euros')])),
-                ('interval', models.CharField(max_length=10, verbose_name='Interval type', choices=[('day', 'Day'),('week', 'Week'), ('month', 'Month'), ('year', 'Year')])),
+                ('interval', models.CharField(max_length=10, verbose_name='Interval type', choices=[('week', 'Week'), ('month', 'Month'), ('year', 'Year')])),
                 ('interval_count', models.IntegerField(default=1, null=True, verbose_name='Intervals between charges')),
                 ('amount', models.DecimalField(verbose_name='Amount (per period)', max_digits=7, decimal_places=2)),
                 ('trial_period_days', models.IntegerField(null=True)),

--- a/djstripe/migrations/0008_auto_20151204_0210.py
+++ b/djstripe/migrations/0008_auto_20151204_0210.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djstripe', '0007_auto_20150625_1243'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plan',
+            name='interval',
+            field=models.CharField(max_length=10, verbose_name='Interval type', choices=[('day', 'Day'), ('week', 'Week'), ('month', 'Month'), ('year', 'Year')]),
+        ),
+    ]

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -668,6 +668,7 @@ class Charge(StripeCharge):
 
 
 INTERVALS = (
+    ('day', 'Day',),
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -668,7 +668,7 @@ class Charge(StripeCharge):
 
 
 INTERVALS = (
-    ('day','Day'), 
+    ('day', 'Day',),
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -668,7 +668,7 @@ class Charge(StripeCharge):
 
 
 INTERVALS = (
-    ('day', 'Day',),
+    ('day','Day'), 
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -510,6 +510,7 @@ class StripeCharge(StripeObject):
 
 
 INTERVALS = (
+    ('day', 'Day',),
     ('week', 'Week',),
     ('month', 'Month',),
     ('year', 'Year',))

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 # dj-stripe requirements
-django>=1.7
+django>=1.7,<1.9
 stripe>=1.22.2
 django-model-utils>=2.2
 django-braces>=1.8.0


### PR DESCRIPTION
The stripe API supports "day, week, month or year" plan intervals. Previously the Plans model on had "week, month and year" choices. Ref - https://stripe.com/docs/api#create_plan-interval

This PR adds Day to the Plans Interval model choices.
