### PR TITLE
Add support for configurable webhook event callback

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -6,10 +6,42 @@ import sys
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
+from django.utils.module_loading import import_string
 
 PY3 = sys.version > "3"
 
-subscriber_request_callback = getattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK", (lambda request: request.user))
+
+def get_callback_function(setting_name, default=None):
+    """
+    Resolves a callback function based on a setting name.
+
+    If the setting value isn't set, default is returned.  If the setting value
+    is already a callable function, that value is used - If the setting value
+    is a string, an attempt is made to import it.  Anything else will result in
+    a failed import causing ImportError to be raised.
+    """
+    func = getattr(settings, setting_name, None)
+    if not func:
+        return default
+
+    if callable(func):
+        return func
+
+    if isinstance(func, six.string_types):
+        func = import_string(func)
+
+    if not callable(func):
+        raise ImproperlyConfigured(
+            "{name} must be callable.".format(name=setting_name))
+
+    return func
+
+
+subscriber_request_callback = (
+    get_callback_function(
+        "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK",
+        default=lambda request: request.user))
 
 INVOICE_FROM_EMAIL = getattr(settings, "DJSTRIPE_INVOICE_FROM_EMAIL", "billing@example.com")
 PAYMENTS_PLANS = getattr(settings, "DJSTRIPE_PLANS", {})
@@ -33,12 +65,17 @@ DEFAULT_PLAN = getattr(settings, "DJSTRIPE_DEFAULT_PLAN", None)
 
 # Try to find the new settings variable first. If that fails, revert to the
 # old variable.
-trial_period_for_subscriber_callback = getattr(settings,
-    "DJSTRIPE_TRIAL_PERIOD_FOR_SUBSCRIBER_CALLBACK",
-    getattr(settings, "DJSTRIPE_TRIAL_PERIOD_FOR_USER_CALLBACK", None)
-)
+trial_period_for_subscriber_callback = (
+    get_callback_function("DJSTRIPE_TRIAL_PERIOD_FOR_SUBSCRIBER_CALLBACK") or
+    get_callback_function("DJSTRIPE_TRIAL_PERIOD_FOR_USER_CALLBACK"))
 
 DJSTRIPE_WEBHOOK_URL = getattr(settings, "DJSTRIPE_WEBHOOK_URL", r"^webhook/$")
+
+# Webhook event callbacks allow an application to take control of what happens
+# when an event from Stripe is received.  One suggestion is to put the event
+# onto a task queue (such as celery) for asynchronous processing.
+WEBHOOK_EVENT_CALLBACK = (
+    get_callback_function("DJSTRIPE_WEBHOOK_EVENT_CALLBACK"))
 
 
 def _check_subscriber_for_email_address(subscriber_model, message):
@@ -82,10 +119,10 @@ def get_subscriber_model():
     _check_subscriber_for_email_address(subscriber_model, "DJSTRIPE_SUBSCRIBER_MODEL must have an email attribute.")
 
     # Custom user model detected. Make sure the callback is configured.
-    if hasattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK"):
-        if not callable(getattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK")):
-            raise ImproperlyConfigured("DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be callable.")
-    else:
-        raise ImproperlyConfigured("DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be implemented if a DJSTRIPE_SUBSCRIBER_MODEL is defined.")
+    func = get_callback_function("DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK")
+    if not func:
+        raise ImproperlyConfigured(
+            "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be implemented "
+            "if a DJSTRIPE_SUBSCRIBER_MODEL is defined.")
 
     return subscriber_model

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -20,7 +20,15 @@ def get_callback_function(setting_name, default=None):
     is already a callable function, that value is used - If the setting value
     is a string, an attempt is made to import it.  Anything else will result in
     a failed import causing ImportError to be raised.
+
+    :param setting_name: The name of the setting to resolve a callback from.
+    :type setting_name: string (``str``/``unicode``)
+    :param default: The default to return if setting isn't populated.
+    :type default: ``bool``
+    :returns: The resolved callback function (if any).
+    :type: ``callable``
     """
+
     func = getattr(settings, setting_name, None)
     if not func:
         return default
@@ -32,16 +40,13 @@ def get_callback_function(setting_name, default=None):
         func = import_string(func)
 
     if not callable(func):
-        raise ImproperlyConfigured(
-            "{name} must be callable.".format(name=setting_name))
+        raise ImproperlyConfigured("{name} must be callable.".format(name=setting_name))
 
     return func
 
 
-subscriber_request_callback = (
-    get_callback_function(
-        "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK",
-        default=lambda request: request.user))
+subscriber_request_callback = get_callback_function("DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK",
+                                                    default=(lambda request: request.user))
 
 INVOICE_FROM_EMAIL = getattr(settings, "DJSTRIPE_INVOICE_FROM_EMAIL", "billing@example.com")
 PAYMENTS_PLANS = getattr(settings, "DJSTRIPE_PLANS", {})
@@ -74,8 +79,7 @@ DJSTRIPE_WEBHOOK_URL = getattr(settings, "DJSTRIPE_WEBHOOK_URL", r"^webhook/$")
 # Webhook event callbacks allow an application to take control of what happens
 # when an event from Stripe is received.  One suggestion is to put the event
 # onto a task queue (such as celery) for asynchronous processing.
-WEBHOOK_EVENT_CALLBACK = (
-    get_callback_function("DJSTRIPE_WEBHOOK_EVENT_CALLBACK"))
+WEBHOOK_EVENT_CALLBACK = get_callback_function("DJSTRIPE_WEBHOOK_EVENT_CALLBACK")
 
 
 def _check_subscriber_for_email_address(subscriber_model, message):

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -17,7 +17,9 @@ from stripe.error import StripeError
 from .forms import PlanForm, CancelSubscriptionForm
 from .mixins import PaymentsContextMixin, SubscriptionMixin
 from .models import Customer, Event, EventProcessingException, Plan
-from .settings import PRORATION_POLICY_FOR_UPGRADES, subscriber_request_callback
+from .settings import (
+    PRORATION_POLICY_FOR_UPGRADES, WEBHOOK_EVENT_CALLBACK,
+    subscriber_request_callback)
 from .sync import sync_subscriber
 
 
@@ -244,5 +246,10 @@ class WebHook(CsrfExemptMixin, View):
         else:
             event = Event._create_from_stripe_object(data)
             event.validate()
-            event.process()
+
+            if WEBHOOK_EVENT_CALLBACK:
+                WEBHOOK_EVENT_CALLBACK(event)
+            else:
+                event.process()
+
         return HttpResponse()

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -14,12 +14,10 @@ from django.utils.encoding import smart_str
 from django.views.generic import DetailView, FormView, TemplateView, View
 from stripe.error import StripeError
 
+from . import settings as djstripe_settings
 from .forms import PlanForm, CancelSubscriptionForm
 from .mixins import PaymentsContextMixin, SubscriptionMixin
 from .models import Customer, Event, EventProcessingException, Plan
-from .settings import (
-    PRORATION_POLICY_FOR_UPGRADES, WEBHOOK_EVENT_CALLBACK,
-    subscriber_request_callback)
 from .sync import sync_subscriber
 
 
@@ -43,7 +41,7 @@ class ChangeCardView(LoginRequiredMixin, PaymentsContextMixin, DetailView):
         if hasattr(self, "customer"):
             return self.customer
         self.customer, _created = Customer.get_or_create(
-            subscriber=subscriber_request_callback(self.request))
+            subscriber=djstripe_settings.subscriber_request_callback(self.request))
         return self.customer
 
     def post(self, request, *args, **kwargs):
@@ -86,7 +84,7 @@ class HistoryView(LoginRequiredMixin, SelectRelatedMixin, DetailView):
 
     def get_object(self):
         customer, _created = Customer.get_or_create(
-            subscriber=subscriber_request_callback(self.request))
+            subscriber=djstripe_settings.subscriber_request_callback(self.request))
         return customer
 
 
@@ -99,7 +97,7 @@ class SyncHistoryView(CsrfExemptMixin, LoginRequiredMixin, View):
         return render(
             request,
             self.template_name,
-            {"customer": sync_subscriber(subscriber_request_callback(request))}
+            {"customer": sync_subscriber(djstripe_settings.subscriber_request_callback(request))}
         )
 
 
@@ -120,7 +118,7 @@ class ConfirmFormView(LoginRequiredMixin, FormValidMessageMixin, SubscriptionMix
         if not Plan.objects.filter(id=plan_id).exists():
             return HttpResponseNotFound()
 
-        customer, _created = Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+        customer, _created = Customer.get_or_create(subscriber=djstripe_settings.subscriber_request_callback(self.request))
 
         if customer.subscription and str(customer.subscription.plan.id) == plan_id and customer.subscription.is_valid():
             message = "You already subscribed to this plan"
@@ -143,7 +141,7 @@ class ConfirmFormView(LoginRequiredMixin, FormValidMessageMixin, SubscriptionMix
         form = self.get_form(form_class)
         if form.is_valid():
             try:
-                customer, _created = Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+                customer, _created = Customer.get_or_create(subscriber=djstripe_settings.subscriber_request_callback(self.request))
                 customer.add_card(self.request.POST.get("stripe_token"))
                 customer.subscribe(form.cleaned_data["plan"])
             except StripeError as exc:
@@ -173,7 +171,7 @@ class ChangePlanView(LoginRequiredMixin, FormValidMessageMixin, SubscriptionMixi
     def post(self, request, *args, **kwargs):
         form = PlanForm(request.POST)
 
-        customer, _created = Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+        customer, _created = Customer.get_or_create(subscriber=djstripe_settings.subscriber_request_callback(self.request))
 
         if not customer.subscription:
             form.add_error(None, "You must already be subscribed to a plan before you can change it.")
@@ -186,7 +184,7 @@ class ChangePlanView(LoginRequiredMixin, FormValidMessageMixin, SubscriptionMixi
                 # When a customer upgrades their plan, and DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES is set to True,
                 # we force the proration of the current plan and use it towards the upgraded plan,
                 # no matter what DJSTRIPE_PRORATION_POLICY is set to.
-                if PRORATION_POLICY_FOR_UPGRADES:
+                if djstripe_settings.PRORATION_POLICY_FOR_UPGRADES:
                     # Is it an upgrade?
                     if selected_plan.amount > customer.subscription.plan.amount:
                         customer.subscription.update(plan=selected_plan, prorate=True)
@@ -208,7 +206,7 @@ class CancelSubscriptionView(LoginRequiredMixin, SubscriptionMixin, FormView):
     success_url = reverse_lazy("djstripe:account")
 
     def form_valid(self, form):
-        customer, _created = Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+        customer, _created = Customer.get_or_create(subscriber=djstripe_settings.subscriber_request_callback(self.request))
         subscription = customer.subscription.cancel()
 
         if subscription.status == subscription.STATUS_CANCELED:
@@ -247,8 +245,8 @@ class WebHook(CsrfExemptMixin, View):
             event = Event._create_from_stripe_object(data)
             event.validate()
 
-            if WEBHOOK_EVENT_CALLBACK:
-                WEBHOOK_EVENT_CALLBACK(event)
+            if djstripe_settings.WEBHOOK_EVENT_CALLBACK:
+                djstripe_settings.WEBHOOK_EVENT_CALLBACK(event)
             else:
                 event.process()
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -319,7 +319,7 @@ Examples:
 
 .. code-block:: python
 
-    from djstripe.models import StripeError
+    from stripe.error import StripeError
 
     @shared_task(bind=True)
     def process_webhook_event(self, event):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -38,10 +38,19 @@ class EventTest(TestCase):
         ), str(event))
 
     @patch('djstripe.models.EventProcessingException.log')
-    def test_stripe_error(self, event_exception_log_mock):
+    def test_process_event_with_log_stripe_error(self, event_exception_log_mock):
         event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
         self.call_handlers.side_effect = StripeError("Boom!")
         self.assertFalse(event.process())
+        self.assertTrue(event_exception_log_mock.called)
+        self.assertFalse(event.processed)
+
+    @patch('djstripe.models.EventProcessingException.log')
+    def test_process_event_with_raise_stripe_error(self, event_exception_log_mock):
+        event = self._create_event(FAKE_EVENT_TRANSFER_CREATED)
+        self.call_handlers.side_effect = StripeError("Boom!")
+        with self.assertRaises(StripeError):
+            event.process(raise_exception=True)
         self.assertTrue(event_exception_log_mock.called)
         self.assertFalse(event.processed)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -53,13 +53,13 @@ class TestSubscriberModelRetrievalMethod(TestCase):
     def test_bad_callback(self):
         self.assertRaisesMessage(ImproperlyConfigured, "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be callable.", get_subscriber_model)
 
-    @override_settings(DJSTRIPE_TEST_CALLBACK=lambda: "ok")
+    @override_settings(DJSTRIPE_TEST_CALLBACK=(lambda: "ok"))
     def test_get_callback_function_with_valid_func_callable(self):
         func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
         self.assertEquals("ok", func())
 
     @override_settings(DJSTRIPE_TEST_CALLBACK='foo.valid_callback')
-    @patch.object(settings, 'import_string', return_value=lambda: "ok")
+    @patch.object(settings, 'import_string', return_value=(lambda: "ok"))
     def test_get_callback_function_with_valid_string_callable(self, import_string_mock):
         func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
         self.assertEquals("ok", func())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,6 +3,7 @@
    :synopsis: dj-stripe Settings Tests.
 
 .. moduleauthor:: Alex Kavanaugh (@kavdev)
+.. moduleauthor:: Lee Skillen (@lskillen)
 
 """
 
@@ -10,8 +11,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
 from django.test import TestCase
 from django.test.utils import override_settings
+from mock import patch
 
-from djstripe.settings import get_subscriber_model
+from djstripe import settings
+from djstripe.settings import get_subscriber_model, get_callback_function
 
 
 class TestSubscriberModelRetrievalMethod(TestCase):
@@ -49,3 +52,32 @@ class TestSubscriberModelRetrievalMethod(TestCase):
     @override_settings(DJSTRIPE_SUBSCRIBER_MODEL='testapp.Organization', DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK=5)
     def test_bad_callback(self):
         self.assertRaisesMessage(ImproperlyConfigured, "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be callable.", get_subscriber_model)
+
+    @override_settings(DJSTRIPE_TEST_CALLBACK=lambda: "ok")
+    def test_get_callback_function_with_valid_func_callable(self):
+        func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
+        self.assertEquals("ok", func())
+
+    @override_settings(DJSTRIPE_TEST_CALLBACK='foo.valid_callback')
+    @patch.object(settings, 'import_string', return_value=lambda: "ok")
+    def test_get_callback_function_with_valid_string_callable(self, import_string_mock):
+        func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
+        self.assertEquals("ok", func())
+        import_string_mock.assert_called_with('foo.valid_callback')
+
+    @override_settings(DJSTRIPE_TEST_CALLBACK='foo.non_existant_callback')
+    def test_get_callback_function_import_error(self):
+        with self.assertRaises(ImportError):
+            get_callback_function("DJSTRIPE_TEST_CALLBACK")
+
+    @override_settings(DJSTRIPE_TEST_CALLBACK='foo.invalid_callback')
+    @patch.object(settings, 'import_string', return_value="not_callable")
+    def test_get_callback_function_with_non_callable_string(self, import_string_mock):
+        with self.assertRaises(ImproperlyConfigured):
+            get_callback_function("DJSTRIPE_TEST_CALLBACK")
+        import_string_mock.assert_called_with('foo.invalid_callback')
+
+    @override_settings(DJSTRIPE_TEST_CALLBACK='foo.non_existant_callback')
+    def test_get_callback_function_(self):
+        with self.assertRaises(ImportError):
+            get_callback_function("DJSTRIPE_TEST_CALLBACK")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -278,7 +278,7 @@ class ChangePlanViewTest(TestCase):
 
         subscription_update_mock.assert_called_once_with(subscription, plan=plan)
 
-    @patch("djstripe.views.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
+    @patch("djstripe.views.djstripe_settings.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
     @patch("djstripe.models.Subscription.update", autospec=True)
     def test_change_sub_with_proration_downgrade(self, subscription_update_mock, proration_policy_mock):
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
@@ -293,7 +293,7 @@ class ChangePlanViewTest(TestCase):
 
         subscription_update_mock.assert_called_once_with(subscription, plan=plan)
 
-    @patch("djstripe.views.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
+    @patch("djstripe.views.djstripe_settings.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
     @patch("djstripe.models.Subscription.update", autospec=True)
     def test_change_sub_with_proration_upgrade(self, subscription_update_mock, proration_policy_mock):
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")
@@ -308,7 +308,7 @@ class ChangePlanViewTest(TestCase):
 
         subscription_update_mock.assert_called_once_with(subscription, plan=plan, prorate=True)
 
-    @patch("djstripe.views.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
+    @patch("djstripe.views.djstripe_settings.PRORATION_POLICY_FOR_UPGRADES", return_value=True)
     @patch("djstripe.models.Subscription.update", autospec=True)
     def test_change_sub_with_proration_same_plan(self, subscription_update_mock, proration_policy_mock):
         Customer.objects.create(subscriber=self.user, stripe_id=FAKE_CUSTOMER["id"], currency="usd")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -38,8 +38,7 @@ class TestWebhook(TestCase):
         self.assertEquals(resp.status_code, 200)
         self.assertTrue(Event.objects.filter(type="transfer.created").exists())
 
-    @patch.object(views, 'WEBHOOK_EVENT_CALLBACK',
-                  return_value=lambda event: event.process())
+    @patch.object(views.djstripe_settings, 'WEBHOOK_EVENT_CALLBACK', return_value=(lambda event: event.process()))
     @patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
     @patch("stripe.Event.retrieve")
     def test_webhook_with_custom_callback(self,
@@ -86,13 +85,11 @@ class TestWebhook(TestCase):
 class TestWebhookHandlers(TestCase):
     def setUp(self):
         # Reset state of registrations per test
-        patcher = patch.object(
-            webhooks, 'registrations', new_callable=lambda: defaultdict(list))
+        patcher = patch.object(webhooks, 'registrations', new_callable=(lambda: defaultdict(list)))
         self.addCleanup(patcher.stop)
         self.registrations = patcher.start()
 
-        patcher = patch.object(
-            webhooks, 'registrations_global', new_callable=list)
+        patcher = patch.object(webhooks, 'registrations_global', new_callable=list)
         self.addCleanup(patcher.stop)
         self.registrations_global = patcher.start()
 


### PR DESCRIPTION
## Description

OK, final PR for the night - This adds support for a configurable webhook event callback, which allows for delegation of event processing.  The primary example for this is to add asynchronous event processing to the framework, which is the scenario described in the examples documentation (and this is what we've done in practice).  Here's a snippet from our celery logs:

```
[23:18:43]    DEBUG - tasks - -: Processing Stripe event: <type=customer.source.created, stripe_id=evt_18Qla7K4CgM56pzkGOJ9S6BN>
[23:18:44]    ERROR - tasks - -: Failed to process Stripe event: <type=customer.source.created, stripe_id=evt_18Qla7K4CgM56pzkGOJ9S6BN>
[23:57:21]    DEBUG - tasks - -: Processing Stripe event: <type=invoice.created, stripe_id=evt_18QmBlK4CgM56pzkQnKI7vdE>
[23:57:27]    DEBUG - tasks - -: Processing Stripe event: <type=customer.subscription.created, stripe_id=evt_18QmBlK4CgM56pzkpt9ypa8G>
[23:57:30]    DEBUG - tasks - -: Processing Stripe event: <type=invoice.payment_succeeded, stripe_id=evt_18QmBlK4CgM56pzkN89F9UyT>
[23:57:43]    DEBUG - tasks - -: Processing Stripe event: <type=customer.updated, stripe_id=evt_18QmBlK4CgM56pzktEetXXcU>
[00:53:05]    DEBUG - tasks - -: Processing Stripe event: <type=customer.subscription.updated, stripe_id=evt_18Qn3fK4CgM56pzktSfx4DHu>
[00:53:07]    DEBUG - tasks - -: Processing Stripe event: <type=invoice.payment_succeeded, stripe_id=evt_18Qn3fK4CgM56pzkpDffufYH>
[00:53:10]    DEBUG - tasks - -: Processing Stripe event: <type=charge.succeeded, stripe_id=evt_18Qn3fK4CgM56pzk3TgGebje>
[00:53:10]    DEBUG - tasks - -: Processing Stripe event: <type=invoice.created, stripe_id=evt_18Qn3fK4CgM56pzkG9ML49CI>
```

As this is adding another callback, and I imagined that there may be more in the future, I assisted with some minor refactoring of existing callbacks to use the new `get_callback_function` helper function within the settings module.  This allows for callables or importable strings to callables to be used when specifying the setting (and existing documentation has been updated to say so).

Event processing was slightly altered to allow exception re-raising on failures (after normal logging has been completed) - The reason for this is that it becomes easier to deal with events that fail asynchronously, because the exact error can be logged immediately or can be used to invoke retries, etc.

Finally ... It's probably worth noting that I encountered cyclic import issues with the djstripe settings file while implementing the asynchronous events support in our code - This was (mostly) caused by the settings being at the module-level, such that the callbacks were imported immediately.  It might be a good idea to consider a lazier solution such as hiding the setting evaluation behind a class/method/function/property/etc - But not a huge issue and not pertinent to this PR! :-)
## Test Output

Ran: `python runtests.py --skip-utc`

```
Welcome to the dj-stripe test suite.

Step 1: Running unit tests.

nosetests . --verbosity=1
Creating test database for alias 'default'...
............................................................................................................................................................................................................S...S..........................................
----------------------------------------------------------------------
Ran 251 tests in 5.094s

OK (SKIP=2)
Destroying test database for alias 'default'...

Step 2: Generating coverage results.

Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
djstripe/context_managers.py                         8      0      0      0   100%
djstripe/contrib/rest_framework/permissions.py       9      0      0      0   100%
djstripe/contrib/rest_framework/serializers.py      11      0      0      0   100%
djstripe/contrib/rest_framework/urls.py              5      0      0      0   100%
djstripe/contrib/rest_framework/views.py            36      0      2      0   100%
djstripe/decorators.py                              19      0      4      0   100%
djstripe/event_handlers.py                          44      0     16      0   100%
djstripe/exceptions.py                               7      0      0      0   100%
djstripe/fields.py                                  76      0     18      0   100%
djstripe/forms.py                                    7      0      0      0   100%
djstripe/managers.py                                37      0      0      0   100%
djstripe/middleware.py                              36      0     18      0   100%
djstripe/mixins.py                                  26      0      2      0   100%
djstripe/models.py                                 342      0    106      0   100%
djstripe/settings.py                                56      0     18      0   100%
djstripe/signals.py                                  3      0      0      0   100%
djstripe/stripe_objects.py                         441      0     53      0   100%
djstripe/sync.py                                    29      0      4      0   100%
djstripe/templatetags/djstripe_tags.py              20      0      4      0   100%
djstripe/urls.py                                     6      0      0      0   100%
djstripe/utils.py                                   35      0     14      0   100%
djstripe/views.py                                  135      0     24      0   100%
djstripe/webhooks.py                                25      0      8      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                             1413      0    291      0   100%

Step 3: Checking for pep8 errors.

pep8 errors:
----------------------------------------------------------------------
None

Tests completed successfully with no errors. Congrats!
```
