### PR TITLE
Run pytest coverage from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 passenv = DJSTRIPE_*
 setenv =
 	PYTHONWARNINGS = all
+	PYTEST_ADDOPTS = --cov --cov-fail-under=95
 commands = pytest {posargs}
 deps =
 	django20: Django>=2.0,<2.1
@@ -64,7 +65,6 @@ deps =
 
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
-addopts = --cov --cov-fail-under=95
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Instead of in default pytest options, this avoids coverage interfering with debugging tests.

Without this change PyCharm won't hit breakpoints.