### PR TITLE
docs: Drop source parameter from Customer.subscribe

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -519,13 +519,6 @@ class Customer(StripeModel):
         """
         Subscribes this customer to a plan.
 
-        Parameters not implemented:
-
-        * **source** - Subscriptions use the customer's default source. Including the source parameter creates \
-                  a new source for this customer and overrides the default source. This functionality is not \
-                  desired; add a source to the customer before attempting to add a subscription. \
-
-
         :param plan: The plan to which to subscribe the customer.
         :type plan: Plan or string (plan ID)
         :param application_fee_percent: This represents the percentage of the subscription invoice subtotal


### PR DESCRIPTION
The source parameter was removed in [2018-08-27][1].

[1]: https://stripe.com/docs/upgrades#2018-07-27