### PR TITLE
Add MySQL support to test settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,24 +1,56 @@
 import os
 
+test_db_vendor = os.environ.get("DJSTRIPE_TEST_DB_VENDOR", "postgres")
 test_db_name = os.environ.get("DJSTRIPE_TEST_DB_NAME", "djstripe")
-test_db_user = os.environ.get("DJSTRIPE_TEST_DB_USER", "postgres")
+test_db_user = os.environ.get("DJSTRIPE_TEST_DB_USER", test_db_vendor)
 test_db_pass = os.environ.get("DJSTRIPE_TEST_DB_PASS", "")
+test_db_host = os.environ.get("DJSTRIPE_TEST_DB_HOST", "localhost")
 
 DEBUG = True
 SECRET_KEY = "djstripe"
 SITE_ID = 1
 TIME_ZONE = "UTC"
 USE_TZ = True
-DATABASES = {
-	"default": {
-		"ENGINE": "django.db.backends.postgresql_psycopg2",
-		"NAME": test_db_name,
-		"USER": test_db_user,
-		"PASSWORD": test_db_pass,
-		"HOST": "localhost",
-		"PORT": "",
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(PROJECT_DIR)
+
+
+if test_db_vendor == "postgres":
+	DATABASES = {
+		"default": {
+			"ENGINE": "django.db.backends.postgresql_psycopg2",
+			"NAME": test_db_name,
+			"USER": test_db_user,
+			"PASSWORD": test_db_pass,
+			"HOST": test_db_host,
+			"PORT": "",
+		}
 	}
-}
+elif test_db_vendor == "mysql":
+	DATABASES = {
+		"default": {
+			"ENGINE": "django.db.backends.mysql",
+			"NAME": test_db_name,
+			"USER": test_db_user,
+			"PASSWORD": test_db_pass,
+			"HOST": test_db_host,
+			"PORT": "",
+		}
+	}
+elif test_db_vendor == "sqlite":
+	# sqlite is not officially supported, but useful for quick testing.
+	# may be dropped if we can't maintain compatibility.
+	DATABASES = {
+		"default": {
+			"ENGINE": "django.db.backends.sqlite3",
+			"NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+			# use a on-disk db for test so --reuse-db can be used
+			"TEST": {"NAME": os.path.join(BASE_DIR, "test_db.sqlite3")},
+		}
+	}
+else:
+	raise NotImplementedError("DJSTRIPE_TEST_DB_VENDOR = {}".format(test_db_vendor))
+
 
 TEMPLATES = [
 	{


### PR DESCRIPTION
Adds enviroment var `DJSTRIPE_TEST_DB_VENDOR` (default=postgres) and `DJSTRIPE_TEST_DB_HOST` (since localhost is a magic value for mysql), so that tests can be run vs MySQL and sqlite.

sqlite is useful for quick local tests runs (especially with `--reuse-db`), it's not intended to be supported for anything else.