### PR TITLE
reduce customer.email length for mysql compatability

### DIFF
--- a/djstripe/migrations/0002_auto_20180627_1121.py
+++ b/djstripe/migrations/0002_auto_20180627_1121.py
@@ -635,7 +635,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='customer',
             name='email',
-            field=models.CharField(blank=True, db_index=True, default='', max_length=5000),
+            field=models.CharField(blank=True, db_index=True, default='', max_length=800),
         ),
         migrations.AlterField(
             model_name='event',

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -398,7 +398,7 @@ class Customer(StripeModel):
         help_text="If a coupon is present and has a limited duration, the date that the discount will end.",
     )
     # </discount>
-    email = models.CharField(max_length=5000, db_index=True, default="", blank=True)
+    email = models.CharField(max_length=800, db_index=True, default="", blank=True)
     shipping = JSONField(
         null=True, blank=True,
         help_text="Shipping information associated with the customer.",


### PR DESCRIPTION
Changed to 800 chars to match Charge.reciept_email - conventionally 254 chars should be long enough (as per Django's EmailField) but I guess there's a reason for this?

Resolves #735 