### PR TITLE
Safe switch of Stripe API version in migrations

### DIFF
--- a/djstripe/migrations/0008_auto_20150806_1641_squashed_0031_auto_20170606_1708.py
+++ b/djstripe/migrations/0008_auto_20150806_1641_squashed_0031_auto_20170606_1708.py
@@ -38,26 +38,26 @@ def resync_subscriptions(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Subscription
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Subscription.objects.count():
-        print("Purging subscriptions. Don't worry, all active subscriptions will be re-synced from stripe. Just in \
-        case you didn't get the memo, we'll print out a json representation of each object for your records:")
-        print(serializers.serialize("json", Subscription.objects.all()))
-        Subscription.objects.all().delete()
+    with stripe_temporary_api_version("2016-03-07"):
+        if Subscription.objects.count():
+            print("Purging subscriptions. Don't worry, all active subscriptions will be re-synced from stripe. Just in \
+            case you didn't get the memo, we'll print out a json representation of each object for your records:")
+            print(serializers.serialize("json", Subscription.objects.all()))
+            Subscription.objects.all().delete()
 
-        print("Re-syncing subscriptions. This may take a while.")
+            print("Re-syncing subscriptions. This may take a while.")
 
-        for stripe_subscription in tqdm(iterable=Subscription.api_list(), desc="Sync", unit=" subscriptions"):
-            subscription = Subscription.sync_from_stripe_data(stripe_subscription)
+            for stripe_subscription in tqdm(iterable=Subscription.api_list(), desc="Sync", unit=" subscriptions"):
+                subscription = Subscription.sync_from_stripe_data(stripe_subscription)
 
-            if not subscription.customer:
-                tqdm.write("The customer for this subscription ({subscription_id}) does not exist locally (so we \
-                won't sync the subscription). You'll want to figure out how that \
-                happened.".format(subscription_id=stripe_subscription['id']))
+                if not subscription.customer:
+                    tqdm.write("The customer for this subscription ({subscription_id}) does not exist locally (so we \
+                    won't sync the subscription). You'll want to figure out how that \
+                    happened.".format(subscription_id=stripe_subscription['id']))
 
-        print("Subscription re-sync complete.")
+            print("Subscription re-sync complete.")
 
 
 def resync_invoiceitems(apps, schema_editor):
@@ -72,127 +72,127 @@ def resync_invoiceitems(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import InvoiceItem
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if InvoiceItem.objects.count():
-        print("Purging invoiceitems. Don't worry, all invoiceitems will be re-synced from stripe. Just in case you \
-        didn't get the memo, we'll print out a json representation of each object for your records:")
-        print(serializers.serialize("json", InvoiceItem.objects.all()))
-        InvoiceItem.objects.all().delete()
+    with stripe_temporary_api_version("2016-03-07"):
+        if InvoiceItem.objects.count():
+            print("Purging invoiceitems. Don't worry, all invoiceitems will be re-synced from stripe. Just in case you \
+            didn't get the memo, we'll print out a json representation of each object for your records:")
+            print(serializers.serialize("json", InvoiceItem.objects.all()))
+            InvoiceItem.objects.all().delete()
 
-        print("Re-syncing invoiceitems. This may take a while.")
+            print("Re-syncing invoiceitems. This may take a while.")
 
-        for stripe_invoiceitem in tqdm(iterable=InvoiceItem.api_list(), desc="Sync", unit=" invoiceitems"):
-            invoice = InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
+            for stripe_invoiceitem in tqdm(iterable=InvoiceItem.api_list(), desc="Sync", unit=" invoiceitems"):
+                invoice = InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
 
-            if not invoice.customer:
-                tqdm.write("The customer for this invoiceitem ({invoiceitem_id}) does not exist \
-                locally (so we won't sync the invoiceitem). You'll want to figure out how that \
-                happened.".format(invoiceitem_id=stripe_invoiceitem['id']))
+                if not invoice.customer:
+                    tqdm.write("The customer for this invoiceitem ({invoiceitem_id}) does not exist \
+                    locally (so we won't sync the invoiceitem). You'll want to figure out how that \
+                    happened.".format(invoiceitem_id=stripe_invoiceitem['id']))
 
-        print("InvoiceItem re-sync complete.")
+            print("InvoiceItem re-sync complete.")
 
 
 def sync_charges(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Charge
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Charge.objects.count():
-        print("syncing charges. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Charge.objects.count():
+            print("syncing charges. This may take a while.")
 
-        for charge in tqdm(Charge.objects.all(), desc="Sync", unit=" charges"):
-            try:
-                Charge.sync_from_stripe_data(charge.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing charge ({charge_id}).".format(charge_id=charge.stripe_id))
+            for charge in tqdm(Charge.objects.all(), desc="Sync", unit=" charges"):
+                try:
+                    Charge.sync_from_stripe_data(charge.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing charge ({charge_id}).".format(charge_id=charge.stripe_id))
 
-        print("Charge sync complete.")
+            print("Charge sync complete.")
 
 
 def sync_invoices(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Invoice
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Invoice.objects.count():
-        print("syncing invoices. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Invoice.objects.count():
+            print("syncing invoices. This may take a while.")
 
-        for invoice in tqdm(iterable=Invoice.objects.all(), desc="Sync", unit=" invoices"):
-            try:
-                Invoice.sync_from_stripe_data(invoice.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing invoice \
-                ({invoice_id}).".format(invoice_id=invoice.stripe_id))
+            for invoice in tqdm(iterable=Invoice.objects.all(), desc="Sync", unit=" invoices"):
+                try:
+                    Invoice.sync_from_stripe_data(invoice.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing invoice \
+                    ({invoice_id}).".format(invoice_id=invoice.stripe_id))
 
-        print("Invoice sync complete.")
+            print("Invoice sync complete.")
 
 
 def sync_transfers(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Transfer
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Transfer.objects.count():
-        print("syncing transfers. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Transfer.objects.count():
+            print("syncing transfers. This may take a while.")
 
-        for transfer in tqdm(iterable=Transfer.objects.all(), desc="Sync", unit=" transfers"):
-            try:
-                Transfer.sync_from_stripe_data(transfer)
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing transfer \
-                ({transfer_id}).".format(transfer_id=transfer.stripe_id))
+            for transfer in tqdm(iterable=Transfer.objects.all(), desc="Sync", unit=" transfers"):
+                try:
+                    Transfer.sync_from_stripe_data(transfer)
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing transfer \
+                    ({transfer_id}).".format(transfer_id=transfer.stripe_id))
 
-        print("Transfer sync complete.")
+            print("Transfer sync complete.")
 
 
 def sync_plans(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Plan
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Plan.objects.count():
-        print("syncing plans. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Plan.objects.count():
+            print("syncing plans. This may take a while.")
 
-        for plan in tqdm(iterable=Plan.objects.all(), desc="Sync", unit=" plans"):
-            try:
-                Plan.sync_from_stripe_data(plan)
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing plan ({plan_id}).".format(transfer_id=plan.stripe_id))
+            for plan in tqdm(iterable=Plan.objects.all(), desc="Sync", unit=" plans"):
+                try:
+                    Plan.sync_from_stripe_data(plan)
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing plan ({plan_id}).".format(transfer_id=plan.stripe_id))
 
-        print("Transfer sync complete.")
+            print("Transfer sync complete.")
 
 
 def sync_customers(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Customer
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Customer.objects.count():
-        print("syncing customers. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Customer.objects.count():
+            print("syncing customers. This may take a while.")
 
-        for customer in tqdm(Customer.objects.all(), desc="Sync", unit=" customers"):
-            try:
-                Customer.sync_from_stripe_data(customer.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing customer \
-                ({customer_id}).".format(customer_id=customer.stripe_id))
-            except IntegrityError:
-                print(customer.api_retrieve())
-                six.reraise(*sys.exc_info())
+            for customer in tqdm(Customer.objects.all(), desc="Sync", unit=" customers"):
+                try:
+                    Customer.sync_from_stripe_data(customer.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing customer \
+                    ({customer_id}).".format(customer_id=customer.stripe_id))
+                except IntegrityError:
+                    print(customer.api_retrieve())
+                    six.reraise(*sys.exc_info())
 
-        print("Customer sync complete.")
+            print("Customer sync complete.")
 
 
 def on_subscriber_delete_purge_customers(collector, field, sub_objs, using):

--- a/djstripe/migrations/0012_model_sync.py
+++ b/djstripe/migrations/0012_model_sync.py
@@ -25,26 +25,26 @@ def resync_subscriptions(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Subscription
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Subscription.objects.count():
-        print("Purging subscriptions. Don't worry, all active subscriptions will be re-synced from stripe. Just in \
-        case you didn't get the memo, we'll print out a json representation of each object for your records:")
-        print(serializers.serialize("json", Subscription.objects.all()))
-        Subscription.objects.all().delete()
+    with stripe_temporary_api_version("2016-03-07"):
+        if Subscription.objects.count():
+            print("Purging subscriptions. Don't worry, all active subscriptions will be re-synced from stripe. Just in \
+            case you didn't get the memo, we'll print out a json representation of each object for your records:")
+            print(serializers.serialize("json", Subscription.objects.all()))
+            Subscription.objects.all().delete()
 
-        print("Re-syncing subscriptions. This may take a while.")
+            print("Re-syncing subscriptions. This may take a while.")
 
-        for stripe_subscription in tqdm(iterable=Subscription.api_list(), desc="Sync", unit=" subscriptions"):
-            subscription = Subscription.sync_from_stripe_data(stripe_subscription)
+            for stripe_subscription in tqdm(iterable=Subscription.api_list(), desc="Sync", unit=" subscriptions"):
+                subscription = Subscription.sync_from_stripe_data(stripe_subscription)
 
-            if not subscription.customer:
-                tqdm.write("The customer for this subscription ({subscription_id}) does not exist locally (so we \
-                won't sync the subscription). You'll want to figure out how that \
-                happened.".format(subscription_id=stripe_subscription['id']))
+                if not subscription.customer:
+                    tqdm.write("The customer for this subscription ({subscription_id}) does not exist locally (so we \
+                    won't sync the subscription). You'll want to figure out how that \
+                    happened.".format(subscription_id=stripe_subscription['id']))
 
-        print("Subscription re-sync complete.")
+            print("Subscription re-sync complete.")
 
 
 def resync_invoiceitems(apps, schema_editor):
@@ -59,127 +59,127 @@ def resync_invoiceitems(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import InvoiceItem
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if InvoiceItem.objects.count():
-        print("Purging invoiceitems. Don't worry, all invoiceitems will be re-synced from stripe. Just in case you \
-        didn't get the memo, we'll print out a json representation of each object for your records:")
-        print(serializers.serialize("json", InvoiceItem.objects.all()))
-        InvoiceItem.objects.all().delete()
+    with stripe_temporary_api_version("2016-03-07"):
+        if InvoiceItem.objects.count():
+            print("Purging invoiceitems. Don't worry, all invoiceitems will be re-synced from stripe. Just in case you \
+            didn't get the memo, we'll print out a json representation of each object for your records:")
+            print(serializers.serialize("json", InvoiceItem.objects.all()))
+            InvoiceItem.objects.all().delete()
 
-        print("Re-syncing invoiceitems. This may take a while.")
+            print("Re-syncing invoiceitems. This may take a while.")
 
-        for stripe_invoiceitem in tqdm(iterable=InvoiceItem.api_list(), desc="Sync", unit=" invoiceitems"):
-            invoice = InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
+            for stripe_invoiceitem in tqdm(iterable=InvoiceItem.api_list(), desc="Sync", unit=" invoiceitems"):
+                invoice = InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
 
-            if not invoice.customer:
-                tqdm.write("The customer for this invoiceitem ({invoiceitem_id}) does not exist \
-                locally (so we won't sync the invoiceitem). You'll want to figure out how that \
-                happened.".format(invoiceitem_id=stripe_invoiceitem['id']))
+                if not invoice.customer:
+                    tqdm.write("The customer for this invoiceitem ({invoiceitem_id}) does not exist \
+                    locally (so we won't sync the invoiceitem). You'll want to figure out how that \
+                    happened.".format(invoiceitem_id=stripe_invoiceitem['id']))
 
-        print("InvoiceItem re-sync complete.")
+            print("InvoiceItem re-sync complete.")
 
 
 def sync_charges(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Charge
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Charge.objects.count():
-        print("syncing charges. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Charge.objects.count():
+            print("syncing charges. This may take a while.")
 
-        for charge in tqdm(Charge.objects.all(), desc="Sync", unit=" charges"):
-            try:
-                Charge.sync_from_stripe_data(charge.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing charge ({charge_id}).".format(charge_id=charge.stripe_id))
+            for charge in tqdm(Charge.objects.all(), desc="Sync", unit=" charges"):
+                try:
+                    Charge.sync_from_stripe_data(charge.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing charge ({charge_id}).".format(charge_id=charge.stripe_id))
 
-        print("Charge sync complete.")
+            print("Charge sync complete.")
 
 
 def sync_invoices(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Invoice
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Invoice.objects.count():
-        print("syncing invoices. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Invoice.objects.count():
+            print("syncing invoices. This may take a while.")
 
-        for invoice in tqdm(iterable=Invoice.objects.all(), desc="Sync", unit=" invoices"):
-            try:
-                Invoice.sync_from_stripe_data(invoice.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing invoice \
-                ({invoice_id}).".format(invoice_id=invoice.stripe_id))
+            for invoice in tqdm(iterable=Invoice.objects.all(), desc="Sync", unit=" invoices"):
+                try:
+                    Invoice.sync_from_stripe_data(invoice.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing invoice \
+                    ({invoice_id}).".format(invoice_id=invoice.stripe_id))
 
-        print("Invoice sync complete.")
+            print("Invoice sync complete.")
 
 
 def sync_transfers(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Transfer
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Transfer.objects.count():
-        print("syncing transfers. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Transfer.objects.count():
+            print("syncing transfers. This may take a while.")
 
-        for transfer in tqdm(iterable=Transfer.objects.all(), desc="Sync", unit=" transfers"):
-            try:
-                Transfer.sync_from_stripe_data(transfer)
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing transfer \
-                ({transfer_id}).".format(transfer_id=transfer.stripe_id))
+            for transfer in tqdm(iterable=Transfer.objects.all(), desc="Sync", unit=" transfers"):
+                try:
+                    Transfer.sync_from_stripe_data(transfer)
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing transfer \
+                    ({transfer_id}).".format(transfer_id=transfer.stripe_id))
 
-        print("Transfer sync complete.")
+            print("Transfer sync complete.")
 
 
 def sync_plans(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Plan
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Plan.objects.count():
-        print("syncing plans. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Plan.objects.count():
+            print("syncing plans. This may take a while.")
 
-        for plan in tqdm(iterable=Plan.objects.all(), desc="Sync", unit=" plans"):
-            try:
-                Plan.sync_from_stripe_data(plan)
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing plan ({plan_id}).".format(transfer_id=plan.stripe_id))
+            for plan in tqdm(iterable=Plan.objects.all(), desc="Sync", unit=" plans"):
+                try:
+                    Plan.sync_from_stripe_data(plan)
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing plan ({plan_id}).".format(transfer_id=plan.stripe_id))
 
-        print("Transfer sync complete.")
+            print("Transfer sync complete.")
 
 
 def sync_customers(apps, schema_editor):
     # This is okay, since we're only doing a forward migration.
     from djstripe.models import Customer
 
-    import stripe
-    stripe.api_version = "2016-03-07"
+    from djstripe.context_managers import stripe_temporary_api_version
 
-    if Customer.objects.count():
-        print("syncing customers. This may take a while.")
+    with stripe_temporary_api_version("2016-03-07"):
+        if Customer.objects.count():
+            print("syncing customers. This may take a while.")
 
-        for customer in tqdm(Customer.objects.all(), desc="Sync", unit=" customers"):
-            try:
-                Customer.sync_from_stripe_data(customer.api_retrieve())
-            except InvalidRequestError:
-                tqdm.write("There was an error while syncing customer \
-                ({customer_id}).".format(customer_id=customer.stripe_id))
-            except IntegrityError:
-                print(customer.api_retrieve())
-                six.reraise(*sys.exc_info())
+            for customer in tqdm(Customer.objects.all(), desc="Sync", unit=" customers"):
+                try:
+                    Customer.sync_from_stripe_data(customer.api_retrieve())
+                except InvalidRequestError:
+                    tqdm.write("There was an error while syncing customer \
+                    ({customer_id}).".format(customer_id=customer.stripe_id))
+                except IntegrityError:
+                    print(customer.api_retrieve())
+                    six.reraise(*sys.exc_info())
 
-        print("Customer sync complete.")
+            print("Customer sync complete.")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Hi,

safe switching of api version in migrations isn't producing following warning under test runners of projects with `dj-stripe` (#551):

```
?: (djstripe.W001) The Stripe API version has a non-default value of '2016-03-07'. Non-default versions are not explicitly supported, and may cause compatibility issues.
	HINT: Use the dj-stripe default for Stripe API version: 2017-06-05
```

All direct changes of `stripe.api_version` was replaced with `stripe_temporary_api_version` context manager, which restores original value.

So, don't need to overwrite `STRIPE_API_VERSION` in `settings.py` for testing envs more.