### PR TITLE
Use a get_or_create with defaults on Customer.create

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -190,7 +190,10 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
             trial_days = djstripe_settings.trial_period_for_subscriber_callback(subscriber)
 
         stripe_customer = cls._api_create(email=subscriber.email)
-        customer = Customer.objects.create(subscriber=subscriber, stripe_id=stripe_customer["id"], currency="usd")
+        customer, created = Customer.objects.get_or_create(
+            stripe_id=stripe_customer["id"],
+            defaults={"subscriber": subscriber, "currency": "usd"}
+        )
 
         if djstripe_settings.DEFAULT_PLAN and trial_days:
             customer.subscribe(


### PR DESCRIPTION
This prevents a potential race condition.