### PR TITLE
Adding Product.get_or_create

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1375,6 +1375,27 @@ class Product(StripeModel):
     )
     unit_label = models.CharField(max_length=12, default="", blank=True)
 
+    @classmethod
+    def get_or_create(cls, **kwargs):
+        """ Get or create a Product."""
+
+        try:
+            return Product.objects.get(stripe_id=kwargs['stripe_id']), False
+        except Product.DoesNotExist:
+            return cls.create(**kwargs), True
+
+    @classmethod
+    def create(cls, **kwargs):
+        # A few minor things are changed in the api-version of the create call
+        api_kwargs = dict(kwargs)
+        api_kwargs['id'] = api_kwargs['stripe_id']
+        del (api_kwargs['stripe_id'])
+        cls._api_create(**api_kwargs)
+
+        product = Product.objects.create(**kwargs)
+
+        return product
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
Sorry I was hoping to get this into the previous PR before you merged.

Added Product.get_or_create() so it can be used in the same way as Plan.get_or_create().

Tested the two together and have confirmed working using the following code:

```
Plan.get_or_create(
    stripe_id=slugify(self.name),
    product=Product.get_or_create(
        stripe_id=slugify(self.name),
        name=self.name,
        type=enums.ProductType.service,
    )[0],
    amount=self.amount,
    currency="gbp",
    interval="week", 
)
```