### PR TITLE
Make Plan.amount nullable, to support tiered plans

### DIFF
--- a/djstripe/migrations/0003_auto_20181117_2328.py
+++ b/djstripe/migrations/0003_auto_20181117_2328.py
@@ -1263,4 +1263,15 @@ class Migration(migrations.Migration):
 				null=True,
 			),
 		),
+		migrations.AlterField(
+			model_name="plan",
+			name="amount",
+			field=djstripe.fields.StripeDecimalCurrencyAmountField(
+				blank=True,
+				decimal_places=2,
+				help_text="Amount to be charged on the interval specified.",
+				max_digits=8,
+				null=True,
+			),
+		),
 	]

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -655,7 +655,7 @@ class Plan(StripeModel):
 		),
 	)
 	amount = StripeDecimalCurrencyAmountField(
-		help_text="Amount to be charged on the interval specified."
+		null=True, blank=True, help_text="Amount to be charged on the interval specified."
 	)
 	billing_scheme = StripeEnumField(
 		enum=enums.PlanBillingScheme,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -704,6 +704,28 @@ FAKE_PLAN_II = {
 	"usage_type": "licensed",
 }
 
+FAKE_TIER_PLAN = {
+	"id": "tier21323",
+	"object": "plan",
+	"active": True,
+	"amount": None,
+	"created": 1386247539,
+	"currency": "usd",
+	"interval": "month",
+	"interval_count": 1,
+	"livemode": False,
+	"metadata": {},
+	"name": "New plan name",
+	"statement_descriptor": None,
+	"trial_period_days": None,
+	"usage_type": "licensed",
+	"tiers_mode": "graduated",
+	"tiers": [
+		{"flat_amount": 4900, "unit_amount": 1000, "up_to": 5},
+		{"flat_amount": None, "unit_amount": 900, "up_to": None},
+	],
+}
+
 
 class SubscriptionDict(dict):
 	def __setattr__(self, name, value):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -12,7 +12,7 @@ from djstripe.admin import PlanAdmin
 from djstripe.models import Plan
 from djstripe.settings import STRIPE_SECRET_KEY
 
-from . import FAKE_PLAN, FAKE_PLAN_II, AssertStripeFksMixin
+from . import FAKE_PLAN, FAKE_PLAN_II, FAKE_TIER_PLAN, AssertStripeFksMixin
 
 
 class TestPlanAdmin(TestCase):
@@ -99,6 +99,18 @@ class PlanTest(AssertStripeFksMixin, TestCase):
 		plan = Plan.sync_from_stripe_data(stripe_plan)
 		assert plan.amount_in_cents == plan.amount * 100
 		assert isinstance(plan.amount_in_cents, int)
+
+		self.assert_fks(
+			plan, expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"}
+		)
+
+	@patch("stripe.Plan.retrieve")
+	def test_stripe_tier_plan(self, plan_retrieve_mock):
+		tier_plan_data = deepcopy(FAKE_TIER_PLAN)
+		plan = Plan.sync_from_stripe_data(tier_plan_data)
+		self.assertEqual(plan.id, tier_plan_data["id"])
+		self.assertIsNone(plan.amount)
+		self.assertIsNotNone(plan.tiers)
 
 		self.assert_fks(
 			plan, expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"}


### PR DESCRIPTION
Based on @dantium's #808 (which applied to stable/1.2).

Resolves #781 on master.

I've not used tiered plans in my Stripe work so any testing feedback on this would be useful.