### PR TITLE
Fix Event Processing Exception Reraising

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -44,12 +44,8 @@ def run_test_suite(args):
         SITE_ID=1,
         DATABASES={
             "default": {
-                "ENGINE": "django.db.backends.postgresql_psycopg2",
-                "NAME": "djstripe",
-                "USER": "postgres",
-                "PASSWORD": "",
-                "HOST": "localhost",
-                "PORT": "",
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
             },
         },
         TEMPLATES=[


### PR DESCRIPTION
As it was we were "munging" the exception that was thrown by always type-casting it to `StripeError` which resulted in some oddities when attempting to actually catch the exception (e.g. trying to catch an `InvalidRequestError` exception would be impossible).

Also switched to in-memory SQLite for the tests for that extra pinch of speed (I don't personally have postgres installed, and we probably shouldn't force it within the test framework - right?)