### PR TITLE
Options are :key:

### DIFF
--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -24,3 +24,4 @@ class CreateSubscriptionSerializer(serializers.Serializer):
 
     stripe_token = serializers.CharField(max_length=200)
     plan = serializers.CharField(max_length=200)
+    charge_immediately = serializers.NullBooleanField()

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -58,7 +58,10 @@ class SubscriptionRestView(APIView):
                     subscriber=subscriber_request_callback(self.request)
                 )
                 customer.update_card(serializer.data["stripe_token"])
-                customer.subscribe(serializer.data["plan"])
+                customer.subscribe(
+                    serializer.data["plan"],
+                    serializer.data.get("charge_immediately", True)
+                )
                 return Response(
                     serializer.data,
                     status=status.HTTP_201_CREATED


### PR DESCRIPTION
- add support for get_or_create a Plan in djstripe when syncing Plans with Stripe api
  - used when possibly wanting to create plans locally instead of on Stripe
- add the option to charge_immediately when subscribing users to a plan
