### PR TITLE
Never raise a CustomerDoesNotExistLocallyException

### DIFF
--- a/djstripe/exceptions.py
+++ b/djstripe/exceptions.py
@@ -20,9 +20,3 @@ class StripeObjectManipulationException(Exception):
     """Raised when an attempt to manipulate a non-standalone stripe object is made not through its parent object."""
 
     pass
-
-
-class CustomerDoesNotExistLocallyException(Exception):
-    """Raised when a user tries to perform an action on a Customer that does not exist locally."""
-
-    pass

--- a/djstripe/managers.py
+++ b/djstripe/managers.py
@@ -27,14 +27,6 @@ class StripeObjectManager(models.Manager):
         """
         return self.filter(stripe_id=data["id"]).exists()
 
-    def get_by_json(self, data, field_name="id"):
-        """Retreive a matching stripe object based on a Stripe object received from Stripe in JSON format.
-
-        :param data: Stripe event object parsed from a JSON string into an object
-        :type data: dict
-        """
-        return self.get(stripe_id=data[field_name])
-
 
 class SubscriptionManager(models.Manager):
     """Manager used in models.Subscription."""

--- a/djstripe/migrations/0012_model_sync.py
+++ b/djstripe/migrations/0012_model_sync.py
@@ -11,8 +11,6 @@ from django.utils import six
 from stripe.error import InvalidRequestError
 from tqdm import tqdm
 
-from djstripe.exceptions import CustomerDoesNotExistLocallyException
-
 
 def resync_subscriptions(apps, schema_editor):
     """
@@ -37,9 +35,9 @@ def resync_subscriptions(apps, schema_editor):
         print("Re-syncing subscriptions. This may take a while.")
 
         for stripe_subscription in tqdm(iterable=Subscription.api_list(), desc="Sync", unit=" subscriptions"):
-            try:
-                Subscription.sync_from_stripe_data(stripe_subscription)
-            except CustomerDoesNotExistLocallyException:
+            subscription = Subscription.sync_from_stripe_data(stripe_subscription)
+
+            if not subscription.customer:
                 tqdm.write("The customer for this subscription ({subscription_id}) does not exist locally (so we \
                 won't sync the subscription). You'll want to figure out how that \
                 happened.".format(subscription_id=stripe_subscription['id']))
@@ -71,9 +69,9 @@ def resync_invoiceitems(apps, schema_editor):
         print("Re-syncing invoiceitems. This may take a while.")
 
         for stripe_invoiceitem in tqdm(iterable=InvoiceItem.api_list(), desc="Sync", unit=" invoiceitems"):
-            try:
-                InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
-            except CustomerDoesNotExistLocallyException:
+            invoice = InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
+
+            if not invoice.customer:
                 tqdm.write("The customer for this invoiceitem ({invoiceitem_id}) does not exist \
                 locally (so we won't sync the invoiceitem). You'll want to figure out how that \
                 happened.".format(invoiceitem_id=stripe_invoiceitem['id']))

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -383,10 +383,13 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
         kwargs['customer'] = self
         return Invoice.upcoming(**kwargs)
 
-    def _attach_objects_hook(self, cls, data):
+    def _attach_objects_post_save_hook(self, cls, data):
         # TODO: other sources
         if data["default_source"] and data["default_source"]["object"] == "card":
-            self.default_source = cls._stripe_object_default_source_to_source(target_cls=Card, data=data)
+            source = cls._stripe_object_default_source_to_source(target_cls=Card, data=data)
+            if source != self.default_source:
+                self.default_source = source
+                self.save()
 
     # SYNC methods should be dropped in favor of the master sync infrastructure proposed
     def _sync_invoices(self, **kwargs):

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -384,10 +384,17 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
         return Invoice.upcoming(**kwargs)
 
     def _attach_objects_post_save_hook(self, cls, data):
-        # TODO: other sources
-        if data["default_source"] and data["default_source"]["object"] == "card":
-            source = cls._stripe_object_default_source_to_source(target_cls=Card, data=data)
-            if source != self.default_source:
+        default_source = data.get("default_source")
+
+        if default_source:
+            # TODO: other sources
+            if not isinstance(default_source, dict) or default_source.get("object") == "card":
+                source, created = Card._get_or_create_from_stripe_object(data, "default_source", refetch=False)
+            else:
+                logger.warn("Unsupported source type on %r: %r", self, default_source)
+                source = None
+
+            if source and source != self.default_source:
                 self.default_source = source
                 self.save()
 

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -29,8 +29,6 @@ from polymorphic.models import PolymorphicModel
 import stripe
 from stripe.error import InvalidRequestError
 
-from djstripe.exceptions import CustomerDoesNotExistLocallyException
-
 from . import settings as djstripe_settings
 from .context_managers import stripe_temporary_api_version
 from .exceptions import StripeObjectManipulationException
@@ -289,12 +287,7 @@ class StripeObject(models.Model):
         """
 
         if "customer" in data and data["customer"]:
-            # We never want to create a customer that doesn't already exist in our database.
-            try:
-                return target_cls.stripe_objects.get_by_json(data, "customer")
-            except target_cls.DoesNotExist:
-                raise CustomerDoesNotExistLocallyException("Because customers are tied to local users, djstripe will "
-                                                           "not create customers that do not already exist locally.")
+            return target_cls._get_or_create_from_stripe_object(data, "customer")[0]
 
     @classmethod
     def _stripe_object_to_transfer(cls, target_cls, data):

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -657,20 +657,6 @@ Fields not implemented:
     )
     shipping = StripeJSONField(null=True, help_text="Shipping information associated with the customer.")
 
-    @classmethod
-    def _stripe_object_default_source_to_source(cls, target_cls, data):
-        """
-        Search the given manager for the source matching this StripeCharge object's ``default_source`` field.
-        Note that the source field is already expanded in each request, and that it is required.
-
-        :param target_cls: The target class
-        :type target_cls: StripeSource
-        :param data: stripe object
-        :type data: dict
-        """
-
-        return target_cls._get_or_create_from_stripe_object(data["default_source"])[0]
-
     def subscribe(self, plan, application_fee_percent=None, coupon=None, quantity=None, metadata=None,
                   tax_percent=None, trial_end=None):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -642,6 +642,10 @@ FAKE_CUSTOMER_II = CustomerDict({
 })
 
 
+FAKE_CUSTOMER_DEFAULT_SOURCE_STRING = deepcopy(FAKE_CUSTOMER)
+FAKE_CUSTOMER_DEFAULT_SOURCE_STRING["default_source"] = FAKE_CARD["id"]
+
+
 class InvoiceDict(dict):
     def pay(self):
         return self

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -21,9 +21,12 @@ from stripe.error import InvalidRequestError
 
 from djstripe.exceptions import MultipleSubscriptionException
 from djstripe.models import Account, Customer, Charge, Card, Subscription, Invoice, Plan
-from tests import (FAKE_CARD, FAKE_CHARGE, FAKE_CUSTOMER, FAKE_ACCOUNT, FAKE_INVOICE,
-                   FAKE_INVOICE_III, FAKE_INVOICEITEM, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_II,
-                   StripeList, FAKE_CARD_V, FAKE_CUSTOMER_II, FAKE_UPCOMING_INVOICE, datetime_to_unix)
+from tests import (
+    FAKE_ACCOUNT, FAKE_CARD, FAKE_CARD_V, FAKE_CHARGE, FAKE_CUSTOMER,
+    FAKE_CUSTOMER_DEFAULT_SOURCE_STRING, FAKE_CUSTOMER_II, FAKE_INVOICE,
+    FAKE_INVOICEITEM, FAKE_INVOICE_III, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_II,
+    FAKE_UPCOMING_INVOICE, StripeList, datetime_to_unix
+)
 
 
 class TestCustomer(TestCase):
@@ -78,6 +81,13 @@ class TestCustomer(TestCase):
 
         self.assertEqual(FAKE_CUSTOMER_II["default_source"]["id"], customer.default_source.stripe_id)
         self.assertEqual(1, customer.sources.count())
+
+    @patch("stripe.Card.retrieve", return_value=FAKE_CARD)
+    def test_customer_sync_default_source_string(self, customer_mock):
+        fake_customer = deepcopy(FAKE_CUSTOMER_DEFAULT_SOURCE_STRING)
+        customer = Customer.sync_from_stripe_data(fake_customer)
+        self.assertEqual(customer.default_source.stripe_id, FAKE_CARD["id"])
+        self.assertEqual(customer.sources.count(), 1)
 
     @patch("stripe.Customer.retrieve")
     def test_customer_purge_leaves_customer_record(self, customer_retrieve_fake):

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -83,6 +83,16 @@ class TestCustomer(TestCase):
         self.assertEqual(1, customer.sources.count())
 
     @patch("stripe.Card.retrieve", return_value=FAKE_CARD)
+    def test_customer_sync_no_sources(self, customer_mock):
+        self.customer.sources.all().delete()
+
+        fake_customer = deepcopy(FAKE_CUSTOMER)
+        fake_customer["default_source"] = None
+        customer = Customer.sync_from_stripe_data(fake_customer)
+        self.assertEqual(customer.sources.count(), 0)
+        self.assertEqual(customer.default_source, None)
+
+    @patch("stripe.Card.retrieve", return_value=FAKE_CARD)
     def test_customer_sync_default_source_string(self, customer_mock):
         fake_customer = deepcopy(FAKE_CUSTOMER_DEFAULT_SOURCE_STRING)
         customer = Customer.sync_from_stripe_data(fake_customer)


### PR DESCRIPTION
We want to be in sync with upstream, even if the customers are missing.

----

Now that the customer object can be null, `CustomerDoesNotExistLocallyException` no longer makes sense. This PR removes it.

The tests get into an infinite recursion but that doesn't happen on live. Can't figure it out. Any guesses?