### PR TITLE
Implement DJSTRIPE_USE_NATIVE_JSONFIELD setting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ---------------------
 * BACKWARDS-INCOMPATIBLE: dj-stripe now supports test-mode and live-mode Customer objects concurrently.
   As a result, the User.customer One-to-One reverse-relationship is now the User.djstripe_customers RelatedManager. (Thanks @jleclanche) #440
+* Postgres users now have access to the ``DJSTRIPE_USE_NATIVE_JSONFIELD`` setting. (Thanks @jleclanche) #517, #523
 * Charge receipts now take `DJSTRIPE_SEND_INVOICE_RECEIPT_EMAILS` into account (Thanks @r0fls)
 * Clarified/modified installation documentation (Thanks @pydanny)
 * Corrected and revised ANONYMOUS_USER_ERROR_MSG (Thanks @pydanny)

--- a/djstripe/fields.py
+++ b/djstripe/fields.py
@@ -9,13 +9,17 @@
 
 import decimal
 
-from django.core.exceptions import ImproperlyConfigured, FieldError
+from django.core.exceptions import FieldError, ImproperlyConfigured
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from jsonfield import JSONField
+from .settings import USE_NATIVE_JSONFIELD
+from .utils import convert_tstamp, dict_nested_accessor
 
-from .utils import dict_nested_accessor, convert_tstamp
+if USE_NATIVE_JSONFIELD:
+    from django.contrib.postgres.fields import JSONField
+else:
+    from jsonfield import JSONField
 
 
 class StripeFieldMixin(object):

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -65,6 +65,7 @@ def _get_idempotency_key(object_type, action, livemode):
 
 get_idempotency_key = get_callback_function("DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK", _get_idempotency_key)
 
+USE_NATIVE_JSONFIELD = getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", False)
 
 PRORATION_POLICY = getattr(settings, 'DJSTRIPE_PRORATION_POLICY', False)
 PRORATION_POLICY_FOR_UPGRADES = getattr(settings, 'DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES', False)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -171,6 +171,26 @@ Examples:
 .. note:: This callback only becomes active when ``DJSTRIPE_SUBSCRIBER_MODEL`` is set.
 
 
+DJSTRIPE_USE_NATIVE_JSONFIELD (=False)
+======================================
+
+Setting this to ``True`` will make the various dj-stripe JSON fields use
+``django.contrib.postgres.fields.JSONField`` instead of the ``jsonfield``
+library (which internally uses ``text`` fields).
+
+The native Django JSONField uses the postgres `jsonb`_ column type, which
+efficiently stores JSON and can be queried far more conveniently. Django also
+supports `querying JSONField`_ with the ORM.
+
+.. note:: This is only supported on Postgres databases.
+
+.. note:: **Migrating between native and non-native must be done manually.**
+
+.. _jsonb: https://www.postgresql.org/docs/9.6/static/functions-json.html
+
+.. _querying JSONField: https://docs.djangoproject.com/en/1.11/ref/contrib/postgres/fields/#querying-jsonfield
+
+
 DJSTRIPE_WEBHOOK_URL (=r"^webhook/$")
 =====================================
 

--- a/runtests.py
+++ b/runtests.py
@@ -136,6 +136,7 @@ def run_test_suite(args):
             "testapp_namespaced:test_url_namespaced",
             "fn:/test_fnmatch*"
         ),
+        DJSTRIPE_USE_NATIVE_JSONFIELD=os.environ.get("USE_NATIVE_JSONFIELD", "") == "1",
     )
 
     # Avoid AppRegistryNotReady exception

--- a/tests/test_zz_jsonfield.py
+++ b/tests/test_zz_jsonfield.py
@@ -1,0 +1,44 @@
+"""
+Tests for JSONField
+
+Due to their nature messing with subclassing, these tests must be run last.
+"""
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from djstripe import fields as fields
+from djstripe import settings as djstripe_settings
+
+try:
+    reload
+except NameError:
+    from importlib import reload
+
+
+@override_settings(DJSTRIPE_USE_NATIVE_JSONFIELD=False)
+class TestFallbackJSONField(TestCase):
+    def test_jsonfield_inheritance(self):
+        from jsonfield import JSONField
+        reload(djstripe_settings)
+        reload(fields)
+
+        self.assertTrue(issubclass(fields.StripeJSONField, JSONField))
+
+    def tearDown(self):
+        reload(djstripe_settings)
+        reload(fields)
+
+
+@override_settings(DJSTRIPE_USE_NATIVE_JSONFIELD=True)
+class TestNativeJSONField(TestCase):
+    def test_jsonfield_inheritance(self):
+        from django.contrib.postgres.fields import JSONField
+        reload(djstripe_settings)
+        reload(fields)
+
+        self.assertTrue(issubclass(fields.StripeJSONField, JSONField))
+
+    def tearDown(self):
+        reload(djstripe_settings)
+        reload(fields)


### PR DESCRIPTION
This PR implements a `DJSTRIPE_USE_NATIVE_JSONFIELD` setting which switches around the inheritance of StripeJSONField.

To Django's migration engine, as the field remains the same class, there is no migration to run. However, *this must only be enabled either on an empty database or on an already-manually-migrated database*. Switching the setting on or off halfway-through is not supported.

Closes #517

glhf

TODO:
- [x] Document the setting
- [x] Add a check to ensure that the setting cannot be set to True on a non-postgres engine.