### PR TITLE
Cherrypick for stable/1.2: Add trial_from_plan, trial_period_days args to Customer.subscribe()

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -914,7 +914,8 @@ class Customer(StripeObject):
 
     def subscribe(
         self, plan, charge_immediately=True, application_fee_percent=None, coupon=None,
-        quantity=None, metadata=None, tax_percent=None, trial_end=None
+        quantity=None, metadata=None, tax_percent=None, trial_end=None, trial_from_plan=None,
+        trial_period_days=None
     ):
         """
         Subscribes this customer to a plan.
@@ -953,6 +954,14 @@ class Customer(StripeObject):
         :param charge_immediately: Whether or not to charge for the subscription upon creation. If False, an
                                    invoice will be created at the end of this period.
         :type charge_immediately: boolean
+        :param trial_from_plan: Indicates if a plan’s trial_period_days should be applied to the subscription.
+                                Setting trial_end per subscription is preferred, and this defaults to false.
+                                Setting this flag to true together with trial_end is not allowed.
+        :type trial_from_plan: boolean
+        :param trial_period_days: Integer representing the number of trial period days before the customer is
+                                  charged for the first time. This will always overwrite any trials that might
+                                  apply via a subscribed plan.
+        :type trial_period_days: integer
 
         .. Notes:
         .. ``charge_immediately`` is only available on ``Customer.subscribe()``
@@ -973,6 +982,8 @@ class Customer(StripeObject):
             metadata=metadata,
             tax_percent=tax_percent,
             trial_end=trial_end,
+            trial_from_plan=trial_from_plan,
+            trial_period_days=trial_period_days,
         )
 
         if charge_immediately:


### PR DESCRIPTION
I need this feature for a project. It may be useful for others too.

Issue was #709. (cherry picked from commit a38cf044e3cb04158c61fa2be145ca2a809b4d94)

