### PR TITLE
Remove StripeCustomer.purge()

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -230,7 +230,6 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
         for source in self.sources.all():
             source.remove()
 
-        super(Customer, self).purge()
         self.date_purged = timezone.now()
         self.save()
 

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -656,16 +656,6 @@ Fields not implemented:
 
         return target_cls._get_or_create_from_stripe_object(data["default_source"])[0]
 
-    def purge(self):
-        """Delete all identifying information we have in this record."""
-
-        # Delete deprecated card details
-        self.card_fingerprint = ""
-        self.card_last_4 = ""
-        self.card_kind = ""
-        self.card_exp_month = None
-        self.card_exp_year = None
-
     def subscribe(self, plan, application_fee_percent=None, coupon=None, quantity=None, metadata=None,
                   tax_percent=None, trial_end=None):
         """


### PR DESCRIPTION
All it did was nullify attributes which were removed in 4b6a9e0b.

NOTE: This does not remove Customer.purge(), the higher level function.