### PR TITLE
Add support for setting STRIPE_API_HOST

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -105,3 +105,22 @@ def check_native_jsonfield_postgres_engine(app_configs=None, **kwargs):
                 ))
 
     return messages
+
+
+@checks.register("djstripe")
+def check_stripe_api_host(app_configs=None, **kwargs):
+    """
+    Check that STRIPE_API_HOST is not being used in production.
+    """
+    from django.conf import settings
+
+    messages = []
+
+    if not settings.DEBUG and hasattr(settings, "STRIPE_API_HOST"):
+        messages.append(checks.Warning(
+            "STRIPE_API_HOST should not be set in production! This is most likely unintended.",
+            hint="Remove STRIPE_API_HOST from your Django settings.",
+            id="djstripe.W002"
+        ))
+
+    return messages

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -100,6 +100,12 @@ else:
     STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_TEST_PUBLIC_KEY", "")
 
 
+# Set STRIPE_API_HOST if you want to use a different Stripe API server
+# Example: https://github.com/stripe/stripe-mock
+if hasattr(settings, "STRIPE_API_HOST"):
+    stripe.api_base = settings.STRIPE_API_HOST
+
+
 def get_default_api_key(livemode):
     """
     Returns the default API key for a value of `livemode`.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -231,3 +231,15 @@ Examples:
 .. code-block:: python
 
     DJSTRIPE_WEBHOOK_EVENT_CALLBACK = 'callbacks.webhook_event_callback'
+
+
+STRIPE_API_HOST (= unset)
+=========================
+
+If set, this sets the base API host for Stripe.
+You may want to set this to, for example, ``"http://localhost:12111"`` if you are
+running `stripe-mock`_.
+
+If this is set in production (DEBUG=False), a warning will be raised on ``manage.py check``.
+
+.. _stripe-mock: https://github.com/stripe/stripe-mock


### PR DESCRIPTION
This allows using a different API base host for development purposes.
For example: https://github.com/stripe/stripe-mock