### PR TITLE
Fix for CancelSubscriptionViewTest on stable/1.2

### DIFF
--- a/djstripe/models.py
+++ b/djstripe/models.py
@@ -2995,7 +2995,7 @@ class Subscription(StripeObject):
 
         return self.update(prorate=False, trial_end=period_end)
 
-    def cancel(self, at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END):
+    def cancel(self, at_period_end=None):
         """
         Cancels this subscription. If you set the at_period_end parameter to true, the subscription will remain active
         until the end of the period, at which point it will be canceled and not renewed. By default, the subscription
@@ -3018,6 +3018,8 @@ class Subscription(StripeObject):
         .. important:: If a subscription is cancelled during a trial period, the ``at_period_end`` flag will be \
         overridden to False so that the trial ends immediately and the customer's card isn't charged.
         """
+        if at_period_end is None:
+            at_period_end = djstripe_settings.CANCELLATION_AT_PERIOD_END
 
         # If plan has trial days and customer cancels before trial period ends, then end subscription now,
         #     i.e. at_period_end=False

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,15 +11,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from copy import deepcopy
 
 from django.contrib.auth import get_user, get_user_model
+from django.test import override_settings
 from django.test.testcases import TestCase
 from django.urls import reverse
 from mock import patch
 
 from djstripe.models import Customer, Plan, Subscription
+from djstripe import settings as djstripe_settings
 
 from . import (
     FAKE_CUSTOMER, FAKE_PLAN, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_CANCELED, FAKE_SUBSCRIPTION_CANCELED_AT_PERIOD_END
 )
+
+try:
+    reload
+except NameError:
+    from importlib import reload
 
 
 class CancelSubscriptionViewTest(TestCase):
@@ -36,31 +43,60 @@ class CancelSubscriptionViewTest(TestCase):
         stripe_customer.subscriber = self.user
         stripe_customer.save()
 
+    def tearDown(self):
+        reload(djstripe_settings)
+
+    # use DJSTRIPE_PRORATION_POLICY=True to get CANCELLATION_AT_PERIOD_END=False
+    @override_settings(DJSTRIPE_PRORATION_POLICY=True)
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
     @patch("djstripe.models.Subscription._api_delete", return_value=FAKE_SUBSCRIPTION_CANCELED)
-    def test_cancel(self, cancel_subscription_mock, customer_retrieve_mock):
-        Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
+    def test_cancel(self, cancel_subscription_mock, subscription_retrieve_mock, customer_retrieve_mock):
+        reload(djstripe_settings)
+
+        subscription = Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
+
+        self.assertFalse(subscription.cancel_at_period_end)
+        self.assertEqual(subscription.status, "active")
 
         response = self.client.post(self.url)
 
-        cancel_subscription_mock.assert_called_once_with(at_period_end=True)
+        subscription.refresh_from_db()
+        self.assertFalse(subscription.cancel_at_period_end)
+        self.assertEqual(subscription.status, "canceled")
+        subscription_retrieve_mock.assert_not_called()
+        cancel_subscription_mock.assert_called_once_with()
+
         self.assertRedirects(response, reverse("home"))
         self.assertTrue(self.user.is_authenticated)
 
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
     @patch("djstripe.models.Subscription._api_delete", return_value=FAKE_SUBSCRIPTION_CANCELED_AT_PERIOD_END)
-    def test_cancel_at_period_end(self, cancel_subscription_mock, customer_retrieve_mock):
-        Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
+    def test_cancel_at_period_end(self, cancel_subscription_mock, subscription_retrieve_mock, customer_retrieve_mock):
+        subscription = Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
+
+        self.assertFalse(subscription.cancel_at_period_end)
 
         response = self.client.post(self.url)
 
-        cancel_subscription_mock.assert_called_once_with(at_period_end=True)
+        subscription.refresh_from_db()
+        self.assertTrue(subscription.cancel_at_period_end)
+
+        # behaviour changed in https://github.com/dj-stripe/dj-stripe/commit/f64af57c1410fcfe03af58b1cb1aace56bb56717
+        subscription_retrieve_mock.assert_called_once()
+        cancel_subscription_mock.assert_not_called()
         self.assertRedirects(response, reverse("home"))
         self.assertTrue(self.user.is_authenticated)
 
+    # use DJSTRIPE_PRORATION_POLICY=True to get CANCELLATION_AT_PERIOD_END=False
+    @override_settings(DJSTRIPE_PRORATION_POLICY=True)
     @patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+    @patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
     @patch("djstripe.models.Subscription._api_delete", return_value=FAKE_SUBSCRIPTION_CANCELED)
-    def test_cancel_next_url(self, cancel_subscription_mock, customer_retrieve_mock):
+    def test_cancel_next_url(self, cancel_subscription_mock, subscription_retrieve_mock, customer_retrieve_mock):
+        reload(djstripe_settings)
+
         Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
 
         response = self.client.post(self.url + "?next=/test")


### PR DESCRIPTION
Resolves #750.

* reload djstripe_settings as per other tests
* changed handling of default param to `Subscription.cancel()` so test reload() in test takes effect

@jleclanche I'm not sure about these changes though, since the behaviour that these tests were checking was changed by f64af57c1410fcfe03af58b1cb1aace56bb56717  

Also, this functionality and test tests have been deleted on master.