### PR TITLE
Change Coupon.percent_off to be a StripePercentField

### DIFF
--- a/djstripe/migrations/0002_auto_20180627_1121.py
+++ b/djstripe/migrations/0002_auto_20180627_1121.py
@@ -480,6 +480,11 @@ class Migration(migrations.Migration):
             old_name="stripe_id",
             new_name="id",
         ),
+        migrations.AlterField(
+            model_name="coupon",
+            name="percent_off",
+            field=djstripe.fields.StripePercentField(blank=True, decimal_places=2, help_text='Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $100 invoice $50 instead.', max_digits=5, null=True, validators=[django.core.validators.MinValueValidator(1), django.core.validators.MaxValueValidator(100)]),
+        ),
 
         # Update all text-type fields to non-null CharField blank=True default=""
         migrations.AlterField(

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
 import stripe
-from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils import timezone
 from django.utils.text import format_lazy
@@ -52,9 +51,14 @@ class Coupon(StripeModel):
             "Name of the coupon displayed to customers on for instance invoices or receipts."
         ),
     )
-    # This is not a StripePercentField. Only integer values between 1 and 100 are possible.
-    percent_off = models.PositiveIntegerField(
-        null=True, blank=True, validators=[MinValueValidator(1), MaxValueValidator(100)]
+    percent_off = StripePercentField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Percent that will be taken off the subtotal of any invoices for this customer "
+            "for the duration of the coupon. For example, a coupon with percent_off of 50 "
+            "will make a $100 invoice $50 instead."
+        )
     )
     redeem_by = StripeDateTimeField(
         null=True,

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -40,32 +40,40 @@ class HumanReadableCouponTest(TestCase):
 
     def test_human_readable_percent_off_forever(self):
         coupon = Coupon.objects.create(
-            id="coupon-test-percent-off-forever", percent_off=10, currency="usd",
+            id="coupon-test-percent-off-forever", percent_off=10.25, currency="usd",
             duration="forever",
         )
-        self.assertEqual(coupon.human_readable, "10% off forever")
+        self.assertEqual(coupon.human_readable, "10.25% off forever")
         self.assertEqual(str(coupon), coupon.human_readable)
 
     def test_human_readable_percent_off_once(self):
         coupon = Coupon.objects.create(
-            id="coupon-test-percent-off-once", percent_off=10, currency="usd",
+            id="coupon-test-percent-off-once", percent_off=10.25, currency="usd",
             duration="once",
         )
-        self.assertEqual(coupon.human_readable, "10% off once")
+        self.assertEqual(coupon.human_readable, "10.25% off once")
         self.assertEqual(str(coupon), coupon.human_readable)
 
     def test_human_readable_percent_off_one_month(self):
         coupon = Coupon.objects.create(
-            id="coupon-test-percent-off-1month", percent_off=10, currency="usd",
+            id="coupon-test-percent-off-1month", percent_off=10.25, currency="usd",
             duration="repeating", duration_in_months=1,
         )
-        self.assertEqual(coupon.human_readable, "10% off for 1 month")
+        self.assertEqual(coupon.human_readable, "10.25% off for 1 month")
         self.assertEqual(str(coupon), coupon.human_readable)
 
     def test_human_readable_percent_off_three_months(self):
         coupon = Coupon.objects.create(
-            id="coupon-test-percent-off-3month", percent_off=10, currency="usd",
+            id="coupon-test-percent-off-3month", percent_off=10.25, currency="usd",
             duration="repeating", duration_in_months=3,
         )
-        self.assertEqual(coupon.human_readable, "10% off for 3 months")
+        self.assertEqual(coupon.human_readable, "10.25% off for 3 months")
+        self.assertEqual(str(coupon), coupon.human_readable)
+
+    def test_human_readable_integer_percent_off_forever(self):
+        coupon = Coupon.objects.create(
+            id="coupon-test-percent-off-forever", percent_off=10, currency="usd",
+            duration="forever",
+        )
+        self.assertEqual(coupon.human_readable, "10% off forever")
         self.assertEqual(str(coupon), coupon.human_readable)


### PR DESCRIPTION
[2018-07-27][1] changed the percent_off field on coupons to be a float, which means we can just use the StripePercentField here in future.

Does the migration look correct? We're migrating from an integer field in the DB to a decimal field, but I assume that should just work out of the box with Django's migrations.

[1]: https://stripe.com/docs/upgrades#2018-07-27