### PR TITLE
Fixed creation of Plan from admin section

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,3 +53,4 @@ Contributors
 * Alec Brunelle (@aleccool213)
 * James Hiew (@jameshiew)
 * Dan Koch (@dmkoch)
+* Dmi Baranov (@dmibaranov)

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -305,6 +305,11 @@ class PlanAdmin(StripeObjectAdmin):
             readonly_fields += (
                 "amount", "currency", "interval", "interval_count", "trial_period_days"
             )
+        else:
+            # stripe id is required for plan creation,
+            # but can't be changed later
+            readonly_fields = tuple(
+                f for f in readonly_fields if f != "stripe_id")
 
         return readonly_fields
 


### PR DESCRIPTION
Hi,

That PR fixes creation of `Plan` in admin section based at switch of readonly fields in `PlanAdmin` (#590). Covered with tests.