### PR TITLE
Change string representation for customer if subscriber doesn't have e-mail attribute

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -193,7 +193,8 @@ class Customer(StripeCustomer):
     def str_parts(self):
         return [
             smart_text(self.subscriber),
-            "email={email}".format(email=self.subscriber.email),
+            "email={email}".format(email=self.subscriber.email
+                if hasattr(self.subscriber, 'email') else ''),
         ] + super(Customer, self).str_parts()
 
     def delete(self, using=None):


### PR DESCRIPTION
Change the string representation for the customer model if subscriber doesn't have an e-mail attribute.

Fixes Issue #297
