### PR TITLE
Fix SubscriptionSerializer on Django Rest Framework>=3.5

### DIFF
--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -23,6 +23,7 @@ class SubscriptionSerializer(ModelSerializer):
         """Model class options."""
 
         model = Subscription
+        fields = "__all__"
 
 
 class CreateSubscriptionSerializer(serializers.Serializer):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,7 @@ sphinx_rtd_theme>=0.1.9
 sphinx-autobuild>=0.6.0
 
 # Contrib packages
-djangorestframework==3.4.6
+djangorestframework>=3.6.2
 
 # Database drivers
 psycopg2>=2.6.2


### PR DESCRIPTION
Avoid this error:

`AssertionError: ("Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the SubscriptionSerializer serializer.",)`