### PR TITLE
Small change that fixes issue #284

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -417,8 +417,8 @@ class Customer(StripeCustomer):
         """
         
         if send_receipt is None:
-            send_receipt = getattr(settings,'DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS',True)
-            
+            send_receipt = getattr(settings, 'DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS', True)
+
         charge_id = super(Customer, self).charge(amount, currency, description, send_receipt, **kwargs)
         recorded_charge = self.record_charge(charge_id)
         if send_receipt:

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -409,12 +409,16 @@ class Customer(StripeCustomer):
             self.send_invoice()
         subscription_made.send(sender=self, plan=plan, stripe_response=resp)
 
-    def charge(self, amount, currency="usd", description=None, send_receipt=True, **kwargs):
+    def charge(self, amount, currency="usd", description=None, send_receipt=None, **kwargs):
         """
         This method expects `amount` to be a Decimal type representing a
         dollar amount. It will be converted to cents so any decimals beyond
         two will be ignored.
         """
+        
+        if send_receipt is None:
+            send_receipt = getattr(settings,'DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS',True)
+            
         charge_id = super(Customer, self).charge(amount, currency, description, send_receipt, **kwargs)
         recorded_charge = self.record_charge(charge_id)
         if send_receipt:

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -415,7 +415,7 @@ class Customer(StripeCustomer):
         dollar amount. It will be converted to cents so any decimals beyond
         two will be ignored.
         """
-        
+
         if send_receipt is None:
             send_receipt = getattr(settings, 'DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS', True)
 


### PR DESCRIPTION
This fixes issue #284. The `charge` method in `models.py` is ignoring the `settings.py` configuration. This change will still default to sending emails unless `DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS` is set to false in `settings.py`.
