### PR TITLE
Automatic sync of foreign keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -53,6 +53,8 @@ History
 - Text-type fields in dj-stripe will no longer ever be None. Instead, any falsy
   text field will return an empty string.
 - Switched test runner to pytest-django
+- ``StripeModel.sync_from_stripe_data()`` will now automatically retrieve related objects
+  and populate foreign keys.
 
 1.2.1 (2018-07-18)
 ------------------

--- a/djstripe/models/__init__.py
+++ b/djstripe/models/__init__.py
@@ -4,7 +4,6 @@ from .billing import (
 	Invoice,
 	InvoiceItem,
 	Plan,
-	Product,
 	Subscription,
 	SubscriptionItem,
 	UpcomingInvoice,
@@ -26,6 +25,7 @@ from .core import (
 	Event,
 	FileUpload,
 	Payout,
+	Product,
 	Refund,
 )
 from .payment_methods import BankAccount, Card, PaymentMethod, Source

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -936,7 +936,7 @@ class Customer(StripeModel):
 			coupon = coupon.id
 
 		stripe_customer = self.api_retrieve()
-		stripe_customer.coupon = coupon
+		stripe_customer["coupon"] = coupon
 		stripe_customer.save(idempotency_key=idempotency_key)
 		return self.__class__.sync_from_stripe_data(stripe_customer)
 

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -251,9 +251,6 @@ class Card(StripeModel):
 			.auto_paging_iter()
 		)
 
-	def _attach_objects_hook(self, cls, data):
-		self.customer = cls._stripe_object_to_customer(target_cls=Customer, data=data)
-
 	def get_stripe_dashboard_url(self):
 		return self.customer.get_stripe_dashboard_url()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -484,7 +484,7 @@ FAKE_CHARGE = ChargeDict(
 		"failure_code": None,
 		"failure_message": None,
 		"fraud_details": {},
-		"invoice": "in_7udnik28sj829dj",
+		"invoice": "in_16YHls2eZvKYlo2CwwH968Mc",
 		"livemode": False,
 		"metadata": {},
 		"order": None,

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -11,10 +11,13 @@ from stripe.error import InvalidRequestError
 from djstripe.exceptions import StripeObjectManipulationException
 from djstripe.models import Card
 
-from . import FAKE_CARD, FAKE_CARD_III, FAKE_CARD_V, FAKE_CUSTOMER, default_account
+from . import (
+	FAKE_CARD, FAKE_CARD_III, FAKE_CARD_V, FAKE_CUSTOMER,
+	AssertStripeFksMixin, default_account
+)
 
 
-class CardTest(TestCase):
+class CardTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.account = default_account()
 		self.user = get_user_model().objects.create_user(
@@ -50,6 +53,8 @@ class CardTest(TestCase):
 			),
 			str(card),
 		)
+
+		self.assert_fks(card, expected_blank_fks={"djstripe.Customer.coupon"})
 
 	@patch("stripe.Token.create")
 	def test_card_create_token(self, token_create_mock):

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -11,10 +11,13 @@ from django.test.testcases import TestCase
 from djstripe.enums import ChargeStatus, LegacySourceType
 from djstripe.models import Account, Charge, Dispute, PaymentMethod
 
-from . import FAKE_ACCOUNT, FAKE_CHARGE, FAKE_CUSTOMER, FAKE_TRANSFER, default_account
+from . import (
+	FAKE_ACCOUNT, FAKE_CHARGE, FAKE_CUSTOMER, FAKE_INVOICE,
+	FAKE_SUBSCRIPTION, FAKE_TRANSFER, AssertStripeFksMixin, default_account
+)
 
 
-class ChargeTest(TestCase):
+class ChargeTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.user = get_user_model().objects.create_user(
 			username="user", email="user@example.com"
@@ -67,8 +70,31 @@ class ChargeTest(TestCase):
 		captured_charge = charge.capture()
 		self.assertTrue(captured_charge.captured)
 
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.invoice",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
 	@patch("djstripe.models.Account.get_default_account")
-	def test_sync_from_stripe_data(self, default_account_mock):
+	@patch("stripe.BalanceTransaction.retrieve")
+	@patch("stripe.Charge.retrieve")
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	def test_sync_from_stripe_data(
+		self,
+		subscription_retrieve_mock,
+		invoice_retrieve_mock,
+		charge_retrieve_mock,
+		balance_transaction_retrieve_mock,
+		default_account_mock,
+	):
 		default_account_mock.return_value = self.account
 
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
@@ -87,8 +113,33 @@ class ChargeTest(TestCase):
 		self.assertEqual("card_16YKQh2eZvKYlo2Cblc5Feoo", charge.source_id)
 		self.assertEqual(charge.source.type, LegacySourceType.card)
 
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
+	@patch("stripe.BalanceTransaction.retrieve")
+	@patch("stripe.Charge.retrieve")
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("djstripe.models.Account.get_default_account")
-	def test_sync_from_stripe_data_max_amount(self, default_account_mock):
+	def test_sync_from_stripe_data_max_amount(
+		self,
+		default_account_mock,
+		subscription_retrieve_mock,
+		invoice_retrieve_mock,
+		charge_retrieve_mock,
+		balance_transaction_retrieve_mock,
+	):
 		default_account_mock.return_value = self.account
 
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
@@ -104,8 +155,33 @@ class ChargeTest(TestCase):
 		self.assertEqual(False, charge.disputed)
 		self.assertEqual(0, charge.amount_refunded)
 
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
 	@patch("djstripe.models.Account.get_default_account")
-	def test_sync_from_stripe_data_unsupported_source(self, default_account_mock):
+	@patch("stripe.BalanceTransaction.retrieve")
+	@patch("stripe.Charge.retrieve")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+	def test_sync_from_stripe_data_unsupported_source(
+		self,
+		invoice_retrieve_mock,
+		subscription_retrieve_mock,
+		charge_retrieve_mock,
+		balance_transaction_retrieve_mock,
+		default_account_mock,
+	):
 		default_account_mock.return_value = self.account
 
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
@@ -116,23 +192,69 @@ class ChargeTest(TestCase):
 		self.assertEqual("unsupported", charge.source.type)
 		self.assertEqual(charge.source, PaymentMethod.objects.get(id="test_id"))
 
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
 	@patch("djstripe.models.Account.get_default_account")
-	def test_sync_from_stripe_data_no_customer(self, default_account_mock):
+	@patch("stripe.BalanceTransaction.retrieve")
+	@patch("stripe.Charge.retrieve")
+	def test_sync_from_stripe_data_no_customer(
+		self, charge_retrieve_mock, balance_transaction_retrieve_mock, default_account_mock
+	):
 		default_account_mock.return_value = self.account
 
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
+
 		fake_charge_copy.pop("customer", None)
+		# remove invoice since it requires a customer
+		fake_charge_copy.pop("invoice", None)
 
 		Charge.sync_from_stripe_data(fake_charge_copy)
 		assert Charge.objects.count() == 1
 		charge = Charge.objects.get()
 		assert charge.customer is None
 
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.customer",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.invoice",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
+	@patch("stripe.BalanceTransaction.retrieve")
 	@patch("stripe.Charge.retrieve")
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
 	@patch("stripe.Transfer.retrieve")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("djstripe.models.Account.get_default_account")
 	def test_sync_from_stripe_data_with_transfer(
-		self, default_account_mock, transfer_retrieve_mock, charge_retrieve_mock
+		self,
+		default_account_mock,
+		subscription_retrieve_mock,
+		transfer_retrieve_mock,
+		invoice_retrieve_mock,
+		charge_retrieve_mock,
+		balance_transaction_retrieve_mock,
 	):
 		default_account_mock.return_value = self.account
 
@@ -144,28 +266,65 @@ class ChargeTest(TestCase):
 		transfer_retrieve_mock.return_value = fake_transfer
 		charge_retrieve_mock.return_value = fake_charge_copy
 
-		charge, created = Charge._get_or_create_from_stripe_object(fake_charge_copy)
+		charge, created = Charge._get_or_create_from_stripe_object(
+			fake_charge_copy, current_ids={fake_charge_copy["id"]}
+		)
 		self.assertTrue(created)
 
 		self.assertNotEqual(None, charge.transfer)
 		self.assertEqual(fake_transfer["id"], charge.transfer.id)
 
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)
+
 	@patch("stripe.Charge.retrieve")
 	@patch("stripe.Account.retrieve")
+	@patch("stripe.BalanceTransaction.retrieve")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
 	def test_sync_from_stripe_data_with_destination(
-		self, account_retrieve_mock, charge_retrieve_mock
+		self,
+		invoice_retrieve_mock,
+		subscription_retrieve_mock,
+		balance_transaction_retrieve_mock,
+		account_retrieve_mock,
+		charge_retrieve_mock,
 	):
 		account_retrieve_mock.return_value = FAKE_ACCOUNT
 
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
 		fake_charge_copy.update({"destination": FAKE_ACCOUNT["id"]})
 
-		charge_retrieve_mock.return_value = fake_charge_copy
-
-		charge, created = Charge._get_or_create_from_stripe_object(fake_charge_copy)
+		charge, created = Charge._get_or_create_from_stripe_object(
+			fake_charge_copy, current_ids={fake_charge_copy["id"]}
+		)
 		self.assertTrue(created)
 
 		self.assertEqual(2, Account.objects.count())
 		account = Account.objects.get(id=FAKE_ACCOUNT["id"])
 
 		self.assertEqual(account, charge.account)
+
+		charge_retrieve_mock.assert_not_called()
+		balance_transaction_retrieve_mock.assert_not_called()
+
+		self.assert_fks(
+			charge,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Plan.product",
+			},
+		)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -2,6 +2,7 @@
 dj-stripe Decorator Tests.
 """
 from copy import deepcopy
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
@@ -13,7 +14,7 @@ from django.test.client import RequestFactory
 from djstripe.decorators import subscription_payment_required
 from djstripe.models import Subscription
 
-from . import FAKE_CUSTOMER, FAKE_SUBSCRIPTION, FUTURE_DATE
+from . import FAKE_CUSTOMER, FAKE_PLAN, FAKE_SUBSCRIPTION, FUTURE_DATE
 
 
 class TestSubscriptionPaymentRequired(TestCase):
@@ -49,7 +50,8 @@ class TestSubscriptionPaymentRequired(TestCase):
 		response = self.test_view(request)
 		self.assertEqual(response.status_code, 302)
 
-	def test_user_active_subscription(self):
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
+	def test_user_active_subscription(self, plan_retrieve_mock):
 		user = get_user_model().objects.create_user(
 			username="pydanny", email="pydanny@gmail.com"
 		)

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -66,7 +66,16 @@ class TestChargeEvents(EventTestCase):
 	@patch("djstripe.models.Account.get_default_account")
 	@patch("stripe.Charge.retrieve")
 	@patch("stripe.Event.retrieve")
-	def test_charge_created(self, event_retrieve_mock, charge_retrieve_mock, account_mock):
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	def test_charge_created(
+		self,
+		subscription_retrieve_mock,
+		invoice_retrieve_mock,
+		event_retrieve_mock,
+		charge_retrieve_mock,
+		account_mock,
+	):
 		FAKE_CUSTOMER.create_for_user(self.user)
 		fake_stripe_event = deepcopy(FAKE_EVENT_CHARGE_SUCCEEDED)
 		event_retrieve_mock.return_value = fake_stripe_event

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -10,16 +10,15 @@ from djstripe.models import InvoiceItem
 
 from . import (
 	FAKE_CHARGE_II, FAKE_CUSTOMER_II, FAKE_INVOICE_II, FAKE_INVOICEITEM,
-	FAKE_PLAN_II, FAKE_SUBSCRIPTION_III, default_account
+	FAKE_PLAN_II, FAKE_SUBSCRIPTION_III, AssertStripeFksMixin, default_account
 )
 
 
-class InvoiceItemTest(TestCase):
+class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.account = default_account()
 
 	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
 	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
@@ -30,7 +29,6 @@ class InvoiceItemTest(TestCase):
 		charge_retrieve_mock,
 		customer_retrieve_mock,
 		subscription_retrieve_mock,
-		plan_retrieve_mock,
 		default_account_mock,
 	):
 		default_account_mock.return_value = self.account
@@ -72,7 +70,18 @@ class InvoiceItemTest(TestCase):
 		invoiceitem_data.update({"subscription": FAKE_SUBSCRIPTION_III["id"]})
 		invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
 
-		self.assertEqual(FAKE_SUBSCRIPTION_III["id"], invoiceitem.subscription.id)
+		self.assert_fks(
+			invoiceitem,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Customer.subscriber",
+				"djstripe.Plan.product",
+				"djstripe.InvoiceItem.plan",
+			},
+		)
 
 	@patch("djstripe.models.Account.get_default_account")
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
@@ -96,3 +105,16 @@ class InvoiceItemTest(TestCase):
 		invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
 
 		self.assertEqual(FAKE_PLAN_II["id"], invoiceitem.plan.id)
+
+		self.assert_fks(
+			invoiceitem,
+			expected_blank_fks={
+				"djstripe.Account.business_logo",
+				"djstripe.Charge.dispute",
+				"djstripe.Charge.transfer",
+				"djstripe.Customer.coupon",
+				"djstripe.Customer.subscriber",
+				"djstripe.InvoiceItem.subscription",
+				"djstripe.Plan.product",
+			},
+		)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -12,7 +12,7 @@ from djstripe.admin import PlanAdmin
 from djstripe.models import Plan
 from djstripe.settings import STRIPE_SECRET_KEY
 
-from . import FAKE_PLAN, FAKE_PLAN_II
+from . import FAKE_PLAN, FAKE_PLAN_II, AssertStripeFksMixin
 
 
 class TestPlanAdmin(TestCase):
@@ -69,7 +69,7 @@ class TestPlanAdmin(TestCase):
 		Plan.objects.get(name=self.plan.name)
 
 
-class PlanTest(TestCase):
+class PlanTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.plan_data = deepcopy(FAKE_PLAN)
 		self.plan = Plan.sync_from_stripe_data(self.plan_data)
@@ -99,6 +99,10 @@ class PlanTest(TestCase):
 		plan = Plan.sync_from_stripe_data(stripe_plan)
 		assert plan.amount_in_cents == plan.amount * 100
 		assert isinstance(plan.amount_in_cents, int)
+
+		self.assert_fks(
+			plan, expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"}
+		)
 
 
 class HumanReadablePlanTest(TestCase):

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -14,12 +14,13 @@ from djstripe.enums import SubscriptionStatus
 from djstripe.models import Plan, Subscription
 
 from . import (
-	FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_PLAN, FAKE_PLAN_II, FAKE_SUBSCRIPTION,
-	FAKE_SUBSCRIPTION_CANCELED, FAKE_SUBSCRIPTION_MULTI_PLAN, datetime_to_unix
+	FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_PLAN, FAKE_PLAN_II,
+	FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_CANCELED,
+	FAKE_SUBSCRIPTION_MULTI_PLAN, AssertStripeFksMixin, datetime_to_unix
 )
 
 
-class SubscriptionTest(TestCase):
+class SubscriptionTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.user = get_user_model().objects.create_user(
 			username="pydanny", email="pydanny@gmail.com"
@@ -35,6 +36,11 @@ class SubscriptionTest(TestCase):
 		self.assertEqual(
 			str(subscription),
 			"{email} on {plan}".format(email=self.user.email, plan=str(subscription.plan)),
+		)
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
 		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
@@ -56,6 +62,11 @@ class SubscriptionTest(TestCase):
 		self.assertTrue(self.customer.has_active_subscription())
 		self.assertTrue(self.customer.has_any_active_subscription())
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
 	def test_is_status_temporarily_current_false(
@@ -72,6 +83,11 @@ class SubscriptionTest(TestCase):
 		self.assertTrue(subscription in self.customer.active_subscriptions)
 		self.assertTrue(self.customer.has_active_subscription())
 		self.assertTrue(self.customer.has_any_active_subscription())
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -90,6 +106,11 @@ class SubscriptionTest(TestCase):
 		self.assertFalse(subscription in self.customer.active_subscriptions)
 		self.assertFalse(self.customer.has_active_subscription())
 		self.assertFalse(self.customer.has_any_active_subscription())
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
@@ -115,6 +136,11 @@ class SubscriptionTest(TestCase):
 		self.assertTrue(self.customer.has_active_subscription())
 		self.assertTrue(self.customer.has_any_active_subscription())
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -129,6 +155,11 @@ class SubscriptionTest(TestCase):
 
 		self.assertFalse(self.customer.has_active_subscription())
 		self.assertFalse(self.customer.has_any_active_subscription())
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
@@ -152,6 +183,11 @@ class SubscriptionTest(TestCase):
 		self.assertTrue(self.customer.has_active_subscription())
 		self.assertTrue(self.customer.has_any_active_subscription())
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -166,6 +202,11 @@ class SubscriptionTest(TestCase):
 		new_subscription = subscription.update(quantity=4)
 
 		self.assertEqual(4, new_subscription.quantity)
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
@@ -184,6 +225,11 @@ class SubscriptionTest(TestCase):
 
 		self.assertEqual(Decimal(0.0), new_subscription.tax_percent)
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -199,6 +245,13 @@ class SubscriptionTest(TestCase):
 		new_subscription = subscription.update(plan=new_plan)
 
 		self.assertEqual(FAKE_PLAN_II["id"], new_subscription.plan.id)
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
+		self.assert_fks(new_plan, expected_blank_fks={"djstripe.Plan.product"})
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
@@ -233,6 +286,11 @@ class SubscriptionTest(TestCase):
 		self.assertFalse(new_subscription in self.customer.active_subscriptions)
 		self.assertFalse(self.customer.has_active_subscription())
 		self.assertFalse(self.customer.has_any_active_subscription())
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
@@ -272,6 +330,11 @@ class SubscriptionTest(TestCase):
 		self.assertTrue(self.customer.has_active_subscription())
 		self.assertTrue(self.customer.has_any_active_subscription())
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
@@ -303,6 +366,11 @@ class SubscriptionTest(TestCase):
 		self.assertFalse(new_subscription.is_valid())
 		self.assertFalse(self.customer.has_active_subscription())
 		self.assertFalse(self.customer.has_any_active_subscription())
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
 	@patch("stripe.Subscription.retrieve")
@@ -337,6 +405,11 @@ class SubscriptionTest(TestCase):
 		)
 		self.assertEqual(reactivated_subscription.cancel_at_period_end, False)
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("djstripe.models.Subscription._api_delete")
 	@patch(
 		"stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_CANCELED)
@@ -355,6 +428,11 @@ class SubscriptionTest(TestCase):
 		subscription.cancel(at_period_end=False)
 		self.assertEqual(Subscription.objects.filter(status="canceled").count(), 1)
 
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
+
 	@patch("djstripe.models.Subscription._api_delete")
 	def test_cancel_error_in_cancel(self, subscription_delete_mock):
 		subscription_delete_mock.side_effect = InvalidRequestError("Unexpected error", "blah")
@@ -364,6 +442,11 @@ class SubscriptionTest(TestCase):
 
 		with self.assertRaises(InvalidRequestError):
 			subscription.cancel(at_period_end=False)
+
+		self.assert_fks(
+			subscription,
+			expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"},
+		)
 
 	@patch("stripe.Plan.retrieve")
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))


### PR DESCRIPTION
* Special handling needed for InvoiceItem to avoid recursive Charge<->Invoice dependency
* Removed redundant _attach_objects_hook's
    
Testing:
    
* Added a test method to recursively check that all ForeignKeys not in a whitelist are set
* Added a bunch of retrieve mocks since we're now fetching more

Resolves #681

Also a few other semi-related fixes as separate commits:

*  Fix inconsistent fake invoice id, to match FAKE_INVOICE
*   Patch Customer.save() to emulate stripe API .coupon -> .discount + Access coupon using dict style for consistency with test
