### PR TITLE
Make str() on some objects a more human-readable string

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -865,6 +865,12 @@ class InvoiceItem(StripeInvoiceItem):
         help_text="The subscription that this invoice item has been created for, if any."
     )
 
+    def __str__(self):
+        if not self.plan:
+            return super(InvoiceItem, self).__str__()
+        price = self.plan.human_readable_price
+        return "Subscription to {plan} ({price})".format(plan=self.plan, price=price)
+
     def _attach_objects_hook(self, cls, data):
         customer = cls._stripe_object_to_customer(target_cls=Customer, data=data)
 

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -141,6 +141,7 @@ class Coupon(StripeCoupon):
 
 
 @class_doc_inherit
+@python_2_unicode_compatible
 class Customer(StripeCustomer):
     doc = """
 
@@ -174,18 +175,13 @@ Use ``Customer.sources`` and ``Customer.subscriptions`` to access them.
     class Meta:
         unique_together = ("subscriber", "livemode")
 
-    def str_parts(self):
-        parts = []
-
-        if self.subscriber:
-            parts.append(smart_text(self.subscriber))
-            parts.append("email={email}".format(email=self.subscriber.email))
+    def __str__(self):
+        if not self.subscriber:
+            return "{stripe_id} (deleted)".format(stripe_id=self.stripe_id)
+        elif self.subscriber.email:
+            return self.subscriber.email
         else:
-            parts.append("(deleted)")
-
-        parts.extend(super(Customer, self).str_parts())
-
-        return parts
+            return self.stripe_id
 
     @classmethod
     def get_or_create(cls, subscriber, livemode=djstripe_settings.STRIPE_LIVE_MODE):

--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -889,6 +889,7 @@ class InvoiceItem(StripeInvoiceItem):
 
 
 @class_doc_inherit
+@python_2_unicode_compatible
 class Plan(StripePlan):
     __doc__ = getattr(StripePlan, "__doc__")
 
@@ -918,6 +919,9 @@ class Plan(StripePlan):
         plan = Plan.objects.create(**kwargs)
 
         return plan
+
+    def __str__(self):
+        return self.name
 
     @property
     def human_readable_price(self):

--- a/djstripe/stripe_objects.py
+++ b/djstripe/stripe_objects.py
@@ -1690,11 +1690,6 @@ Fields not implemented:
     def amount_in_cents(self):
         return int(self.amount * 100)
 
-    def str_parts(self):
-        return [
-            "name={name}".format(name=self.name),
-        ] + super(StripePlan, self).str_parts()
-
 
 class StripeSubscription(StripeObject):
     """

--- a/runtests.py
+++ b/runtests.py
@@ -43,9 +43,9 @@ def run_test_suite(args):
             "default": {
                 "ENGINE": "django.db.backends.postgresql_psycopg2",
                 "NAME": "djstripe",
-                "USER": "",
+                "USER": "postgres",
                 "PASSWORD": "",
-                "HOST": "",
+                "HOST": "localhost",
                 "PORT": "",
             },
         },

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -43,9 +43,9 @@ class TestCustomer(TestCase):
         self.account = Account.objects.create()
 
     def test_str(self):
-        self.assertEqual("<{subscriber}, email={email}, stripe_id={stripe_id}>".format(
-            subscriber=str(self.user), email=self.user.email, stripe_id=FAKE_CUSTOMER["id"]
-        ), str(self.customer))
+        self.assertEqual(str(self.customer), self.user.email)
+        self.customer.subscriber = None
+        self.assertEqual(str(self.customer), "{stripe_id} (deleted)".format(stripe_id=self.customer.stripe_id))
 
     def test_customer_dashboard_url(self):
         expected_url = "https://dashboard.stripe.com/test/customers/{}".format(self.customer.stripe_id)
@@ -715,7 +715,6 @@ class TestCustomer(TestCase):
         self.user.delete()
         customer = Customer.objects.get(stripe_id=FAKE_CUSTOMER["id"])
         self.assertIsNotNone(customer.date_purged)
-        self.assertEqual(["(deleted)", "stripe_id=cus_6lsBvm5rJ0zyHc"], customer.str_parts())
 
     @patch("stripe.Customer.retrieve")
     def test_delete_subscriber_without_customer_is_noop(self, customer_retrieve_mock):

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -26,18 +26,25 @@ class InvoiceItemTest(TestCase):
         Customer.objects.create(subscriber=user, stripe_id=FAKE_CUSTOMER_II["id"], livemode=False)
 
     @patch("djstripe.models.Account.get_default_account")
+    @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
     @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
     @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
     @patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II))
     def test_str(self, invoice_retrieve_mock, charge_retrieve_mock, customer_retrieve_mock, subscription_retrieve_mock,
-                 default_account_mock):
+                 plan_retrieve_mock, default_account_mock):
         default_account_mock.return_value = self.account
 
         invoiceitem_data = deepcopy(FAKE_INVOICEITEM)
+        invoiceitem_data["plan"] = FAKE_PLAN_II
         invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
         self.assertEqual(invoiceitem.get_stripe_dashboard_url(), invoiceitem.invoice.get_stripe_dashboard_url())
 
+        self.assertEqual(
+            str(invoiceitem),
+            "Subscription to New plan name ({price})".format(price=invoiceitem.plan.human_readable_price)
+        )
+        invoiceitem.plan = None
         self.assertEqual(str(invoiceitem), "<amount={amount}, date={date}, stripe_id={stripe_id}>".format(
             amount=invoiceitem.amount,
             date=invoiceitem.date,

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -83,10 +83,7 @@ class PlanTest(TestCase):
         object_create_mock.assert_called_once_with(metadata=metadata, stripe_id=1, arg1=1, arg2=2, amount=1)
 
     def test_str(self):
-        self.assertEqual("<name={name}, stripe_id={stripe_id}>".format(
-            name=self.plan_data["name"],
-            stripe_id=self.plan_data["id"]), str(self.plan)
-        )
+        self.assertEqual(str(self.plan), self.plan_data["name"])
 
     @patch("stripe.Plan.retrieve", return_value=FAKE_PLAN)
     def test_stripe_plan(self, plan_retrieve_mock):


### PR DESCRIPTION
I'd like to move away from our current string-parts __str__ to something where we can actually stuff objects into templates and expect them to look good. I'm modeling stuff like InvoiceItem based on Stripe's Dashboard (which i believe is also how it shows up in invoice emails)