### PR TITLE
Explicit event subtype handlers

### DIFF
--- a/djstripe/webhooks.py
+++ b/djstripe/webhooks.py
@@ -4,6 +4,7 @@
    :synopsis: dj-stripe - Utils related to processing or registering for webhooks
 
 .. moduleauthor:: Bill Huneke (@wahuneke)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 A model registers itself here if it wants to be in the list of processing
 functions for a particular webhook. Each processor will have the ability
@@ -94,7 +95,10 @@ def call_handlers(event, event_data, event_type, event_subtype):
     :param event_subtype: The event sub-type, e.g. 'updated'.
     :type event_subtype: string (`str`/`unicode`)
     """
-    qualified_event_type = "%s.%s" % (event_type, event_subtype)
+    qualified_event_type = (
+        "{event_type}.{event_subtype}".format(
+            event_type=event_type, event_subtype=event_subtype))
+
     for handler_func in itertools.chain(
             registrations_global,
             registrations[event_type],

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -7,14 +7,17 @@
 """
 
 from copy import deepcopy
+from collections import defaultdict
 import json
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
-from mock import patch
+from mock import patch, Mock, ANY
 
+from djstripe import webhooks
 from djstripe.models import Event, EventProcessingException
+from djstripe.webhooks import handler, handler_all, call_handlers
 from tests import FAKE_EVENT_TRANSFER_CREATED, FAKE_TRANSFER
 
 
@@ -58,3 +61,45 @@ class TestWebhook(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(1, Event.objects.filter(type="transfer.created").count())
         self.assertEqual(1, EventProcessingException.objects.count())
+
+
+class TestWebhookHandlers(TestCase):
+    def setUp(self):
+        # Reset state of registrations per test
+        patcher = patch.object(
+            webhooks, 'registrations', new_callable=lambda: defaultdict(list))
+        self.addCleanup(patcher.stop)
+        self.registrations = patcher.start()
+
+        patcher = patch.object(
+            webhooks, 'registrations_global', new_callable=list)
+        self.addCleanup(patcher.stop)
+        self.registrations_global = patcher.start()
+
+    def test_global_handler_registration(self):
+        func_mock = Mock()
+        handler_all()(func_mock)
+        call_handlers(Mock(), {'data': 'foo'}, 'wib', 'ble')  # handled
+        self.assertEqual(1, func_mock.call_count)
+
+    def test_event_handler_registration(self):
+        global_func_mock = Mock()
+        handler_all()(global_func_mock)
+        func_mock = Mock()
+        handler(['foo'])(func_mock)
+        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
+        call_handlers(Mock(), {'data': 'foo'}, 'bar', 'foo')  # not handled
+        self.assertEqual(2, global_func_mock.call_count)  # called each time
+        self.assertEqual(1, func_mock.call_count)
+        func_mock.assert_called_with(ANY, ANY, 'foo', 'bar')
+
+    def test_event_subtype_handler_registration(self):
+        global_func_mock = Mock()
+        handler_all()(global_func_mock)
+        func_mock = Mock()
+        handler(['foo.bar'])(func_mock)
+        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
+        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'baz')  # not handled
+        self.assertEqual(2, global_func_mock.call_count)  # called each time
+        self.assertEqual(1, func_mock.call_count)
+        func_mock.assert_called_with(ANY, ANY, 'foo', 'bar')

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -103,3 +103,15 @@ class TestWebhookHandlers(TestCase):
         self.assertEqual(2, global_func_mock.call_count)  # called each time
         self.assertEqual(1, func_mock.call_count)
         func_mock.assert_called_with(ANY, ANY, 'foo', 'bar')
+
+    def test_global_handler_registration_with_function(self):
+        func_mock = Mock()
+        handler_all(func_mock)
+        call_handlers(Mock(), {'data': 'foo'}, 'wib', 'ble')  # handled
+        self.assertEqual(1, func_mock.call_count)
+
+    def test_event_handle_registation_with_string(self):
+        func_mock = Mock()
+        handler('foo')(func_mock)
+        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
+        self.assertEqual(1, func_mock.call_count)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -3,6 +3,7 @@
    :synopsis: dj-stripe Webhook Tests.
 
 .. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 """
 


### PR DESCRIPTION
## Description

First PR request, start 'em simple-ish!  For folks like ourselves who like to extend the dj-stripe event handling system, this PR will allow handlers based on event sub-type, such as:

```
@handler('customer.subscription.deleted')
def handle_deleted_subscription(event, event_data, event_type, event_subtype):
    # Do something with deleted subscriptions only
    return
```

Note that the argument can now be a string rather than a list, if subscribing to a single event type or event sub-type (needing to be a list caught us out embarassingly, as it "fails" silent, or rather it would have registered each character from the string as a separate event handler).

For convenience and to follow usual style for decorators, the global `handler_all` decorator also no longer needs to have parentheses when being called:

```
@handler_all
def handle([snip]):
    pass

@handler_all()
def handler([snip]):
    pass
```
## Test Output

```
Welcome to the dj-stripe test suite.

Step 1: Running unit tests.

nosetests . --verbosity=1
Creating test database for alias 'default'...
..................................................................................................................................................................................................S...S.........................................
----------------------------------------------------------------------
Ran 240 tests in 5.620s

OK (SKIP=2)
Destroying test database for alias 'default'...

Step 2: Generating coverage results.

Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
djstripe/context_managers.py                         8      0      0      0   100%
djstripe/contrib/rest_framework/permissions.py       9      0      0      0   100%
djstripe/contrib/rest_framework/serializers.py      11      0      0      0   100%
djstripe/contrib/rest_framework/urls.py              5      0      0      0   100%
djstripe/contrib/rest_framework/views.py            36      0      2      0   100%
djstripe/decorators.py                              19      0      4      0   100%
djstripe/event_handlers.py                          44      0     16      0   100%
djstripe/exceptions.py                               7      0      0      0   100%
djstripe/fields.py                                  76      0     18      0   100%
djstripe/forms.py                                    7      0      0      0   100%
djstripe/managers.py                                37      0      0      0   100%
djstripe/middleware.py                              36      0     18      0   100%
djstripe/mixins.py                                  26      0      2      0   100%
djstripe/models.py                                 333      0    102      0   100%
djstripe/settings.py                                43      0     12      0   100%
djstripe/signals.py                                  3      0      0      0   100%
djstripe/stripe_objects.py                         441      0     53      0   100%
djstripe/sync.py                                    29      0      4      0   100%
djstripe/templatetags/djstripe_tags.py              20      0      4      0   100%
djstripe/urls.py                                     6      0      0      0   100%
djstripe/utils.py                                   35      0     14      0   100%
djstripe/views.py                                  133      0     22      0   100%
djstripe/webhooks.py                                25      0      8      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                             1389      0    279      0   100%

Step 3: Checking for pep8 errors.

pep8 errors:
----------------------------------------------------------------------
./docs/conf.py:32:1: E402 module level import not at top of file
./tests/__init__.py:17:1: F401 'django.conf.settings' imported but unused
./tests/test_invoice.py:154:1: W391 blank line at end of file
./tests/test_contrib/test_views.py:17:1: F401 'mock.PropertyMock' imported but unused
4
pep8 errors detected.

YOUR CHANGES HAVE INTRODUCED PEP8 ERRORS!
```

The PEP8 issues don't seem to be related to these changes.
