### PR TITLE
Fixed DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES docs

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -2541,7 +2541,7 @@ class Subscription(StripeObject):
                                wish to use for proration calculations.
         :type proration_date: datetime
 
-        .. note:: The default value for ``prorate`` is overridden by the DJSTRIPE_PRORATION_POLICY setting.
+        .. note:: The default value for ``prorate`` is the DJSTRIPE_PRORATION_POLICY setting.
 
         .. important:: Updating a subscription by changing the plan or quantity creates a new ``Subscription`` in \
         Stripe (and dj-stripe).

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -69,7 +69,6 @@ get_idempotency_key = get_callback_function("DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK",
 USE_NATIVE_JSONFIELD = getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", False)
 
 PRORATION_POLICY = getattr(settings, 'DJSTRIPE_PRORATION_POLICY', False)
-PRORATION_POLICY_FOR_UPGRADES = getattr(settings, 'DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES', False)
 CANCELLATION_AT_PERIOD_END = not getattr(settings, 'DJSTRIPE_PRORATION_POLICY', False)
 
 DJSTRIPE_WEBHOOK_URL = getattr(settings, "DJSTRIPE_WEBHOOK_URL", r"^webhook/$")

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -60,14 +60,6 @@ By default, plans are not prorated in dj-stripe. Concretely, this is how this tr
 
 Assigning ``True`` to ``DJSTRIPE_PRORATION_POLICY`` reverses the functioning of item 2 (plan cancellation) by making a cancellation effective right away and refunding the unused balance to the customer, and affects the functioning of item 3 (plan change) by prorating the previous customer's plan towards their new plan's amount.
 
-DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES (=False)
-===============================================
-
-By default, the plan change policy described in item 3 above holds also for plan upgrades.
-
-Assigning ``True`` to ``DJSTRIPE_PRORATION_POLICY_FOR_UPGRADES`` allows dj-stripe to prorate plans in the specific case of an upgrade. Therefore, if a customer upgrades their plan, their new plan is effective right away, and they get billed for the new plan's amount minus the unused balance from their previous plan.
-
-
 DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS (=())
 ===================================================
 


### PR DESCRIPTION
See #584. ``PRORATION_POLICY_FOR_UPGRADES`` is stale; the setting was used in the views we removed in #477.