### PR TITLE
Register checks for the stripe API keys

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ omit =
     djstripe/migrations/*
     djstripe/management/*
     djstripe/admin.py
-    djstripe/*__init__.py
+    djstripe/checks.py
 
 [html]
 directory = cover

--- a/djstripe/__init__.py
+++ b/djstripe/__init__.py
@@ -4,6 +4,7 @@
   :synopsis: dj-stripe - Django + Stripe Made Easy
 """
 import pkg_resources
+from . import checks  # noqa: Register the checks
 
 
 __version__ = pkg_resources.require("dj-stripe")[0].version

--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -1,0 +1,24 @@
+from django.core import checks
+
+
+@checks.register("djstripe")
+def check_stripe_api_key(app_configs=None, **kwargs):
+    from . import settings as djstripe_settings
+    errors = []
+
+    if not djstripe_settings.STRIPE_SECRET_KEY:
+        msg = "Could not find a Stripe API key."
+        hint = "Add STRIPE_TEST_SECRET_KEY and STRIPE_LIVE_SECRET_KEY to your settings."
+        errors.append(checks.Critical(msg, hint=hint, id="djstripe.C001"))
+    elif djstripe_settings.STRIPE_LIVE_MODE:
+        if not djstripe_settings.LIVE_API_KEY.startswith("sk_live_"):
+            msg = "Bad Stripe live API key."
+            hint = 'STRIPE_LIVE_SECRET_KEY should start with "sk_live_"'
+            errors.append(checks.Critical(msg, hint=hint, id="djstripe.W001"))
+    else:
+        if not djstripe_settings.TEST_API_KEY.startswith("sk_test_"):
+            msg = "Bad Stripe test API key."
+            hint = 'STRIPE_TEST_SECRET_KEY should start with "sk_test_"'
+            errors.append(checks.Critical(msg, hint=hint, id="djstripe.W002"))
+
+    return errors


### PR DESCRIPTION
This starts registering checks for djstripe, which you can run with `manage.py check`. They run automatically alongside things like runserver.

This initial check looks for misconfiguration of the stripe API_KEY settings. If the API key is missing altogether, we'll error critically. If the API key doesn't start with `sk_live_` or `sk_test_` (depending on the STRIPE_LIVE_MODE setting), we'll output a warning.