### PR TITLE
Hooked up SubscriptionItem for multi-plan support

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -148,6 +148,15 @@ class SubscriptionInline(admin.StackedInline):
 	show_change_link = True
 
 
+class SubscriptionItemInline(admin.StackedInline):
+	"""A TabularInline for use models.Subscription."""
+
+	model = models.SubscriptionItem
+	extra = 0
+	readonly_fields = ("id", "created")
+	show_change_link = True
+
+
 class InvoiceItemInline(admin.StackedInline):
 	"""A TabularInline for use InvoiceItem."""
 
@@ -323,6 +332,8 @@ class SubscriptionAdmin(StripeModelAdmin):
 	raw_id_fields = ("customer",)
 	list_display = ("customer", "status")
 	list_filter = ("status", "cancel_at_period_end")
+
+	inlines = (SubscriptionItemInline,)
 
 	def cancel_subscription(self, request, queryset):
 		"""Cancel a subscription."""

--- a/djstripe/migrations/0003_auto_20181117_2328.py
+++ b/djstripe/migrations/0003_auto_20181117_2328.py
@@ -1242,4 +1242,25 @@ class Migration(migrations.Migration):
 				max_length=5000,
 			),
 		),
+		migrations.AlterField(
+			model_name="subscription",
+			name="plan",
+			field=models.ForeignKey(
+				blank=True,
+				help_text="The plan associated with this subscription. This value will be `null` for multi-plan subscriptions",
+				null=True,
+				on_delete=django.db.models.deletion.CASCADE,
+				related_name="subscriptions",
+				to="djstripe.Plan",
+			),
+		),
+		migrations.AlterField(
+			model_name="subscription",
+			name="quantity",
+			field=models.IntegerField(
+				blank=True,
+				help_text="The quantity applied to this subscription. This value will be `null` for multi-plan subscriptions",
+				null=True,
+			),
+		),
 	]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -658,6 +658,56 @@ FAKE_SUBSCRIPTION_III = SubscriptionDict(
 	}
 )
 
+FAKE_SUBSCRIPTION_MULTI_PLAN = SubscriptionDict(
+	{
+		"id": "sub_E79FrmCOtMMxqp",
+		"object": "subscription",
+		"application_fee_percent": None,
+		"billing": "charge_automatically",
+		"cancel_at_period_end": False,
+		"canceled_at": None,
+		"current_period_end": 1546912192,
+		"current_period_start": 1544233792,
+		"customer": "cus_4UbFSo9tl62jqj",
+		"discount": None,
+		"ended_at": None,
+		"metadata": {},
+		"plan": None,
+		"quantity": None,
+		"start": 1544233792,
+		"status": "active",
+		"tax_percent": None,
+		"trial_end": None,
+		"trial_start": None,
+		"items": {
+			"data": [
+				{
+					"created": 1544233793,
+					"id": "si_E79FjMrM7eM0II",
+					"metadata": {},
+					"object": "subscription_item",
+					"plan": deepcopy(FAKE_PLAN),
+					"quantity": 1,
+					"subscription": "sub_E79FrmCOtMMxqp",
+				},
+				{
+					"created": 1544233793,
+					"id": "si_E79FjKZf0GFOs2",
+					"metadata": {},
+					"object": "subscription_item",
+					"plan": deepcopy(FAKE_PLAN_II),
+					"quantity": 1,
+					"subscription": "sub_E79FrmCOtMMxqp",
+				},
+			],
+			"has_more": False,
+			"object": "list",
+			"total_count": 2,
+			"url": "/v1/subscription_items?subscription=sub_E79FrmCOtMMxqp",
+		},
+	}
+)
+
 
 class Sources(object):
 	def __init__(self, card_fakes):
@@ -754,10 +804,10 @@ FAKE_CUSTOMER_II = CustomerDict(
 		},
 		"subscriptions": {
 			"object": "list",
-			"total_count": 1,
+			"total_count": 2,
 			"has_more": False,
 			"url": "/v1/customers/cus_4UbFSo9tl62jqj/subscriptions",
-			"data": [deepcopy(FAKE_SUBSCRIPTION_III)],
+			"data": [deepcopy(FAKE_SUBSCRIPTION_III), deepcopy(FAKE_SUBSCRIPTION_MULTI_PLAN)],
 		},
 	}
 )

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -69,7 +69,6 @@ class SubscriptionSerializerTest(TestCase):
 			data={
 				"id": "sub_6lsC8pt7IcFpjA",
 				"customer": self.customer.djstripe_id,
-				"billing": "charge_automatically",
 				"plan": self.plan.djstripe_id,
 				"start": now,
 				"status": SubscriptionStatus.active,
@@ -79,7 +78,7 @@ class SubscriptionSerializerTest(TestCase):
 		)
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.validated_data, {})
-		self.assertEqual(serializer.errors, {"quantity": ["This field is required."]})
+		self.assertEqual(serializer.errors, {"billing": ["This field is required."]})
 
 
 class CreateSubscriptionSerializerTest(TestCase):


### PR DESCRIPTION
Fixes subscription sync for multi-plan subscriptions, SubscriptionItem sync working.

* Fixes subscription sync for multi-plan subscriptions (https://github.com/dj-stripe/dj-stripe/issues/417#issuecomment-445421748)
  * Added very basic test of a multi-plan subscription
  * Added SubscriptionItem admin to Subscription
* Make Subscription.plan and .quantity nullable
  * Changed serializer test since quantity is now no longer required



