### PR TITLE
Fix _sync_from_stripe_data() when given a deleted object

### DIFF
--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -385,6 +385,14 @@ class StripeObject(models.Model):
         :type data: dict
         """
 
+        if data.get("deleted", False):
+            # The object looks like `{"id": "xxx_...", "deleted": True}`
+            # That means a record of it exists, but its contents have been deleted.
+            stripe_id = data["id"]
+            # We delete the object from the database (if it exists) and return None.
+            cls.stripe_objects.filter(stripe_id=stripe_id).delete()
+            return
+
         instance, created = cls._get_or_create_from_stripe_object(data)
 
         if not created:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -54,6 +54,13 @@ class TestSyncSubscriber(TestCase):
 
         self.assertEqual("ERROR: No such customer:", sys.stdout.getvalue().strip())
 
+    def test_sync_deleted_customer(self):
+        stripe_id = FAKE_CUSTOMER["id"]
+        customer = Customer.objects.create(subscriber=self.user, stripe_id=stripe_id)
+        assert Customer.objects.filter(stripe_id=customer.stripe_id).count() == 1
+        Customer.sync_from_stripe_data({"id": stripe_id, "deleted": True})
+        assert Customer.objects.filter(stripe_id=customer.stripe_id).count() == 0
+
 
 class TestSyncPlans(TestCase):
 


### PR DESCRIPTION
Calls to sync are usually made after `api_retrieve()`, which can
return an object that contains a "deleted" directive.
This directive means the object has been deleted from the Stripe
database. We can completely get rid of it ourselves as well.