### PR TITLE
Allow billing_cycle_anchor argument when creating a subscription

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1048,6 +1048,7 @@ class Subscription(StripeModel):
 		self,
 		plan=None,
 		application_fee_percent=None,
+		billing_cycle_anchor=None,
 		coupon=None,
 		prorate=djstripe_settings.PRORATION_POLICY,
 		proration_date=None,
@@ -1061,6 +1062,12 @@ class Subscription(StripeModel):
 
 		:param plan: The plan to which to subscribe the customer.
 		:type plan: Plan or string (plan ID)
+		:param application_fee_percent:
+		:type application_fee_percent:
+		:param billing_cycle_anchor:
+		:type billing_cycle_anchor:
+		:param coupon:
+		:type coupon:
 		:param prorate: Whether or not to prorate when switching plans. Default is True.
 		:type prorate: boolean
 		:param proration_date:
@@ -1070,6 +1077,14 @@ class Subscription(StripeModel):
 			logic, such as prorating by day instead of by second, by providing the time that you
 			wish to use for proration calculations.
 		:type proration_date: datetime
+		:param metadata:
+		:type metadata:
+		:param quantity:
+		:type quantity:
+		:param tax_percent:
+		:type tax_percent:
+		:param trial_end:
+		:type trial_end:
 
 		.. note:: The default value for ``prorate`` is the DJSTRIPE_PRORATION_POLICY setting.
 

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -518,6 +518,7 @@ class Customer(StripeModel):
 		quantity=None,
 		metadata=None,
 		tax_percent=None,
+		billing_cycle_anchor=None,
 		trial_end=None,
 		trial_from_plan=None,
 		trial_period_days=None,
@@ -544,6 +545,11 @@ class Customer(StripeModel):
 			be calculated and added as tax to the final amount each billing period.
 		:type tax_percent: Decimal. Precision is 2; anything more will be ignored. A positive decimal
 			between 1 and 100.
+		:param billing_cycle_anchor: A future timestamp to anchor the subscription’s billing cycle.
+			This is used to determine the date of the first full invoice, and,
+			for plans with month or year intervals, the day of the month for
+			subsequent invoices.
+		:type billing_cycle_anchor: datetime
 		:param trial_end: The end datetime of the trial period the customer will get before being charged for
 			the first time. If set, this will override the default trial period of the plan the
 			customer is being subscribed to. The special value ``now`` can be provided to end
@@ -579,6 +585,7 @@ class Customer(StripeModel):
 			coupon=coupon,
 			quantity=quantity,
 			metadata=metadata,
+			billing_cycle_anchor=billing_cycle_anchor,
 			tax_percent=tax_percent,
 			trial_end=trial_end,
 			trial_from_plan=trial_from_plan,


### PR DESCRIPTION
Fixes #814