### PR TITLE
Replace django_mock with a much smaller QuerySetMock implementation

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -27,7 +27,6 @@ from django.utils import six, timezone
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.functional import cached_property
 from doc_inherit import class_doc_inherit
-from mock_django.query import QuerySetMock
 from stripe.error import StripeError, InvalidRequestError
 
 import traceback as exception_traceback
@@ -43,7 +42,7 @@ from .stripe_objects import (
     StripeEvent, StripeInvoice, StripeInvoiceItem, StripePlan, StripeSource,
     StripeSubscription, StripeTransfer
 )
-from .utils import get_friendly_currency_amount
+from .utils import get_friendly_currency_amount, QuerySetMock
 
 
 logger = logging.getLogger(__name__)
@@ -829,7 +828,7 @@ class UpcomingInvoice(Invoice):
         will act like a normal queryset, but mutation will silently fail.
         """
 
-        return QuerySetMock(InvoiceItem, *self._invoiceitems)
+        return QuerySetMock.from_iterable(InvoiceItem, self._invoiceitems)
 
     @property
     def stripe_id(self):

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.query import QuerySet
 from django.utils import timezone
 
 
@@ -135,3 +136,26 @@ def get_friendly_currency_amount(amount, currency):
     currency = currency.upper()
     sigil = CURRENCY_SIGILS.get(currency, "")
     return "{sigil}{amount} {currency}".format(sigil=sigil, amount=amount, currency=currency)
+
+
+class QuerySetMock(QuerySet):
+    """
+    A mocked QuerySet class that does not handle updates.
+    Used by UpcomingInvoice.invoiceitems.
+    """
+
+    @classmethod
+    def from_iterable(cls, model, iterable):
+        instance = cls(model)
+        instance._result_cache = list(iterable)
+        instance._prefetch_done = True
+        return instance
+
+    def _clone(self):
+        return self.__class__.from_iterable(self.model, self._result_cache)
+
+    def update(self):
+        return 0
+
+    def delete(self):
+        return 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
 	stripe >= 1.53.0
 	tqdm >= 4.8.4
 	python-doc-inherit >= 0.3.0
-	mock-django >= 0.6.10
 
 [options.packages.find]
 exclude =

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -248,6 +248,10 @@ class InvoiceTest(TestCase):
         self.assertEqual(1, len(items))
         self.assertEqual(FAKE_SUBSCRIPTION["id"], items[0].stripe_id)
 
+        # delete/update should do nothing
+        self.assertEqual(invoice.invoiceitems.update(), 0)
+        self.assertEqual(invoice.invoiceitems.delete(), 0)
+
         self.assertIsNotNone(invoice.plan)
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.stripe_id)
 


### PR DESCRIPTION
We reimplement a simpler QuerySetMock instead of pulling in the entirety of django_mock.

Our implementation is much smaller, tailored to our use case.

Requires #509