### PR TITLE
Use trial_period_days associated to a plan when calling Customer.subscribe()

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -562,6 +562,9 @@ class Customer(StripeModel):
         """
         from .billing import Subscription
 
+        if trial_period_days is None:
+            trial_period_days = plan.trial_period_days
+
         # Convert Plan to id
         if isinstance(plan, StripeModel):
             plan = plan.id


### PR DESCRIPTION
Previously, the trial period of a Plan was ignored