### PR TITLE
Add sync_plans_from_stripe management command

### DIFF
--- a/djstripe/management/commands/djstripe_sync_plans_from_stripe.py
+++ b/djstripe/management/commands/djstripe_sync_plans_from_stripe.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+.. module:: djstripe.management.commands.djstriple_sync_plans_from_stripe.
+
+   :synopsis: dj-stripe - sync_plans_from_stripe command.
+
+.. moduleauthor:: @beheh
+
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.core.management.base import BaseCommand
+
+from ...models import Plan
+
+
+class Command(BaseCommand):
+    """Sync plans from stripe."""
+
+    help = "Sync plans from stripe."
+
+    def handle(self, *args, **options):
+        """Call sync_from_stripe_data for each plan returned by api_list."""
+        for plan_data in Plan.api_list():
+            plan = Plan.sync_from_stripe_data(plan_data)
+            print("Synchronized plan {0}".format(plan.stripe_id))


### PR DESCRIPTION
Hi there! I keep having to look for this command whenever I reprovision my local virtual machine for tests, and whilst everyone seems to be using the following snippet:

```python
from djstripe.models import Plan

for plan in Plan.api_list():
    Plan.sync_from_stripe_data(plan)
```

...it should probably really be a management command.

Regarding tests:
- `Plan.api_list` doesn't have a test, but looks very trivial
- `sync_data_from_stripe_plan` seems to be sufficiently tested, as it's used all around the tests

Happy to take some pointers if/how this should be tested.

Refs  #624, #601, #575, #542 and probably more...