### PR TITLE
Fix readthedocs build on master

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,15 @@
+pip>=10.0.1
+setuptools>=39.2.0
+wheel>=0.31.1
+six>=1.11.0
+django>=2.0.5
+stripe>=1.53.0
+python-doc-inherit>=0.3.0
+jsonfield>=2.0.2
+tqdm>=4.8.4
+
+# Docs
+sphinx>=1.7.4
+sphinx_rtd_theme>=0.1.9
+sphinx-autobuild>=0.6.0
+sphinxcontrib-django


### PR DESCRIPTION
restore docs/requirements.txt to fix readthedocs build

Restores from 1214414b527babd675bedb7d7625469cf4d72272, was deleted in 351f46e85ab59330d078f8dda9c2bcd33f3d76c9 - I guess it was deleted by mistake as part of the 1.2.0 release?

Resolves #770 

Tested by doing a scratch readthedocs account and confirming this branch builds.