### PR TITLE
pass application_fee to charge

### DIFF
--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -777,7 +777,7 @@ Fields not implemented:
         stripe_charge = StripeCharge._api_create(
             amount=int(amount * 100),  # Convert dollars into cents
             currency=currency,
-            application_fee=int(amount * 100),  # Convert dollars into cents
+            application_fee=int(application_fee * 100) if application_fee else None,  # Convert dollars into cents
             capture=capture,
             description=description,
             destination=destination,


### PR DESCRIPTION
While attempting to just simply do a `customer.charge(amount)`, I'd get an error back from Stripe:

> Can only apply an application_fee when the request is made on behalf of another account (using an OAuth key, the Stripe-Account header, or the destination parameter)

Noticed application_fee was being passed in to the charge by default, but the StripeCharge wasn't using the passed in value. It was the same exact value as amount. I changed it to `int(application_fee * 100)` if application_fee is passed in, but not 100% sure if this is what it wants. This fixed my issue and I can now charge successfully.