### PR TITLE
Fix API spam on customer creation

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -199,7 +199,7 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
         stripe_customer = cls._api_create(email=subscriber.email)
         customer, created = Customer.objects.get_or_create(
             stripe_id=stripe_customer["id"],
-            defaults={"subscriber": subscriber, "currency": "usd"}
+            defaults={"subscriber": subscriber}
         )
 
         if djstripe_settings.DEFAULT_PLAN and trial_days:

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -199,7 +199,7 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
         stripe_customer = cls._api_create(email=subscriber.email)
         customer, created = Customer.objects.get_or_create(
             stripe_id=stripe_customer["id"],
-            defaults={"subscriber": subscriber}
+            defaults={"subscriber": subscriber, "livemode": stripe_customer["livemode"]}
         )
 
         if djstripe_settings.DEFAULT_PLAN and trial_days:


### PR DESCRIPTION
1. The `currency` field is not necessary in there. We'll get it from Stripe.
2. Setting the livemode as a default is necessary to ensure we don't spam the API with indempotent customer create requests. Otherwise, the customer is saved with livemode=None in the DB and we're going to keep attempting to create it.