### PR TITLE
Implement Plan.amount_in_cents

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -120,3 +120,9 @@ def get_subscriber_model():
                 "if a DJSTRIPE_SUBSCRIBER_MODEL is defined.")
 
     return subscriber_model
+
+
+ZERO_DECIMAL_CURRENCIES = set([
+    "bif", "clp", "djf", "gnf", "jpy", "kmf", "krw", "mga", "pyg", "rwf",
+    "vnd", "vuv", "xaf", "xof", "xpf",
+])

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -1638,6 +1638,10 @@ Fields not implemented:
         "Null if the plan has no trial period."
     )
 
+    @property
+    def amount_in_cents(self):
+        return self.amount * 100
+
     def str_parts(self):
         return [
             "name={name}".format(name=self.name),

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -87,11 +87,13 @@ class PlanTest(TestCase):
             stripe_id=self.plan_data["id"]), str(self.plan)
         )
 
-    @patch("stripe.Plan.retrieve", return_value="soup")
+    @patch("stripe.Plan.retrieve", return_value=FAKE_PLAN)
     def test_stripe_plan(self, plan_retrieve_mock):
-        self.assertEqual("soup", self.plan.api_retrieve())
+        stripe_plan = self.plan.api_retrieve()
         plan_retrieve_mock.assert_called_once_with(
             id=self.plan_data["id"],
             api_key=settings.STRIPE_SECRET_KEY,
             expand=None
         )
+        plan = Plan.sync_from_stripe_data(stripe_plan)
+        assert plan.amount_in_cents == plan.amount * 100


### PR DESCRIPTION
The Checkout.js API requires the plan's amount in cents. This commit implements the `amount_in_cents` property on the plan which takes the plan's currency into account and doesn't multiply zero-decimal currency plans (although I haven't tested that, according to #247 zero-decimal currencies aren't working right now).