### PR TITLE
Positional arguments passthrough for runtests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ htmlcov
 
 # OSX
 .DS_Store
+
+# Virtualenv
+.venv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ cwd = os.getcwd()
 parent = os.path.dirname(cwd)
 sys.path.append(parent)
 
-import djstripe
+import djstripe  # noqa
 
 settings.configure(
     INSTALLED_APPS=[

--- a/runtests.py
+++ b/runtests.py
@@ -214,7 +214,7 @@ def run_test_suite(args):
         print("----------------------------------------------------------------------")
 
         from subprocess import call
-        flake_result = call(["flake8", ".", "--count", "--exclude", ".venv"])
+        flake_result = call(["flake8", ".", "--count"])
         if flake_result != 0:
             sys.stderr.write("pep8 errors detected.\n")
             sys.stderr.write(colored(text="\nYOUR CHANGES HAVE INTRODUCED PEP8 ERRORS!\n\n", color="red", attrs=["bold"]))

--- a/runtests.py
+++ b/runtests.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument("--skip-utc", action="store_true", help="Skip any tests that require the system timezone to be in UTC.")
     parser.add_argument("--no-coverage", action="store_true", help="Disable checking for 100% code coverage (Not advised).")
     parser.add_argument("--no-pep8", action="store_true", help="Disable checking for pep8 errors (Not advised).")
+    parser.add_argument("tests", nargs='*', default=['.'])
     args = parser.parse_args()
 
     run_test_suite(args)
@@ -26,6 +27,7 @@ def run_test_suite(args):
     skip_utc = args.skip_utc
     enable_coverage = not args.no_coverage
     enable_pep8 = not args.no_pep8
+    tests = args.tests
 
     if enable_coverage:
         cov = Coverage(config_file=True)
@@ -181,7 +183,7 @@ def run_test_suite(args):
     from django_nose import NoseTestSuiteRunner
 
     test_runner = NoseTestSuiteRunner(verbosity=1)
-    failures = test_runner.run_tests(["."])
+    failures = test_runner.run_tests(tests)
 
     if failures:
         sys.exit(failures)
@@ -212,7 +214,7 @@ def run_test_suite(args):
         print("----------------------------------------------------------------------")
 
         from subprocess import call
-        flake_result = call(["flake8", ".", "--count"])
+        flake_result = call(["flake8", ".", "--count", "--exclude", ".venv"])
         if flake_result != 0:
             sys.stderr.write("pep8 errors detected.\n")
             sys.stderr.write(colored(text="\nYOUR CHANGES HAVE INTRODUCED PEP8 ERRORS!\n\n", color="red", attrs=["bold"]))

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ universal = 1
 [flake8]
 ignore = E501,E128
 max-complexity = 15
-exclude = *docs/*,*tests/*
+exclude = .venv

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,6 @@ import calendar
 from copy import deepcopy
 from datetime import datetime
 
-from django.conf import settings
 from django.utils import timezone
 
 FUTURE_DATE = datetime(2100, 4, 30, tzinfo=timezone.utc)

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from mock import patch, PropertyMock
+from mock import patch
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -151,4 +151,3 @@ class InvoiceTest(TestCase):
         invoice = Invoice.sync_from_stripe_data(invoice_data)
 
         self.assertEqual(None, invoice.subscription)
-


### PR DESCRIPTION
## Description

Another simple PR to add positional argument support to runtests.py, to be able to pass through arguments to nose - Useful when developing small changes when prepping a PR so that the tests can be executed against a subset rather than the full fat test, for example:

`$ python runtests.py --skip-utc tests/test_fields.py` (path syntax)
_or_
`$ python runtests.py --skip-utc tests.test_fields.py` (module syntax)

Example output:

``` ...
----------------------------------------------------------------------
Ran 3 tests in 0.009s

OK
```

Also (minor) adds an exclusion for `.venv` for `.gitignore` and flake8, since this is how we usually develop - I can chop this bit out if it isn't desirable (I realise `mkvirtualenvwrapper` is fairly popular, and it is something we might jump on in the future as well).
## Test Output

Ran: `$ python runtests.py --skip-utc`

```

Welcome to the dj-stripe test suite.

Step 1: Running unit tests.

nosetests . --verbosity=1
Creating test database for alias 'default'...
..................................................................................................................................................................................................S...S....................................
----------------------------------------------------------------------
Ran 235 tests in 5.434s

OK (SKIP=2)
Destroying test database for alias 'default'...

Step 2: Generating coverage results.

Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
djstripe/context_managers.py                         8      0      0      0   100%
djstripe/contrib/rest_framework/permissions.py       9      0      0      0   100%
djstripe/contrib/rest_framework/serializers.py      11      0      0      0   100%
djstripe/contrib/rest_framework/urls.py              5      0      0      0   100%
djstripe/contrib/rest_framework/views.py            36      0      2      0   100%
djstripe/decorators.py                              19      0      4      0   100%
djstripe/event_handlers.py                          44      0     16      0   100%
djstripe/exceptions.py                               7      0      0      0   100%
djstripe/fields.py                                  76      0     18      0   100%
djstripe/forms.py                                    7      0      0      0   100%
djstripe/managers.py                                37      0      0      0   100%
djstripe/middleware.py                              36      0     18      0   100%
djstripe/mixins.py                                  26      0      2      0   100%
djstripe/models.py                                 333      0    102      0   100%
djstripe/settings.py                                43      0     12      0   100%
djstripe/signals.py                                  3      0      0      0   100%
djstripe/stripe_objects.py                         441      0     53      0   100%
djstripe/sync.py                                    29      0      4      0   100%
djstripe/templatetags/djstripe_tags.py              20      0      4      0   100%
djstripe/urls.py                                     6      0      0      0   100%
djstripe/utils.py                                   35      0     14      0   100%
djstripe/views.py                                  133      0     22      0   100%
djstripe/webhooks.py                                17      0      4      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                             1381      0    275      0   100%

Step 3: Checking for pep8 errors.

pep8 errors:
----------------------------------------------------------------------
./docs/conf.py:32:1: E402 module level import not at top of file
./tests/__init__.py:17:1: F401 'django.conf.settings' imported but unused
./tests/test_invoice.py:154:1: W391 blank line at end of file
./tests/test_contrib/test_views.py:17:1: F401 'mock.PropertyMock' imported but unused
4
pep8 errors detected.

YOUR CHANGES HAVE INTRODUCED PEP8 ERRORS!
```

_Edit:_

TravisCI twisted my arm, fixed the PEP8 errors and re-ran to produce:

```
pep8 errors:
----------------------------------------------------------------------
None

Tests completed successfully with no errors. Congrats!
```
