### PR TITLE
Improve CRUD-like event handling for objects

### DIFF
--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -22,6 +22,7 @@ from .models import Charge, Customer, Card, Subscription, Plan, Transfer, Invoic
 @webhooks.handler_all
 def customer_event_attach(event, event_data, event_type, event_subtype):
     """ Makes the related customer available on the event for all handlers. """
+
     event.customer = None
     crud_type = CrudType.determine(event_subtype, exact=True)
 
@@ -30,90 +31,56 @@ def customer_event_attach(event, event_data, event_type, event_subtype):
     else:
         customer_stripe_id = event_data["object"].get("customer", None)
 
-    if not customer_stripe_id:
-        return
-
-    try:
-        event.customer = Customer.objects.get(stripe_id=customer_stripe_id)
-    except Customer.DoesNotExist:
-        pass
+    if customer_stripe_id:
+        try:
+            event.customer = Customer.objects.get(stripe_id=customer_stripe_id)
+        except Customer.DoesNotExist:
+            pass
 
 
 @webhooks.handler("customer")
-def customer_webhook_handler(
-        event, event_data, event_type, event_subtype):
+def customer_webhook_handler(event, event_data, event_type, event_subtype):
     """ Handles updates for customer objects. """
-    crud_type = CrudType.determine(event_subtype, exact=True)
-    if not crud_type.valid:
-        return
 
-    if not event.customer:
+    crud_type = CrudType.determine(event_subtype, exact=True)
+    if crud_type.valid and event.customer:
         # As customers are tied to local users, djstripe will not create
         # customers that do not already exist locally.
-        return
-
-    if crud_type.deleted:
-        # Deletions for customers are handled a little bit differently, since
-        # the customer is "purged" but not fully deleted from the system, so
-        # the object is updated first then "deleted".
-        _handle_crud_type_event(
-            Customer, event_data, event_subtype,
-            crud_type=CrudType(updated=True))
-
-    _handle_crud_type_event(
-        Customer, event_data, event_subtype, crud_type=crud_type)
+        _handle_crud_type_event(target_cls=Customer, event_data=event_data, event_subtype=event_subtype, crud_type=crud_type)
 
 
 @webhooks.handler("customer.source")
 def customer_source_webhook_handler(
         event, event_data, event_type, event_subtype):
     """ Handles updates for customer source objects. """
+
     source_type = event_data["object"]["object"]
 
     # TODO: other sources
-    if source_type != "card":
-        return
-
-    obj, crud_type = _handle_crud_type_event(
-        Card, event_data, event_subtype, customer=event.customer)
+    if source_type == "card":
+        _handle_crud_type_event(target_cls=Card, event_data=event_data, event_subtype=event_subtype, customer=event.customer)
 
 
 @webhooks.handler("customer.subscription")
-def customer_subscription_webhook_handler(
-        event, event_data, event_type, event_subtype):
-    """ Handles updates for subscription objects. """
-    _handle_crud_type_event(
-        Subscription, event_data, event_subtype, customer=event.customer)
+def customer_subscription_webhook_handler(event, event_data, event_type, event_subtype):
+    """ Handles updates for customer subscription objects. """
+
+    _handle_crud_type_event(target_cls=Subscription, event_data=event_data, event_subtype=event_subtype, customer=event.customer)
 
 
-@webhooks.handler("transfer")
-def transfer_webhook_handler(event, event_data, event_type, event_subtype):
-    """ Handles updates for transfer objects. """
-    _handle_crud_type_event(Transfer, event_data, event_subtype)
+@webhooks.handler(["transfer", "charge", "invoice", "invoiceitem", "plan"])
+def other_object_webhook_handler(event, event_data, event_type, event_subtype):
+    """ Handles updates for transfer, charge, invoice, invoiceitem and plan objects. """
 
+    target_cls = {
+        "charge": Charge,
+        "invoice": Invoice,
+        "invoiceitem": InvoiceItem,
+        "plan": Plan,
+        "transfer": Transfer
+    }.get(event_type)
 
-@webhooks.handler(["charge"])
-def charge_webhook_handler(event, event_data, event_type, event_subtype):
-    """ Handles updates for charge objects. """
-    _handle_crud_type_event(Charge, event_data, event_subtype)
-
-
-@webhooks.handler("invoice")
-def invoice_webhook_handler(event, event_data, event_type, event_subtype):
-    """ Handles updates for invoice objects. """
-    _handle_crud_type_event(Invoice, event_data, event_subtype)
-
-
-@webhooks.handler("invoiceitem")
-def invoiceitem_webhook_handler(event, event_data, event_type, event_subtype):
-    """ Handles updates for invoice item objects. """
-    _handle_crud_type_event(InvoiceItem, event_data, event_subtype)
-
-
-@webhooks.handler("plan")
-def plan_webhook_handler(event, event_data, event_type, event_subtype):
-    """ Handles updates for plan objects. """
-    _handle_crud_type_event(Plan, event_data, event_subtype)
+    _handle_crud_type_event(target_cls=target_cls, event_data=event_data, event_subtype=event_subtype, customer=event.customer)
 
 
 #
@@ -122,17 +89,19 @@ def plan_webhook_handler(event, event_data, event_type, event_subtype):
 
 class CrudType(object):
     """ Helper object to determine CRUD-like event state. """
+
     created = False
     updated = False
     deleted = False
 
     def __init__(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
     @property
     def valid(self):
         """ Returns True if this is a CRUD-like event. """
+
         return self.created or self.updated or self.deleted
 
     @classmethod
@@ -141,11 +110,12 @@ class CrudType(object):
         Determines if the event subtype is a crud_type (without the 'R') event.
 
         :param event_subtype: The event subtype to examine.
+        :type event_subtype: string (``str``/`unicode``)
         :param exact: If True, match crud_type to event subtype string exactly.
+        :param type: ``bool``
         :returns: The CrudType state object.
         :rtype: ``CrudType``
         """
-        crud_type = cls()
 
         def check(crud_type_event):
             if exact:
@@ -153,19 +123,19 @@ class CrudType(object):
             else:
                 return event_subtype.endswith(crud_type_event)
 
+        created = updated = deleted = False
+
         if check("updated"):
-            crud_type.updated = True
+            updated = True
         elif check("created"):
-            crud_type.created = True
+            created = True
         elif check("deleted"):
-            crud_type.deleted = True
+            deleted = True
 
-        return crud_type
+        return cls(created=created, updated=updated, deleted=deleted)
 
 
-def _handle_crud_type_event(
-        cls, event_data, event_subtype, stripe_id=None, customer=None,
-        crud_type=None):
+def _handle_crud_type_event(target_cls, event_data, event_subtype, stripe_id=None, customer=None, crud_type=None):
     """
     Helper to process crud_type-like events for objects.
 
@@ -177,6 +147,8 @@ def _handle_crud_type_event(
     from the local database, if it existed.  If it doesn't exist then it is
     ignored (but the event processing still succeeds).
 
+    :param target_cls: The djstripe model being handled.
+    :type: ``djstripe.stripe_objects.StripeObject``
     :param event_data: The event object data received from the Stripe API.
     :param event_subtype: The event subtype string.
     :param stripe_id: The object Stripe ID - If not provided then this is
@@ -187,22 +159,23 @@ def _handle_crud_type_event(
     :returns: The object (if any) and the event CrudType.
     :rtype: ``tuple(obj, CrudType)``
     """
+
     crud_type = crud_type or CrudType.determine(event_subtype)
     stripe_id = stripe_id or event_data["object"]["id"]
     obj = None
 
     if crud_type.deleted:
         try:
-            obj = cls.objects.get(stripe_id=stripe_id)
+            obj = target_cls.objects.get(stripe_id=stripe_id)
             obj.delete()
-        except cls.DoesNotExist:
+        except target_cls.DoesNotExist:
             pass
     else:
         # Any other event type (creates, updates, etc.)
         kwargs = {"stripe_id": stripe_id}
         if customer:
             kwargs["customer"] = customer
-        data = cls(**kwargs).api_retrieve()
-        obj = cls.sync_from_stripe_data(data)
+        data = target_cls(**kwargs).api_retrieve()
+        obj = target_cls.sync_from_stripe_data(data)
 
     return obj, crud_type

--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -5,6 +5,7 @@
 
 .. moduleauthor:: Bill Huneke (@wahuneke)
 .. moduleauthor:: Alex Kavanaugh (@akavanau)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 Implement webhook event handlers for all the models that need to respond to webhook events.
 
@@ -17,92 +18,191 @@ NOTE: Event data is not guaranteed to be in the correct API version format. See 
 from . import webhooks
 from .models import Charge, Customer, Card, Subscription, Plan, Transfer, Invoice, InvoiceItem
 
-STRIPE_CRUD_EVENTS = ["created", "updated", "deleted"]
 
-
-# ---------------------------
-# Charge model events
-# ---------------------------
-@webhooks.handler(['charge'])
-def charge_webhook_handler(event, event_data, event_type, event_subtype):
-    versioned_charge_data = Charge(stripe_id=event_data["object"]["id"]).api_retrieve()
-    Charge.sync_from_stripe_data(versioned_charge_data)
-
-
-# ---------------------------
-# Customer model events
-# ---------------------------
 @webhooks.handler_all
 def customer_event_attach(event, event_data, event_type, event_subtype):
+    """ Makes the related customer available on the event for all handlers. """
+    event.customer = None
+    crud_type = CrudType.determine(event_subtype, exact=True)
 
-    if event_type == "customer" and event_subtype in STRIPE_CRUD_EVENTS:
-        stripe_customer_id = event_data["object"]["id"]
+    if event_type == "customer" and crud_type.valid:
+        customer_stripe_id = event_data["object"]["id"]
     else:
-        stripe_customer_id = event_data["object"].get("customer", None)
+        customer_stripe_id = event_data["object"].get("customer", None)
 
-    if stripe_customer_id:
-        try:
-            event.customer = Customer.objects.get(stripe_id=stripe_customer_id)
-        except Customer.DoesNotExist:
-            pass
+    if not customer_stripe_id:
+        return
 
-
-@webhooks.handler(['customer'])
-def customer_webhook_handler(event, event_data, event_type, event_subtype):
-
-    customer = event.customer
-    if customer:
-        if event_subtype in STRIPE_CRUD_EVENTS:
-            versioned_customer_data = Customer(stripe_id=event_data["object"]["id"]).api_retrieve()
-            Customer.sync_from_stripe_data(versioned_customer_data)
-
-            if event_subtype == "deleted":
-                customer.purge()
-#         elif event_subtype.startswith("discount."):
-#             pass  # TODO
-        elif event_subtype.startswith("source."):
-            source_type = event_data["object"]["object"]
-
-            # TODO: other sources
-            if source_type == "card":
-                versioned_card_data = Card(stripe_id=event_data["object"]["id"], customer=customer).api_retrieve()
-                Card.sync_from_stripe_data(versioned_card_data)
-        elif event_subtype.startswith("subscription."):
-            versioned_subscription_data = Subscription(stripe_id=event_data["object"]["id"], customer=customer).api_retrieve()
-            Subscription.sync_from_stripe_data(versioned_subscription_data)
+    try:
+        event.customer = Customer.objects.get(stripe_id=customer_stripe_id)
+    except Customer.DoesNotExist:
+        pass
 
 
-# ---------------------------
-# Transfer model events
-# ---------------------------
-@webhooks.handler(["transfer"])
+@webhooks.handler("customer")
+def customer_webhook_handler(
+        event, event_data, event_type, event_subtype):
+    """ Handles updates for customer objects. """
+    crud_type = CrudType.determine(event_subtype, exact=True)
+    if not crud_type.valid:
+        return
+
+    if not event.customer:
+        # As customers are tied to local users, djstripe will not create
+        # customers that do not already exist locally.
+        return
+
+    if crud_type.deleted:
+        # Deletions for customers are handled a little bit differently, since
+        # the customer is "purged" but not fully deleted from the system, so
+        # the object is updated first then "deleted".
+        _handle_crud_type_event(
+            Customer, event_data, event_subtype,
+            crud_type=CrudType(updated=True))
+
+    _handle_crud_type_event(
+        Customer, event_data, event_subtype, crud_type=crud_type)
+
+
+@webhooks.handler("customer.source")
+def customer_source_webhook_handler(
+        event, event_data, event_type, event_subtype):
+    """ Handles updates for customer source objects. """
+    source_type = event_data["object"]["object"]
+
+    # TODO: other sources
+    if source_type != "card":
+        return
+
+    obj, crud_type = _handle_crud_type_event(
+        Card, event_data, event_subtype, customer=event.customer)
+
+
+@webhooks.handler("customer.subscription")
+def customer_subscription_webhook_handler(
+        event, event_data, event_type, event_subtype):
+    """ Handles updates for subscription objects. """
+    _handle_crud_type_event(
+        Subscription, event_data, event_subtype, customer=event.customer)
+
+
+@webhooks.handler("transfer")
 def transfer_webhook_handler(event, event_data, event_type, event_subtype):
-    versioned_transfer_data = Transfer(stripe_id=event_data["object"]["id"]).api_retrieve()
-    Transfer.sync_from_stripe_data(versioned_transfer_data)
+    """ Handles updates for transfer objects. """
+    _handle_crud_type_event(Transfer, event_data, event_subtype)
 
 
-# ---------------------------
-# Invoice model events
-# ---------------------------
-@webhooks.handler(['invoice'])
+@webhooks.handler(["charge"])
+def charge_webhook_handler(event, event_data, event_type, event_subtype):
+    """ Handles updates for charge objects. """
+    _handle_crud_type_event(Charge, event_data, event_subtype)
+
+
+@webhooks.handler("invoice")
 def invoice_webhook_handler(event, event_data, event_type, event_subtype):
-    versioned_invoice_data = Invoice(stripe_id=event_data["object"]["id"]).api_retrieve()
-    Invoice.sync_from_stripe_data(versioned_invoice_data)
+    """ Handles updates for invoice objects. """
+    _handle_crud_type_event(Invoice, event_data, event_subtype)
 
 
-# ---------------------------
-# InvoiceItem model events
-# ---------------------------
-@webhooks.handler(['invoiceitem'])
+@webhooks.handler("invoiceitem")
 def invoiceitem_webhook_handler(event, event_data, event_type, event_subtype):
-    versioned_invoiceitem_data = InvoiceItem(stripe_id=event_data["object"]["id"]).api_retrieve()
-    InvoiceItem.sync_from_stripe_data(versioned_invoiceitem_data)
+    """ Handles updates for invoice item objects. """
+    _handle_crud_type_event(InvoiceItem, event_data, event_subtype)
 
 
-# ---------------------------
-# Plan model events
-# ---------------------------
-@webhooks.handler(['plan'])
+@webhooks.handler("plan")
 def plan_webhook_handler(event, event_data, event_type, event_subtype):
-    versioned_plan_data = Plan(stripe_id=event_data["object"]["id"]).api_retrieve()
-    Plan.sync_from_stripe_data(versioned_plan_data)
+    """ Handles updates for plan objects. """
+    _handle_crud_type_event(Plan, event_data, event_subtype)
+
+
+#
+# Helpers
+#
+
+class CrudType(object):
+    """ Helper object to determine CRUD-like event state. """
+    created = False
+    updated = False
+    deleted = False
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.iteritems():
+            setattr(self, k, v)
+
+    @property
+    def valid(self):
+        """ Returns True if this is a CRUD-like event. """
+        return self.created or self.updated or self.deleted
+
+    @classmethod
+    def determine(cls, event_subtype, exact=False):
+        """
+        Determines if the event subtype is a crud_type (without the 'R') event.
+
+        :param event_subtype: The event subtype to examine.
+        :param exact: If True, match crud_type to event subtype string exactly.
+        :returns: The CrudType state object.
+        :rtype: ``CrudType``
+        """
+        crud_type = cls()
+
+        def check(crud_type_event):
+            if exact:
+                return event_subtype == crud_type_event
+            else:
+                return event_subtype.endswith(crud_type_event)
+
+        if check("updated"):
+            crud_type.updated = True
+        elif check("created"):
+            crud_type.created = True
+        elif check("deleted"):
+            crud_type.deleted = True
+
+        return crud_type
+
+
+def _handle_crud_type_event(
+        cls, event_data, event_subtype, stripe_id=None, customer=None,
+        crud_type=None):
+    """
+    Helper to process crud_type-like events for objects.
+
+    Non-deletes (creates, updates and "anything else" events) are treated as
+    update_or_create events - The object will be retrieved locally, then it is
+    synchronised with the Stripe API for parity.
+
+    Deletes only occur for delete events and cause the object to be deleted
+    from the local database, if it existed.  If it doesn't exist then it is
+    ignored (but the event processing still succeeds).
+
+    :param event_data: The event object data received from the Stripe API.
+    :param event_subtype: The event subtype string.
+    :param stripe_id: The object Stripe ID - If not provided then this is
+    retrieved from the event object data by "object.id" key.
+    :param customer: The customer object which is passed on object creation.
+    :param crud_type: The CrudType object - If not provided it is determined
+    based on the event subtype string.
+    :returns: The object (if any) and the event CrudType.
+    :rtype: ``tuple(obj, CrudType)``
+    """
+    crud_type = crud_type or CrudType.determine(event_subtype)
+    stripe_id = stripe_id or event_data["object"]["id"]
+    obj = None
+
+    if crud_type.deleted:
+        try:
+            obj = cls.objects.get(stripe_id=stripe_id)
+            obj.delete()
+        except cls.DoesNotExist:
+            pass
+    else:
+        # Any other event type (creates, updates, etc.)
+        kwargs = {"stripe_id": stripe_id}
+        if customer:
+            kwargs["customer"] = customer
+        data = cls(**kwargs).api_retrieve()
+        obj = cls.sync_from_stripe_data(data)
+
+    return obj, crud_type

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -419,6 +419,7 @@ class Event(StripeEvent):
         previously processed successfully.
         :rtype: bool
         """
+
         if not self.valid:
             return False
 
@@ -428,8 +429,7 @@ class Event(StripeEvent):
                 # except that some webhook handlers can have side effects outside of our local database, meaning that
                 # even if we rollback on our database, some updates may have been sent to Stripe, etc in resposne to
                 # webhooks...
-                webhooks.call_handlers(
-                    self, self.message, self.event_type, self.event_subtype)
+                webhooks.call_handlers(self, self.message, self.event_type, self.event_subtype)
                 self._send_signal()
                 self.processed = True
             except StripeError as exc:

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -21,6 +21,7 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.functional import cached_property
 from doc_inherit import class_doc_inherit
 from model_utils.models import TimeStampedModel
 from stripe.error import StripeError, InvalidRequestError
@@ -125,7 +126,9 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
 
     # account = models.ForeignKey(Account, related_name="customers")
 
-    default_source = models.ForeignKey(StripeSource, null=True, related_name="customers")
+    default_source = models.ForeignKey(
+        StripeSource, null=True, related_name="customers",
+        on_delete=models.SET_NULL)
 
     subscriber = models.OneToOneField(getattr(settings, 'DJSTRIPE_SUBSCRIBER_MODEL', settings.AUTH_USER_MODEL), null=True)
     date_purged = models.DateTimeField(null=True, editable=False)
@@ -331,7 +334,6 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
 
     def has_valid_source(self):
         """ Check whether the customer has a valid payment source."""
-
         return self.default_source is not None
 
     def add_card(self, source, set_default=True):
@@ -421,14 +423,13 @@ class Event(StripeEvent):
             return False
 
         if not self.processed or force:
-            event_type, event_subtype = self.type.split(".", 1)
-
             try:
                 # TODO: would it make sense to wrap the next 4 lines in a transaction.atomic context? Yes it would,
                 # except that some webhook handlers can have side effects outside of our local database, meaning that
                 # even if we rollback on our database, some updates may have been sent to Stripe, etc in resposne to
                 # webhooks...
-                webhooks.call_handlers(self, self.message, event_type, event_subtype)
+                webhooks.call_handlers(
+                    self, self.message, self.event_type, self.event_subtype)
                 self._send_signal()
                 self.processed = True
             except StripeError as exc:
@@ -457,6 +458,21 @@ class Event(StripeEvent):
         signal = WEBHOOK_SIGNALS.get(self.type)
         if signal:
             return signal.send(sender=Event, event=self)
+
+    @cached_property
+    def parts(self):
+        """ Gets the event type/subtype as a list of parts. """
+        return str(self.type).split(".")
+
+    @cached_property
+    def event_type(self):
+        """ Gets the event type string. """
+        return self.parts[0]
+
+    @cached_property
+    def event_subtype(self):
+        """ Gets the event subtype string. """
+        return ".".join(self.parts[1:])
 
 
 @class_doc_inherit

--- a/djstripe/webhooks.py
+++ b/djstripe/webhooks.py
@@ -51,6 +51,7 @@ def handler(event_types):
     :param event_types: The event type(s) or sub-type(s) that should be handled.
     :type event_types: A sequence (`list`) or string (`str`/`unicode`).
     """
+
     if isinstance(event_types, six.string_types):
         event_types = [event_types]
 
@@ -67,10 +68,12 @@ def handler_all(func=None):
     Decorator which registers a function as a webhook handler for ALL webhook
     events, regardless of event type or sub-type.
     """
+
     if not func:
         return functools.partial(handler_all)
 
     registrations_global.append(func)
+
     return func
 
 
@@ -87,13 +90,13 @@ def call_handlers(event, event_data, event_type, event_subtype):
     Handlers within each group are invoked in order of registration.
 
     :param event: The event model object.
-    :type event: `djstripe.models.Event`
+    :type event: ``djstripe.models.Event``
     :param event_data: The raw data for the event.
-    :type event_data: `dict`
+    :type event_data: ``dict``
     :param event_type: The event type, e.g. 'customer'.
-    :type event_type: string (`str`/`unicode`)
+    :type event_type: string (``str``/``unicode``)
     :param event_subtype: The event sub-type, e.g. 'updated'.
-    :type event_subtype: string (`str`/`unicode`)
+    :type event_subtype: string (``str``/`unicode``)
     """
 
     chain = [registrations_global]
@@ -103,8 +106,8 @@ def call_handlers(event, event_data, event_type, event_subtype):
     #   1. "customer"
     #   2. "customer.subscription"
     #   3. "customer.subscription.created"
-    for k, _ in enumerate(event.parts):
-        qualified_event_type = ".".join(event.parts[:(k + 1)])
+    for index, _ in enumerate(event.parts):
+        qualified_event_type = ".".join(event.parts[:(index + 1)])
         chain.append(registrations[qualified_event_type])
 
     for handler_func in itertools.chain(*chain):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1043,6 +1043,13 @@ FAKE_EVENT_CUSTOMER_CREATED = {
     "type": "customer.created",
 }
 
+FAKE_EVENT_CUSTOMER_DELETED = (
+    deepcopy(FAKE_EVENT_CUSTOMER_CREATED))
+FAKE_EVENT_CUSTOMER_DELETED.update({
+    "id": "evt_38DHch3whaDvKYlo2jksfsFFxy",
+    "type": "customer.deleted"
+})
+
 FAKE_EVENT_CUSTOMER_SOURCE_CREATED = {
     "id": "evt_DvKYlo38huDvKYlo2C7SXedrZk",
     "object": "event",
@@ -1056,6 +1063,19 @@ FAKE_EVENT_CUSTOMER_SOURCE_CREATED = {
     "request": "req_o3whaDvh3whaDj",
     "type": "customer.source.created",
 }
+
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED = (
+    deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_CREATED))
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED.update({
+    "id": "evt_DvKYlo38huDvKYlo2C7SXedrYk",
+    "type": "customer.source.deleted"
+})
+
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE = (
+    deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_DELETED))
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE.update({
+    "id": "evt_DvKYlo38huDvKYlo2C7SXedzAk",
+})
 
 FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED = {
     "id": "evt_38DHch3wHD2eZvKYlCT2oe5ff3",
@@ -1071,6 +1091,12 @@ FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED = {
     "type": "customer.subscription.created",
 }
 
+FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED = (
+    deepcopy(FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED))
+FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED.update({
+    "id": "evt_38DHch3wHD2eZvKYlCT2oeryaf",
+    "type": "customer.subscription.deleted"})
+
 FAKE_EVENT_INVOICE_CREATED = {
     "id": "evt_187IHD2eZvKYlo2C6YKQi2eZ",
     "object": "event",
@@ -1084,6 +1110,12 @@ FAKE_EVENT_INVOICE_CREATED = {
     "request": "req_8O4sB7hkDobVT",
     "type": "invoice.created",
 }
+
+FAKE_EVENT_INVOICE_DELETED = (
+    deepcopy(FAKE_EVENT_INVOICE_CREATED))
+FAKE_EVENT_INVOICE_DELETED.update({
+    "id": "evt_187IHD2eZvKYlo2Cjkjsr34H",
+    "type": "invoice.deleted"})
 
 FAKE_EVENT_INVOICEITEM_CREATED = {
     "id": "evt_187IHD2eZvKYlo2C7SXedrZk",
@@ -1099,6 +1131,12 @@ FAKE_EVENT_INVOICEITEM_CREATED = {
     "type": "invoiceitem.created",
 }
 
+FAKE_EVENT_INVOICEITEM_DELETED = (
+    deepcopy(FAKE_EVENT_INVOICEITEM_CREATED))
+FAKE_EVENT_INVOICEITEM_DELETED.update({
+    "id": "evt_187IHD2eZvKYloJfdsnnfs34",
+    "type": "invoiceitem.deleted"})
+
 FAKE_EVENT_PLAN_CREATED = {
     "id": "evt_1877X72eZvKYlo2CLK6daFxu",
     "object": "event",
@@ -1113,6 +1151,12 @@ FAKE_EVENT_PLAN_CREATED = {
     "type": "plan.created",
 }
 
+FAKE_EVENT_PLAN_DELETED = (
+    deepcopy(FAKE_EVENT_PLAN_CREATED))
+FAKE_EVENT_PLAN_DELETED.update({
+    "id": "evt_1877X72eZvKYl2jkds32jJFc",
+    "type": "plan.deleted"})
+
 FAKE_EVENT_TRANSFER_CREATED = {
     "id": "evt_16igNU2eZvKYlo2CYyMkYvet",
     "object": "event",
@@ -1126,6 +1170,12 @@ FAKE_EVENT_TRANSFER_CREATED = {
     "request": "req_6wZW9MskhYU15Y",
     "type": "transfer.created",
 }
+
+FAKE_EVENT_TRANSFER_DELETED = (
+    deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+FAKE_EVENT_TRANSFER_DELETED.update({
+    "id": "evt_16igNU2eZvKjklfsdjk232Mf",
+    "type": "transfer.deleted"})
 
 FAKE_TOKEN = {
     "id": "tok_16YDIe2eZvKYlo2CPvqprIJd",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1043,8 +1043,7 @@ FAKE_EVENT_CUSTOMER_CREATED = {
     "type": "customer.created",
 }
 
-FAKE_EVENT_CUSTOMER_DELETED = (
-    deepcopy(FAKE_EVENT_CUSTOMER_CREATED))
+FAKE_EVENT_CUSTOMER_DELETED = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
 FAKE_EVENT_CUSTOMER_DELETED.update({
     "id": "evt_38DHch3whaDvKYlo2jksfsFFxy",
     "type": "customer.deleted"
@@ -1064,15 +1063,13 @@ FAKE_EVENT_CUSTOMER_SOURCE_CREATED = {
     "type": "customer.source.created",
 }
 
-FAKE_EVENT_CUSTOMER_SOURCE_DELETED = (
-    deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_CREATED))
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED = deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_CREATED)
 FAKE_EVENT_CUSTOMER_SOURCE_DELETED.update({
     "id": "evt_DvKYlo38huDvKYlo2C7SXedrYk",
     "type": "customer.source.deleted"
 })
 
-FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE = (
-    deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_DELETED))
+FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE = deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_DELETED)
 FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE.update({
     "id": "evt_DvKYlo38huDvKYlo2C7SXedzAk",
 })
@@ -1091,8 +1088,7 @@ FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED = {
     "type": "customer.subscription.created",
 }
 
-FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED = (
-    deepcopy(FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED))
+FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED = deepcopy(FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED)
 FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED.update({
     "id": "evt_38DHch3wHD2eZvKYlCT2oeryaf",
     "type": "customer.subscription.deleted"})
@@ -1111,8 +1107,7 @@ FAKE_EVENT_INVOICE_CREATED = {
     "type": "invoice.created",
 }
 
-FAKE_EVENT_INVOICE_DELETED = (
-    deepcopy(FAKE_EVENT_INVOICE_CREATED))
+FAKE_EVENT_INVOICE_DELETED = deepcopy(FAKE_EVENT_INVOICE_CREATED)
 FAKE_EVENT_INVOICE_DELETED.update({
     "id": "evt_187IHD2eZvKYlo2Cjkjsr34H",
     "type": "invoice.deleted"})
@@ -1131,8 +1126,7 @@ FAKE_EVENT_INVOICEITEM_CREATED = {
     "type": "invoiceitem.created",
 }
 
-FAKE_EVENT_INVOICEITEM_DELETED = (
-    deepcopy(FAKE_EVENT_INVOICEITEM_CREATED))
+FAKE_EVENT_INVOICEITEM_DELETED = deepcopy(FAKE_EVENT_INVOICEITEM_CREATED)
 FAKE_EVENT_INVOICEITEM_DELETED.update({
     "id": "evt_187IHD2eZvKYloJfdsnnfs34",
     "type": "invoiceitem.deleted"})
@@ -1151,8 +1145,7 @@ FAKE_EVENT_PLAN_CREATED = {
     "type": "plan.created",
 }
 
-FAKE_EVENT_PLAN_DELETED = (
-    deepcopy(FAKE_EVENT_PLAN_CREATED))
+FAKE_EVENT_PLAN_DELETED = deepcopy(FAKE_EVENT_PLAN_CREATED)
 FAKE_EVENT_PLAN_DELETED.update({
     "id": "evt_1877X72eZvKYl2jkds32jJFc",
     "type": "plan.deleted"})
@@ -1171,8 +1164,7 @@ FAKE_EVENT_TRANSFER_CREATED = {
     "type": "transfer.created",
 }
 
-FAKE_EVENT_TRANSFER_DELETED = (
-    deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+FAKE_EVENT_TRANSFER_DELETED = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
 FAKE_EVENT_TRANSFER_DELETED.update({
     "id": "evt_16igNU2eZvKjklfsdjk232Mf",
     "type": "transfer.deleted"})

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -3,6 +3,7 @@
    :synopsis: dj-stripe Event Handler Tests.
 
 .. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 """
 
@@ -13,15 +14,43 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from mock import patch
 
-from djstripe.models import Event, Charge, Transfer, Account, Plan, Customer, InvoiceItem, Invoice, Card, Subscription
-from tests import (FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_EVENT_CHARGE_SUCCEEDED, FAKE_EVENT_TRANSFER_CREATED,
-                   FAKE_EVENT_PLAN_CREATED, FAKE_CHARGE, FAKE_CHARGE_II, FAKE_INVOICE_II, FAKE_EVENT_INVOICEITEM_CREATED,
-                   FAKE_EVENT_INVOICE_CREATED, FAKE_EVENT_CUSTOMER_CREATED, FAKE_EVENT_CUSTOMER_SOURCE_CREATED,
-                   FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_III)
 from djstripe.exceptions import CustomerDoesNotExistLocallyException
+from djstripe.models import (
+    Event, Charge, Transfer, Account, Plan, Customer,
+    InvoiceItem, Invoice, Card, Subscription)
+from tests import (
+    FAKE_CARD, FAKE_CHARGE, FAKE_CHARGE_II, FAKE_CUSTOMER, FAKE_CUSTOMER_II,
+    FAKE_EVENT_CHARGE_SUCCEEDED, FAKE_EVENT_CUSTOMER_CREATED,
+    FAKE_EVENT_CUSTOMER_DELETED, FAKE_EVENT_CUSTOMER_SOURCE_CREATED,
+    FAKE_EVENT_CUSTOMER_SOURCE_DELETED,
+    FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE,
+    FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED,
+    FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED, FAKE_EVENT_INVOICE_CREATED,
+    FAKE_EVENT_INVOICE_DELETED, FAKE_EVENT_INVOICEITEM_CREATED,
+    FAKE_EVENT_INVOICEITEM_DELETED, FAKE_EVENT_PLAN_CREATED,
+    FAKE_EVENT_PLAN_DELETED, FAKE_EVENT_TRANSFER_CREATED,
+    FAKE_EVENT_TRANSFER_DELETED, FAKE_INVOICE, FAKE_INVOICE_II,
+    FAKE_INVOICEITEM, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_III,
+    FAKE_TRANSFER)
 
 
-class TestChargeEvents(TestCase):
+class EventTestCase(TestCase):
+    #
+    # Helpers
+    #
+
+    @patch('stripe.Event.retrieve')
+    def _create_event(self, event_data, event_retrieve_mock, patch_data=None):
+        event_data = deepcopy(event_data)
+        if patch_data:
+            event_data.update(patch_data)
+        event_retrieve_mock.return_value = event_data
+        event = Event.sync_from_stripe_data(event_data)
+        event.validate()
+        return event
+
+
+class TestChargeEvents(EventTestCase):
 
     def setUp(self):
         self.user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")
@@ -48,17 +77,17 @@ class TestChargeEvents(TestCase):
         self.assertEquals(charge.status, fake_stripe_event["data"]["object"]["status"])
 
 
-class TestCustomerEvents(TestCase):
+class TestCustomerEvents(EventTestCase):
 
     def setUp(self):
         self.user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")
 
     @patch("stripe.Customer.retrieve")
     @patch("stripe.Event.retrieve")
-    def test_customer_created(self, event_retrieve_mock, customer_retreive_mock):
+    def test_customer_created(self, event_retrieve_mock, customer_retrieve_mock):
         fake_stripe_event = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
-        customer_retreive_mock.return_value = fake_stripe_event["data"]["object"]
+        customer_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
 
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
 
@@ -73,10 +102,10 @@ class TestCustomerEvents(TestCase):
 
     @patch("stripe.Customer.retrieve")
     @patch("stripe.Event.retrieve")
-    def test_customer_created_no_customer_exists(self, event_retrieve_mock, customer_retreive_mock):
+    def test_customer_created_no_customer_exists(self, event_retrieve_mock, customer_retrieve_mock):
         fake_stripe_event = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
-        customer_retreive_mock.return_value = fake_stripe_event["data"]["object"]
+        customer_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
 
         event = Event.sync_from_stripe_data(fake_stripe_event)
 
@@ -85,24 +114,17 @@ class TestCustomerEvents(TestCase):
 
         self.assertFalse(Customer.objects.filter(stripe_id=fake_stripe_event["data"]["object"]["id"]).exists())
 
-    @patch("stripe.Customer.retrieve")
-    @patch("stripe.Event.retrieve")
-    def test_customer_deleted(self, event_retrieve_mock, customer_retreive_mock):
-        fake_stripe_event = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
-        fake_stripe_event["type"] = "customer.deleted"
-
-        event_retrieve_mock.return_value = fake_stripe_event
-        customer_retreive_mock.return_value = fake_stripe_event["data"]["object"]
-
+    @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER)
+    def test_customer_deleted(self, customer_retrieve_mock):
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
+        event = self._create_event(FAKE_EVENT_CUSTOMER_CREATED)
+        self.assertTrue(event.process())
 
-        event = Event.sync_from_stripe_data(fake_stripe_event)
+        event = self._create_event(FAKE_EVENT_CUSTOMER_DELETED)
+        self.assertTrue(event.process())
 
-        event.validate()
-        event.process()
-
-        customer = Customer.objects.get(stripe_id=fake_stripe_event["data"]["object"]["id"])
-        self.assertNotEqual(None, customer.date_purged)
+        customer = Customer.objects.get(stripe_id=FAKE_CUSTOMER["id"])
+        self.assertIsNotNone(customer.date_purged)
 
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
     @patch("stripe.Event.retrieve")
@@ -138,6 +160,38 @@ class TestCustomerEvents(TestCase):
 
         self.assertFalse(Card.objects.filter(stripe_id=fake_stripe_event["data"]["object"]["id"]).exists())
 
+    @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    def test_customer_default_source_deleted(self, customer_retrieve_mock):
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_CREATED)
+        Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
+        self.assertTrue(event.process())
+
+        card = Card.objects.get(stripe_id=FAKE_CARD["id"])
+        customer = Customer.objects.get(stripe_id=FAKE_CUSTOMER["id"])
+        customer.default_source = card
+        customer.save()
+        self.assertIsNotNone(customer.default_source)
+        self.assertTrue(customer.has_valid_source())
+
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_DELETED)
+        self.assertTrue(event.process())
+
+        customer = Customer.objects.get(stripe_id=FAKE_CUSTOMER["id"])
+        self.assertIsNone(customer.default_source)
+        self.assertFalse(customer.has_valid_source())
+
+    @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    def test_customer_source_double_delete(self, customer_retrieve_mock):
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_CREATED)
+        Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
+        self.assertTrue(event.process())
+
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_DELETED)
+        self.assertTrue(event.process())
+
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE)
+        self.assertTrue(event.process())
+
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
     @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -158,15 +212,32 @@ class TestCustomerEvents(TestCase):
         self.assertEqual(subscription.status, fake_stripe_event["data"]["object"]["status"])
         self.assertEqual(subscription.quantity, fake_stripe_event["data"]["object"]["quantity"])
 
+    @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+    @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    def test_customer_subscription_deleted(
+            self, customer_retrieve_mock, subscription_retrieve_mock, plan_retrieve_mock):
+        Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED)
+        self.assertTrue(event.process())
+
+        Subscription.objects.get(stripe_id=FAKE_SUBSCRIPTION["id"])
+
+        event = self._create_event(FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED)
+        self.assertTrue(event.process())
+
+        with self.assertRaises(Subscription.DoesNotExist):
+            Subscription.objects.get(stripe_id=FAKE_SUBSCRIPTION["id"])
+
     @patch("stripe.Customer.retrieve")
     @patch("stripe.Event.retrieve")
-    def test_customer_bogus_event_type(self, event_retrieve_mock, customer_retreive_mock):
+    def test_customer_bogus_event_type(self, event_retrieve_mock, customer_retrieve_mock):
         fake_stripe_event = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
         fake_stripe_event["data"]["object"]["customer"] = fake_stripe_event["data"]["object"]["id"]
         fake_stripe_event["type"] = "customer.praised"
 
         event_retrieve_mock.return_value = fake_stripe_event
-        customer_retreive_mock.return_value = fake_stripe_event["data"]["object"]
+        customer_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
 
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
 
@@ -179,7 +250,7 @@ class TestCustomerEvents(TestCase):
         self.assertEqual(None, customer.account_balance)
 
 
-class TestInvoiceEvents(TestCase):
+class TestInvoiceEvents(EventTestCase):
 
     @patch("djstripe.models.Charge.send_receipt", autospec=True)
     @patch("djstripe.models.Account.get_default_account")
@@ -237,8 +308,34 @@ class TestInvoiceEvents(TestCase):
         self.assertEquals(invoice.amount_due, fake_stripe_event["data"]["object"]["amount_due"] / decimal.Decimal("100"))
         self.assertEquals(invoice.paid, fake_stripe_event["data"]["object"]["paid"])
 
+    @patch("djstripe.models.Charge.send_receipt", autospec=True)
+    @patch("djstripe.models.Account.get_default_account")
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+    @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+    @patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+    def test_invoice_deleted(
+            self, invoice_retrieve_mock, charge_retrieve_mock,
+            customer_retrieve_mock, subscription_retrieve_mock,
+            default_account_mock, send_receipt_mock):
+        default_account_mock.return_value = Account.objects.create()
 
-class TestInvoiceItemEvents(TestCase):
+        user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")
+        Customer.objects.create(subscriber=user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
+
+        event = self._create_event(FAKE_EVENT_INVOICE_CREATED)
+        self.assertTrue(event.process())
+
+        Invoice.objects.get(stripe_id=FAKE_INVOICE["id"])
+
+        event = self._create_event(FAKE_EVENT_INVOICE_DELETED)
+        self.assertTrue(event.process())
+
+        with self.assertRaises(Invoice.DoesNotExist):
+            Invoice.objects.get(stripe_id=FAKE_INVOICE["id"])
+
+
+class TestInvoiceItemEvents(EventTestCase):
 
     @patch("djstripe.models.Account.get_default_account")
     @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
@@ -267,8 +364,34 @@ class TestInvoiceItemEvents(TestCase):
         invoiceitem = InvoiceItem.objects.get(stripe_id=fake_stripe_event["data"]["object"]["id"])
         self.assertEquals(invoiceitem.amount, fake_stripe_event["data"]["object"]["amount"] / decimal.Decimal("100"))
 
+    @patch("djstripe.models.Account.get_default_account")
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
+    @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
+    @patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II))
+    @patch("stripe.InvoiceItem.retrieve", return_value=deepcopy(FAKE_INVOICEITEM))
+    def test_invoiceitem_deleted(
+            self, invoiceitem_retrieve_mock, invoice_retrieve_mock,
+            charge_retrieve_mock, customer_retrieve_mock,
+            subscription_retrieve_mock, default_account_mock):
+        default_account_mock.return_value = Account.objects.create()
 
-class TestPlanEvents(TestCase):
+        user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")
+        Customer.objects.create(subscriber=user, stripe_id=FAKE_CUSTOMER_II["id"], currency="usd")
+
+        event = self._create_event(FAKE_EVENT_INVOICEITEM_CREATED)
+        self.assertTrue(event.process())
+
+        InvoiceItem.objects.get(stripe_id=FAKE_INVOICEITEM["id"])
+
+        event = self._create_event(FAKE_EVENT_INVOICEITEM_DELETED)
+        self.assertTrue(event.process())
+
+        with self.assertRaises(InvoiceItem.DoesNotExist):
+            InvoiceItem.objects.get(stripe_id=FAKE_INVOICEITEM["id"])
+
+
+class TestPlanEvents(EventTestCase):
 
     @patch('stripe.Plan.retrieve')
     @patch("stripe.Event.retrieve")
@@ -285,8 +408,21 @@ class TestPlanEvents(TestCase):
         plan = Plan.objects.get(stripe_id=fake_stripe_event["data"]["object"]["id"])
         self.assertEquals(plan.name, fake_stripe_event["data"]["object"]["name"])
 
+    @patch('stripe.Plan.retrieve', return_value=FAKE_PLAN)
+    def test_plan_deleted(self, plan_retrieve_mock):
+        event = self._create_event(FAKE_EVENT_PLAN_CREATED)
+        self.assertTrue(event.process())
 
-class TestTransferEvents(TestCase):
+        Plan.objects.get(stripe_id=FAKE_PLAN["id"])
+
+        event = self._create_event(FAKE_EVENT_PLAN_DELETED)
+        self.assertTrue(event.process())
+
+        with self.assertRaises(Plan.DoesNotExist):
+            Plan.objects.get(stripe_id=FAKE_PLAN["id"])
+
+
+class TestTransferEvents(EventTestCase):
 
     @patch('stripe.Transfer.retrieve')
     @patch("stripe.Event.retrieve")
@@ -303,3 +439,16 @@ class TestTransferEvents(TestCase):
         transfer = Transfer.objects.get(stripe_id=fake_stripe_event["data"]["object"]["id"])
         self.assertEquals(transfer.amount, fake_stripe_event["data"]["object"]["amount"] / decimal.Decimal("100"))
         self.assertEquals(transfer.status, fake_stripe_event["data"]["object"]["status"])
+
+    @patch('stripe.Transfer.retrieve', return_value=FAKE_TRANSFER)
+    def test_transfer_deleted(self, transfer_retrieve_mock):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        self.assertTrue(event.process())
+
+        Transfer.objects.get(stripe_id=FAKE_TRANSFER["id"])
+
+        event = self._create_event(FAKE_EVENT_TRANSFER_DELETED)
+        self.assertTrue(event.process())
+
+        with self.assertRaises(Transfer.DoesNotExist):
+            Transfer.objects.get(stripe_id=FAKE_TRANSFER["id"])

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -15,23 +15,16 @@ from django.test import TestCase
 from mock import patch
 
 from djstripe.exceptions import CustomerDoesNotExistLocallyException
-from djstripe.models import (
-    Event, Charge, Transfer, Account, Plan, Customer,
-    InvoiceItem, Invoice, Card, Subscription)
-from tests import (
-    FAKE_CARD, FAKE_CHARGE, FAKE_CHARGE_II, FAKE_CUSTOMER, FAKE_CUSTOMER_II,
-    FAKE_EVENT_CHARGE_SUCCEEDED, FAKE_EVENT_CUSTOMER_CREATED,
-    FAKE_EVENT_CUSTOMER_DELETED, FAKE_EVENT_CUSTOMER_SOURCE_CREATED,
-    FAKE_EVENT_CUSTOMER_SOURCE_DELETED,
-    FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE,
-    FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED,
-    FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED, FAKE_EVENT_INVOICE_CREATED,
-    FAKE_EVENT_INVOICE_DELETED, FAKE_EVENT_INVOICEITEM_CREATED,
-    FAKE_EVENT_INVOICEITEM_DELETED, FAKE_EVENT_PLAN_CREATED,
-    FAKE_EVENT_PLAN_DELETED, FAKE_EVENT_TRANSFER_CREATED,
-    FAKE_EVENT_TRANSFER_DELETED, FAKE_INVOICE, FAKE_INVOICE_II,
-    FAKE_INVOICEITEM, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_III,
-    FAKE_TRANSFER)
+from djstripe.models import Event, Charge, Transfer, Account, Plan, Customer, InvoiceItem, Invoice, Card, Subscription
+from tests import (FAKE_CARD, FAKE_CHARGE, FAKE_CHARGE_II, FAKE_CUSTOMER, FAKE_CUSTOMER_II,
+                   FAKE_EVENT_CHARGE_SUCCEEDED, FAKE_EVENT_CUSTOMER_CREATED,
+                   FAKE_EVENT_CUSTOMER_DELETED, FAKE_EVENT_CUSTOMER_SOURCE_CREATED,
+                   FAKE_EVENT_CUSTOMER_SOURCE_DELETED, FAKE_EVENT_CUSTOMER_SOURCE_DELETED_DUPE,
+                   FAKE_EVENT_CUSTOMER_SUBSCRIPTION_CREATED, FAKE_EVENT_CUSTOMER_SUBSCRIPTION_DELETED,
+                   FAKE_EVENT_INVOICE_CREATED, FAKE_EVENT_INVOICE_DELETED, FAKE_EVENT_INVOICEITEM_CREATED,
+                   FAKE_EVENT_INVOICEITEM_DELETED, FAKE_EVENT_PLAN_CREATED, FAKE_EVENT_PLAN_DELETED,
+                   FAKE_EVENT_TRANSFER_CREATED, FAKE_EVENT_TRANSFER_DELETED, FAKE_INVOICE, FAKE_INVOICE_II,
+                   FAKE_INVOICEITEM, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_III, FAKE_TRANSFER)
 
 
 class EventTestCase(TestCase):
@@ -42,11 +35,14 @@ class EventTestCase(TestCase):
     @patch('stripe.Event.retrieve')
     def _create_event(self, event_data, event_retrieve_mock, patch_data=None):
         event_data = deepcopy(event_data)
+
         if patch_data:
             event_data.update(patch_data)
+
         event_retrieve_mock.return_value = event_data
         event = Event.sync_from_stripe_data(event_data)
         event.validate()
+
         return event
 
 
@@ -314,10 +310,8 @@ class TestInvoiceEvents(EventTestCase):
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
     @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
     @patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-    def test_invoice_deleted(
-            self, invoice_retrieve_mock, charge_retrieve_mock,
-            customer_retrieve_mock, subscription_retrieve_mock,
-            default_account_mock, send_receipt_mock):
+    def test_invoice_deleted(self, invoice_retrieve_mock, charge_retrieve_mock, customer_retrieve_mock,
+                             subscription_retrieve_mock, default_account_mock, send_receipt_mock):
         default_account_mock.return_value = Account.objects.create()
 
         user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -14,7 +14,7 @@ import json
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
-from mock import patch, Mock, ANY
+from mock import call, patch, Mock, PropertyMock, ANY
 
 from djstripe import webhooks
 from djstripe.models import Event, EventProcessingException
@@ -80,39 +80,60 @@ class TestWebhookHandlers(TestCase):
     def test_global_handler_registration(self):
         func_mock = Mock()
         handler_all()(func_mock)
-        call_handlers(Mock(), {'data': 'foo'}, 'wib', 'ble')  # handled
+        self._call_handlers("wib.ble", {"data": "foo"})  # handled
         self.assertEqual(1, func_mock.call_count)
+        func_mock.assert_called_with(ANY, ANY, "wib", "ble")
 
     def test_event_handler_registration(self):
         global_func_mock = Mock()
         handler_all()(global_func_mock)
         func_mock = Mock()
-        handler(['foo'])(func_mock)
-        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
-        call_handlers(Mock(), {'data': 'foo'}, 'bar', 'foo')  # not handled
+        handler(["foo"])(func_mock)
+        self._call_handlers("foo.bar", {"data": "foo"})  # handled
+        self._call_handlers("bar.foo", {"data": "foo"})  # not handled
         self.assertEqual(2, global_func_mock.call_count)  # called each time
         self.assertEqual(1, func_mock.call_count)
-        func_mock.assert_called_with(ANY, ANY, 'foo', 'bar')
+        func_mock.assert_called_with(ANY, ANY, "foo", "bar")
 
     def test_event_subtype_handler_registration(self):
         global_func_mock = Mock()
         handler_all()(global_func_mock)
         func_mock = Mock()
-        handler(['foo.bar'])(func_mock)
-        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
-        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'baz')  # not handled
-        self.assertEqual(2, global_func_mock.call_count)  # called each time
-        self.assertEqual(1, func_mock.call_count)
-        func_mock.assert_called_with(ANY, ANY, 'foo', 'bar')
+        handler(["foo.bar"])(func_mock)
+        self._call_handlers("foo.bar", {"data": "foo"})  # handled
+        self._call_handlers("foo.bar.wib", {"data": "foo"})  # handled
+        self._call_handlers("foo.baz", {"data": "foo"})  # not handled
+        self.assertEqual(3, global_func_mock.call_count)  # called each time
+        self.assertEqual(2, func_mock.call_count)
+        func_mock.assert_has_calls([
+            call(ANY, ANY, "foo", "bar"),
+            call(ANY, ANY, "foo", "bar.wib")])
 
     def test_global_handler_registration_with_function(self):
         func_mock = Mock()
         handler_all(func_mock)
-        call_handlers(Mock(), {'data': 'foo'}, 'wib', 'ble')  # handled
+        self._call_handlers("wib.ble", {"data": "foo"})  # handled
         self.assertEqual(1, func_mock.call_count)
+        func_mock.assert_called_with(ANY, ANY, "wib", "ble")
 
     def test_event_handle_registation_with_string(self):
         func_mock = Mock()
-        handler('foo')(func_mock)
-        call_handlers(Mock(), {'data': 'foo'}, 'foo', 'bar')  # handled
+        handler("foo")(func_mock)
+        self._call_handlers("foo.bar", {"data": "foo"})  # handled
         self.assertEqual(1, func_mock.call_count)
+        func_mock.assert_called_with(ANY, ANY, "foo", "bar")
+
+    #
+    # Helpers
+    #
+
+    @staticmethod
+    def _call_handlers(event_spec, data):
+        event = Mock(spec=Event)
+        event_parts = event_spec.split(".")
+        event_type = event_parts[0]
+        event_subtype = ".".join(event_parts[1:])
+        type(event).parts = PropertyMock(return_value=event_parts)
+        type(event).event_type = PropertyMock(return_value=event_type)
+        type(event).event_subtype = PropertyMock(return_value=event_subtype)
+        return call_handlers(event, data, event_type, event_subtype)


### PR DESCRIPTION
## Description

During integration we noticed that our local state was occasionally getting de-synchronised from the Stripe account - This primarily happened on deletion events, where objects that have been deleted upstream didn't cause a deletion locally.

This PR refactors the event handling code to ensure that CRUD-like (without the 'R', so creation, updating and deletion) are handled correctly.  it also ensures that if a customer's default source is deleted, it unsets it for them and also ensures that the customer itself doesn't get deleted (a surprising side-effect without `on_delete`, hehe).

As a part of the refactor, I extended the functionality provided by PR #316 by allowing matching at every part of the event, so it is now possible to subscribe a handler to `customer.subscription` to receive all sub-events within that (e.g. `customer.subscription.created`) - This allows us to write slightly nicer handlers that don't need as many branching conditions.

Hopefully all of this is above-board - If there's any questions or changes required, fire away!
## Test Output

Ran: `python runtests.py --skip-utc`

```
Welcome to the dj-stripe test suite.

Step 1: Running unit tests.

nosetests . --verbosity=1
Creating test database for alias 'default'...
.............................................................................................................................................................................................................S...S.........................................
----------------------------------------------------------------------
Ran 251 tests in 5.234s

OK (SKIP=2)
Destroying test database for alias 'default'...

Step 2: Generating coverage results.

Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
djstripe/context_managers.py                         8      0      0      0   100%
djstripe/contrib/rest_framework/permissions.py       9      0      0      0   100%
djstripe/contrib/rest_framework/serializers.py      11      0      0      0   100%
djstripe/contrib/rest_framework/urls.py              5      0      0      0   100%
djstripe/contrib/rest_framework/views.py            36      0      2      0   100%
djstripe/decorators.py                              19      0      4      0   100%
djstripe/event_handlers.py                          80      0     26      0   100%
djstripe/exceptions.py                               7      0      0      0   100%
djstripe/fields.py                                  76      0     18      0   100%
djstripe/forms.py                                    7      0      0      0   100%
djstripe/managers.py                                37      0      0      0   100%
djstripe/middleware.py                              36      0     18      0   100%
djstripe/mixins.py                                  26      0      2      0   100%
djstripe/models.py                                 344      0    104      0   100%
djstripe/settings.py                                43      0     12      0   100%
djstripe/signals.py                                  3      0      0      0   100%
djstripe/stripe_objects.py                         441      0     53      0   100%
djstripe/sync.py                                    29      0      4      0   100%
djstripe/templatetags/djstripe_tags.py              20      0      4      0   100%
djstripe/urls.py                                     6      0      0      0   100%
djstripe/utils.py                                   35      0     14      0   100%
djstripe/views.py                                  133      0     22      0   100%
djstripe/webhooks.py                                28      0     10      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                             1439      0    293      0   100%

Step 3: Checking for pep8 errors.

pep8 errors:
----------------------------------------------------------------------
None

Tests completed successfully with no errors. Congrats!
```
