### PR TITLE
Add Stripe Dashboard link from admin change panel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,6 +32,7 @@ History
 * Customer.sync_cards() (Thanks @jleclanche) #438
 * Many stability fixes, bugfixes, and code cleanup (Thanks @jleclanche)
 * Improved admin interface (Thanks @jleclanche with @jameshiew) #451
+* Added Stripe Dashboard link to admin change panel (Thanks @jleclanche) #465
 * Implemented ``Plan.amount_in_cents`` (Thanks @jleclanche) #466
 * Implemented ``Subscription.reactivate()`` (Thanks @jleclanche) #470
 

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -141,6 +141,8 @@ class EventProcessingExceptionAdmin(admin.ModelAdmin):
 class StripeObjectAdmin(admin.ModelAdmin):
     """Base class for all StripeObject-based model admins"""
 
+    change_form_template = "djstripe/admin/change_form.html"
+
     def get_list_display(self, request):
         return ("stripe_id", ) + self.list_display + ("stripe_timestamp", "livemode")
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -596,6 +596,9 @@ class Card(StripeCard):
         else:
             raise ValidationError("A customer was not attached to this card.")
 
+    def get_stripe_dashboard_url(self):
+        return self.customer.get_stripe_dashboard_url()
+
     def remove(self):
         """Removes a card from this customer's account."""
 
@@ -644,6 +647,9 @@ class Invoice(StripeInvoice):
 
     class Meta(object):
         ordering = ["-date"]
+
+    def get_stripe_dashboard_url(self):
+        return self.customer.get_stripe_dashboard_url()
 
     def _attach_objects_hook(self, cls, data):
         self.customer = cls._stripe_object_to_customer(target_cls=Customer, data=data)
@@ -718,6 +724,9 @@ class UpcomingInvoice(Invoice):
     def __init__(self, *args, **kwargs):
         super(UpcomingInvoice, self).__init__(*args, **kwargs)
         self._invoiceitems = []
+
+    def get_stripe_dashboard_url(self):
+        return ""
 
     def _attach_objects_hook(self, cls, data):
         super(UpcomingInvoice, self)._attach_objects_hook(cls, data)
@@ -800,6 +809,9 @@ class InvoiceItem(StripeInvoiceItem):
             customer = customer or subscription.customer
 
         self.customer = customer
+
+    def get_stripe_dashboard_url(self):
+        return self.invoice.get_stripe_dashboard_url()
 
 
 @class_doc_inherit

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -54,6 +54,7 @@ class StripeObject(models.Model):
     # e.g. Event, Charge, Customer, etc.
     stripe_class = None
     expand_fields = None
+    stripe_dashboard_item_name = ""
 
     objects = models.Manager()
     stripe_objects = StripeObjectManager()
@@ -85,6 +86,22 @@ class StripeObject(models.Model):
 
     class Meta:
         abstract = True
+
+    def get_stripe_dashboard_url(self):
+        """Get the stripe dashboard url for this object."""
+        base_url = "https://dashboard.stripe.com/"
+
+        if not self.livemode:
+            base_url += "test/"
+
+        if not self.stripe_dashboard_item_name or not self.stripe_id:
+            return ""
+        else:
+            return "{base_url}{item}/{stripe_id}".format(
+                base_url=base_url,
+                item=self.stripe_dashboard_item_name,
+                stripe_id=self.stripe_id
+            )
 
     def api_retrieve(self, api_key=settings.STRIPE_SECRET_KEY):
         """
@@ -448,6 +465,7 @@ Fields not implemented:
 
     stripe_class = stripe.Charge
     expand_fields = ["balance_transaction"]
+    stripe_dashboard_item_name = "payments"
 
     amount = StripeCurrencyField(help_text="Amount charged.")
     amount_refunded = StripeCurrencyField(
@@ -604,6 +622,7 @@ Fields not implemented:
 
     stripe_class = stripe.Customer
     expand_fields = ["default_source"]
+    stripe_dashboard_item_name = "customers"
 
     account_balance = StripeIntegerField(
         null=True,
@@ -882,6 +901,7 @@ Fields not implemented:
         abstract = True
 
     stripe_class = stripe.Event
+    stripe_dashboard_item_name = "events"
 
     type = StripeCharField(max_length=250, help_text="Stripe's event description code")
     request_id = StripeCharField(
@@ -944,6 +964,7 @@ Fields not implemented:
 
     stripe_class = stripe.Transfer
     expand_fields = ["balance_transaction"]
+    stripe_dashboard_item_name = "transfers"
 
     STATUS_PAID = "paid"
     STATUS_PENDING = "pending"
@@ -1314,6 +1335,7 @@ Fields not implemented:
         abstract = True
 
     stripe_class = stripe.Invoice
+    stripe_dashboard_item_name = "invoices"
 
     amount_due = StripeCurrencyField(
         help_text="Final amount due at this time for this invoice. If the invoice's total is smaller than the minimum "
@@ -1608,6 +1630,7 @@ Fields not implemented:
         abstract = True
 
     stripe_class = stripe.Plan
+    stripe_dashboard_item_name = "plans"
 
     INTERVAL_TYPES = ["day", "week", "month", "year"]
     INTERVAL_TYPE_CHOICES = [(interval_type, interval_type.title()) for interval_type in INTERVAL_TYPES]
@@ -1677,6 +1700,7 @@ Fields not implemented:
         abstract = True
 
     stripe_class = stripe.Subscription
+    stripe_dashboard_item_name = "subscriptions"
 
     STATUS_ACTIVE = "active"
     STATUS_TRIALING = "trialing"

--- a/djstripe/templates/djstripe/admin/change_form.html
+++ b/djstripe/templates/djstripe/admin/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+	{{ block.super }}
+	{% with original.get_stripe_dashboard_url as stripe_url %}
+	{% if stripe_url %}
+		<li><a href="{{ stripe_url }}" target="_blank" id="djstripe-view-on-stripe"><i class="icon-user icon-alpha75"></i>{% trans "View on Stripe Dashboard" %}</a></li>
+	{% endif %}
+	{% endwith %}
+{% endblock %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -13,7 +13,6 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from mock import Mock, patch
-import six
 
 from djstripe.admin import reprocess_events, subscription_status
 from djstripe.models import Customer, Event, Subscription
@@ -31,7 +30,7 @@ class TestAdminSite(TestCase):
         Bad search field <customer__user__username> for Customer model.
         """
 
-        for _model, model_admin in six.iteritems(admin.site._registry):
+        for _model, model_admin in admin.site._registry.items():
             for search_field in getattr(model_admin, 'search_fields', []):
                 model_name = model_admin.model.__name__
                 self.assertFalse(search_field.startswith('{table_name}__'.format(

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -35,6 +35,7 @@ class CardTest(TestCase):
         card = Card.sync_from_stripe_data(deepcopy(FAKE_CARD))
 
         self.assertEqual(customer, card.customer)
+        self.assertEqual(card.get_stripe_dashboard_url(), customer.get_stripe_dashboard_url())
 
     def test_str(self):
         user = get_user_model().objects.create_user(username="pydanny", email="pydanny@gmail.com")

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -44,6 +44,17 @@ class TestCustomer(TestCase):
             subscriber=str(self.user), email=self.user.email, stripe_id=FAKE_CUSTOMER["id"]
         ), str(self.customer))
 
+    def test_customer_dashboard_url(self):
+        expected_url = "https://dashboard.stripe.com/test/customers/{}".format(self.customer.stripe_id)
+        self.assertEqual(self.customer.get_stripe_dashboard_url(), expected_url)
+
+        self.customer.livemode = True
+        expected_url = "https://dashboard.stripe.com/customers/{}".format(self.customer.stripe_id)
+        self.assertEqual(self.customer.get_stripe_dashboard_url(), expected_url)
+
+        unsaved_customer = Customer()
+        self.assertEqual(unsaved_customer.get_stripe_dashboard_url(), "")
+
     def test_customer_sync_unsupported_source(self):
         fake_customer = deepcopy(FAKE_CUSTOMER_II)
         fake_customer["default_source"]["object"] = "fish"

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -35,6 +35,7 @@ class InvoiceTest(TestCase):
     def test_str(self, charge_retrieve_mock, subscription_retrive_mock, default_account_mock):
         default_account_mock.return_value = self.account
         invoice = Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+        self.assertEqual(invoice.get_stripe_dashboard_url(), self.customer.get_stripe_dashboard_url())
 
         self.assertEqual(
             "<amount_due={amount_due}, date={date}, status={status}, stripe_id={stripe_id}>".format(
@@ -253,6 +254,7 @@ class InvoiceTest(TestCase):
         self.assertIsNotNone(invoice)
         self.assertIsNone(invoice.stripe_id)
         self.assertIsNone(invoice.save())
+        self.assertEquals(invoice.get_stripe_dashboard_url(), "")
 
         subscription_retrieve_mock.assert_called_once_with(api_key=ANY, expand=ANY, id=FAKE_SUBSCRIPTION["id"])
         plan_retrieve_mock.assert_not_called()

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -36,6 +36,7 @@ class InvoiceItemTest(TestCase):
 
         invoiceitem_data = deepcopy(FAKE_INVOICEITEM)
         invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
+        self.assertEqual(invoiceitem.get_stripe_dashboard_url(), invoiceitem.invoice.get_stripe_dashboard_url())
 
         self.assertEqual(str(invoiceitem), "<amount={amount}, date={date}, stripe_id={stripe_id}>".format(
             amount=invoiceitem.amount,


### PR DESCRIPTION
This PR adds a link at the top right of the admin of almost every object type to view the object in the Stripe dashboard.

The URL is autogenerated from the object type and takes into consideration whether we're in live mode or not.

![image](https://cloud.githubusercontent.com/assets/235410/24010863/b82df69a-0a81-11e7-829a-87c6e5e1d299.png)
