### PR TITLE
Add event re-processing support in admin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+"""
+.. module:: djstripe.admin
+   :synopsis: dj-stripe - Django Administration interface definitions
+
+.. moduleauthor:: Daniel Greenfeld (@pydanny)
+.. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
+
+"""
 
 from django.contrib import admin
 

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -116,6 +116,31 @@ admin.site.register(
     ],
 )
 
+
+def reprocess_events(modeladmin, request, queryset):
+    """ Re-processes the selected webhook events.
+
+    Note that this isn't idempotent, so any side-effects that are produced from
+    the event being handled will be multiplied (for example, an event handler
+    that sends emails will send duplicates; an event handler that adds 1 to a
+    total count will be a count higher than it was, etc.)
+
+    There aren't any event handlers with adverse side-effects built within
+    dj-stripe, but there might be within your own event handlers, third-party
+    plugins, contrib code, etc.
+    """
+    processed = 0
+    for event in queryset:
+        if event.process(force=True):
+            processed += 1
+
+    modeladmin.message_user(
+        request,
+        "{processed}/{total} event(s) successfully re-processed.".format(
+            processed=processed, total=queryset.count()))
+reprocess_events.short_description = "Re-process selected webhook events"
+
+
 admin.site.register(
     Event,
     raw_id_fields=["customer"],
@@ -137,6 +162,9 @@ admin.site.register(
         "stripe_id",
         "customer__stripe_id",
         "validated_message"
+    ],
+    actions=[
+        reprocess_events
     ],
 )
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
+"""
+.. module:: djstripe.models
+   :synopsis: dj-stripe - Django ORM model definitions
+
+.. moduleauthor:: Daniel Greenfeld (@pydanny)
+.. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
+
+"""
+
 from __future__ import unicode_literals
 
 import logging

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,6 +3,7 @@
    :synopsis: dj-stripe Admin Tests.
 
 .. moduleauthor:: Oleksandr (@nanvel)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 """
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -11,9 +11,10 @@ from copy import deepcopy
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from mock import patch
+from mock import Mock, patch
 
-from djstripe.models import Customer, Event
+from djstripe import webhooks
+from djstripe.models import Customer, Event, StripeError
 from tests import FAKE_EVENT_TRANSFER_CREATED, FAKE_CUSTOMER
 
 
@@ -23,8 +24,12 @@ class EventTest(TestCase):
         self.user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")
         self.customer = Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
 
+        patcher = patch.object(webhooks, 'call_handlers')
+        self.addCleanup(patcher.stop)
+        self.call_handlers = patcher.start()
+
     def test_str(self):
-        event = Event.sync_from_stripe_data(deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
 
         self.assertEqual("<type={type}, stripe_id={stripe_id}>".format(
             type=FAKE_EVENT_TRANSFER_CREATED["type"],
@@ -32,15 +37,49 @@ class EventTest(TestCase):
         ), str(event))
 
     @patch('djstripe.models.EventProcessingException.log')
-    @patch('stripe.Event.retrieve')
-    def test_stripe_error(self, event_retrieve_mock, event_exception_log_mock):
-        fake_event_data = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
-        event_retrieve_mock.return_value = fake_event_data
-
-        event = Event.sync_from_stripe_data(fake_event_data)
-
-        event.validate()
-        event.process()
-
+    def test_stripe_error(self, event_exception_log_mock):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        self.call_handlers.side_effect = StripeError("Boom!")
+        self.assertFalse(event.process())
         self.assertTrue(event_exception_log_mock.called)
         self.assertFalse(event.processed)
+
+    def test_process_event_when_invalid(self):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        event.valid = False
+        self.assertFalse(event.process())
+        self.assertFalse(event.process(force=True))  # no effect
+
+    def test_reprocess_event_not_forced(self):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        event.save = Mock()
+
+        self.assertTrue(event.process())
+        event.save.assert_called_with()
+        event.save.reset_mock()
+
+        self.assertTrue(event.process())
+        event.save.assert_not_called()
+
+    def test_reprocess_event_forced(self):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        event.save = Mock()
+
+        self.assertTrue(event.process())
+        event.save.assert_called_with()
+        event.save.reset_mock()
+
+        self.assertTrue(event.process(force=True))
+        event.save.assert_called_with()
+
+    #
+    # Helpers
+    #
+
+    @patch('stripe.Event.retrieve')
+    def _create_event(self, event_data, event_retrieve_mock):
+        event_data = deepcopy(event_data)
+        event_retrieve_mock.return_value = event_data
+        event = Event.sync_from_stripe_data(event_data)
+        event.validate()
+        return event

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -4,6 +4,7 @@
 
 .. moduleauthor:: Daniel Greenfeld (@pydanny)
 .. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 """
 


### PR DESCRIPTION
## Description

Adds the ability to reprocess events from within the admin interface, which is extremely useful when developing new event handlers (or for debugging when an event failed).  A flash message is displayed after processing to inform the user whether or not the events were processed successfully.

As a part of these changes it is now possible for a previously processed event to become "unprocessed" if an error is raised during re-processing - This might happen if a bug was introduced in an event handler, or for some other reason, such as a dependent object now being missing (e.g. a subscription was deleted that a previous event utilised).
## Screenshot

![admin](https://cloud.githubusercontent.com/assets/2248287/16321258/db60672a-3993-11e6-8b00-71eccaee778e.png)
## Test Output

Ran: `python runtests.py --skip-utc`

```
Welcome to the dj-stripe test suite.

Step 1: Running unit tests.

nosetests . --verbosity=1
Creating test database for alias 'default'...
......................................................................................................................................................................................................S...S.........................................
----------------------------------------------------------------------
Ran 244 tests in 5.063s

OK (SKIP=2)
Destroying test database for alias 'default'...

Step 2: Generating coverage results.

Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
djstripe/context_managers.py                         8      0      0      0   100%
djstripe/contrib/rest_framework/permissions.py       9      0      0      0   100%
djstripe/contrib/rest_framework/serializers.py      11      0      0      0   100%
djstripe/contrib/rest_framework/urls.py              5      0      0      0   100%
djstripe/contrib/rest_framework/views.py            36      0      2      0   100%
djstripe/decorators.py                              19      0      4      0   100%
djstripe/event_handlers.py                          44      0     16      0   100%
djstripe/exceptions.py                               7      0      0      0   100%
djstripe/fields.py                                  76      0     18      0   100%
djstripe/forms.py                                    7      0      0      0   100%
djstripe/managers.py                                37      0      0      0   100%
djstripe/middleware.py                              36      0     18      0   100%
djstripe/mixins.py                                  26      0      2      0   100%
djstripe/models.py                                 337      0    104      0   100%
djstripe/settings.py                                43      0     12      0   100%
djstripe/signals.py                                  3      0      0      0   100%
djstripe/stripe_objects.py                         441      0     53      0   100%
djstripe/sync.py                                    29      0      4      0   100%
djstripe/templatetags/djstripe_tags.py              20      0      4      0   100%
djstripe/urls.py                                     6      0      0      0   100%
djstripe/utils.py                                   35      0     14      0   100%
djstripe/views.py                                  133      0     22      0   100%
djstripe/webhooks.py                                25      0      8      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                             1393      0    281      0   100%

Step 3: Checking for pep8 errors.

pep8 errors:
----------------------------------------------------------------------
None

Tests completed successfully with no errors. Congrats!
```
