### PR TITLE
Readme: add needed django.contribe.sites to INSTALLED_APPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,12 @@ Add ``djstripe`` to your ``INSTALLED_APPS``:
 
 .. code-block:: python
 
-    INSTALLED_APPS +=(
+    INSTALLED_APPS =(
+        ...
+        "django.contrib.sites"
+        ...
         "djstripe",
+        ...
     )
 
 Add your stripe keys:


### PR DESCRIPTION
dj-stripe depends on it and won't work (at least on django 1.10) without it.