### PR TITLE
Fix an apparent minor test bug - unused variable

### DIFF
--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -74,7 +74,7 @@ class ChargeTest(TestCase):
 		fake_charge_copy = deepcopy(FAKE_CHARGE)
 		fake_charge_copy.update({"application_fee": {"amount": 0}})
 
-		charge = Charge.sync_from_stripe_data(FAKE_CHARGE)
+		charge = Charge.sync_from_stripe_data(fake_charge_copy)
 
 		self.assertEqual(Decimal("22"), charge.amount)
 		self.assertEqual(True, charge.paid)


### PR DESCRIPTION
Looked like a small test bug, the variable `fake_charge_copy` wasn't being used before (I didn't look into the history as to why).

Possibly it should just be removed instead in this case.