### PR TITLE
Made deprecated Invoice fields nullable

### DIFF
--- a/djstripe/migrations/0003_auto_20181117_2328.py
+++ b/djstripe/migrations/0003_auto_20181117_2328.py
@@ -1274,4 +1274,20 @@ class Migration(migrations.Migration):
 				null=True,
 			),
 		),
+		migrations.AlterField(
+			model_name="invoice",
+			name="closed",
+			field=models.NullBooleanField(
+				default=False,
+				help_text="Whether or not the invoice is still trying to collect payment. An invoice is closed if it's either paid or it has been marked closed. A closed invoice will no longer attempt to collect payment.",
+			),
+		),
+		migrations.AlterField(
+			model_name="invoice",
+			name="forgiven",
+			field=models.NullBooleanField(
+				default=False,
+				help_text="Whether or not the invoice has been forgiven. Forgiving an invoice instructs us to update the subscription status as if the invoice were successfully paid. Once an invoice has been forgiven, it cannot be unforgiven or reopened.",
+			),
+		),
 	]

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -194,6 +194,39 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 	@patch("djstripe.models.Account.get_default_account")
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
 	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+	def test_status_forgiven_deprecated(
+		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
+	):
+		# forgiven parameter deprecated in API 2018-11-08 - see https://stripe.com/docs/upgrades#2018-11-08
+		default_account_mock.return_value = self.account
+
+		invoice_data = deepcopy(FAKE_INVOICE)
+		invoice_data.update({"paid": False, "closed": False})
+		invoice_data.pop("forgiven")
+		invoice_data["status"] = "uncollectible"
+		invoice = Invoice.sync_from_stripe_data(invoice_data)
+
+		self.assertEqual(Invoice.STATUS_FORGIVEN, invoice.status)
+
+	@patch("djstripe.models.Account.get_default_account")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+	def test_status_forgiven_default(
+		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
+	):
+		# forgiven parameter deprecated in API 2018-11-08 - see https://stripe.com/docs/upgrades#2018-11-08
+		default_account_mock.return_value = self.account
+
+		invoice_data = deepcopy(FAKE_INVOICE)
+		invoice_data.update({"paid": False, "closed": False})
+		invoice_data.pop("forgiven")
+		invoice = Invoice.sync_from_stripe_data(invoice_data)
+
+		self.assertEqual(Invoice.STATUS_OPEN, invoice.status)
+
+	@patch("djstripe.models.Account.get_default_account")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
 	def test_status_closed(
 		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
 	):
@@ -215,6 +248,40 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 				"djstripe.Plan.product",
 			},
 		)
+
+	@patch("djstripe.models.Account.get_default_account")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+	def test_status_closed_deprecated(
+		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
+	):
+		# closed parameter deprecated in API 2018-11-08 - see https://stripe.com/docs/upgrades#2018-11-08
+		default_account_mock.return_value = self.account
+
+		invoice_data = deepcopy(FAKE_INVOICE)
+		invoice_data.update({"paid": False})
+		invoice_data["auto_advance"] = not invoice_data.pop("closed")
+
+		invoice = Invoice.sync_from_stripe_data(invoice_data)
+
+		self.assertEqual(Invoice.STATUS_CLOSED, invoice.status)
+
+	@patch("djstripe.models.Account.get_default_account")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+	def test_status_closed_default(
+		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
+	):
+		# closed parameter deprecated in API 2018-11-08 - see https://stripe.com/docs/upgrades#2018-11-08
+		default_account_mock.return_value = self.account
+
+		invoice_data = deepcopy(FAKE_INVOICE)
+		invoice_data.update({"paid": False})
+		invoice_data.pop("closed")
+
+		invoice = Invoice.sync_from_stripe_data(invoice_data)
+
+		self.assertEqual(Invoice.STATUS_OPEN, invoice.status)
 
 	@patch("djstripe.models.Account.get_default_account")
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))


### PR DESCRIPTION
Ported forwards test from stable/1.2 (#773)

I'm not sure how deprecated fields are usually handled, I guess once `DEFAULT_STRIPE_API_VERSION` is >= "2018-11-08" these columns can be removed?