### PR TITLE
Middleware in Django >= 1.10

### DIFF
--- a/djstripe/middleware.py
+++ b/djstripe/middleware.py
@@ -11,6 +11,7 @@
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import resolve
+from django.utils.deprecation import MiddlewareMixin
 
 import fnmatch
 
@@ -30,7 +31,7 @@ EXEMPT = list(DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS)
 EXEMPT.append("[djstripe]")
 
 
-class SubscriptionPaymentMiddleware(object):
+class SubscriptionPaymentMiddleware(MiddlewareMixin):
     """
     Used to redirect users from subcription-locked request destinations.
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,10 +6,8 @@
 
 """
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings, modify_settings

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,11 +6,13 @@
 
 """
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.test.utils import override_settings
+from django.test.utils import override_settings, modify_settings
 
 from djstripe.middleware import SubscriptionPaymentMiddleware
 from djstripe.models import Customer, Subscription
@@ -74,6 +76,17 @@ class MiddlewareURLTest(TestCase):
 
         response = self.middleware.process_request(request)
         self.assertEqual(response, None)
+
+    @override_settings(DEBUG=True)
+    @modify_settings(MIDDLEWARE={
+        'append': ['djstripe.middleware.SubscriptionPaymentMiddleware']})
+    def test_middleware_loads(self):
+        """Check that the middleware can be loaded by django's
+        middleware handlers. This is to check for compatibility across
+        the change to django's middleware class structure. See
+        https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+        """
+        self.client.get('/__debug__')
 
 
 class MiddlewareLogicTest(TestCase):


### PR DESCRIPTION
Because the interface for Middleware changed in 1.10 (see [the docs](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)), `djstripe.middleware.SubscriptionPaymentMiddleware` won't load if you add it to `MIDDLEWARE`.

This PR changes `SubscriptionPaymentMiddleware` to inherit from `MiddlewareMixin` instead of `object`, which maintains backwards compatibility while allowing use of this middleware in the django 1.10 style.