### PR TITLE
Fix migration 0023 subscriber model reference

### DIFF
--- a/djstripe/migrations/0023_auto_20170307_0937.py
+++ b/djstripe/migrations/0023_auto_20170307_0937.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from django.db import migrations, models
 
 
+DJSTRIPE_SUBSCRIBER_MODEL = getattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL", settings.AUTH_USER_MODEL)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -17,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customer',
             name='subscriber',
-            field=models.ForeignKey(null=True, on_delete=models.SET_NULL, related_name='djstripe_customers', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(null=True, on_delete=models.SET_NULL, related_name='djstripe_customers', to=DJSTRIPE_SUBSCRIBER_MODEL),
         ),
         migrations.AlterUniqueTogether(
             name='customer',


### PR DESCRIPTION
Fix for users that use a custom subscriber model (such as us) - d'oh!  I think in the future we should change references to this in models to use a free function such as `djstripe_settings.get_subscriber_model()` instead, so that it'll actually get picked up in auto-generated migrations instead of having to do this manually everytime.