### PR TITLE
Sync refunds on Charge

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -516,6 +516,30 @@ class StripeModel(models.Model):
 
 		return subscriptionitems
 
+	@classmethod
+	def _stripe_object_to_refunds(cls, target_cls, data, charge):
+		"""
+		Retrieves Refunds for a charge
+		:param target_cls: The target class to instantiate per invoice item.
+		:type target_cls: ``Refund``
+		:param data: The data dictionary received from the Stripe API.
+		:type data: dict
+		:param charge: The charge object that refunds are for.
+		:type invoice: ``djstripe.models.Refund``
+		:return:
+		"""
+
+		refunds = data.get("refunds")
+		if not refunds:
+			return []
+
+		refund_objs = []
+		for refund_data in refunds.get("data", []):
+			item, _ = target_cls._get_or_create_from_stripe_object(refund_data, refetch=False)
+			refund_objs.append(item)
+
+		return refund_objs
+
 	def _sync(self, record_data):
 		for attr, value in record_data.items():
 			setattr(self, attr, value)

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -346,6 +346,11 @@ class Charge(StripeModel):
 		if "destination" in data and data["destination"]:
 			return target_cls._get_or_create_from_stripe_object(data, "destination")[0]
 
+	def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+		super()._attach_objects_post_save_hook(cls, data, pending_relations=pending_relations)
+
+		cls._stripe_object_to_refunds(target_cls=Refund, data=data, charge=self)
+
 
 class Customer(StripeModel):
 	"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -599,6 +599,50 @@ FAKE_CHARGE_II = ChargeDict(
 	}
 )
 
+FAKE_CHARGE_REFUNDED = deepcopy(FAKE_CHARGE)
+FAKE_CHARGE_REFUNDED = FAKE_CHARGE_REFUNDED.refund(
+	amount=FAKE_CHARGE_REFUNDED["amount"]
+)
+
+FAKE_REFUND = {
+	"id": "re_1E0he8KatMEEd8456454S01Vc",
+	"object": "refund",
+	"amount": FAKE_CHARGE_REFUNDED["amount_refunded"],
+	"balance_transaction": "txn_1E0he8KaGRDEd998TDswMZuN",
+	"charge": FAKE_CHARGE_REFUNDED["id"],
+	"created": 1549425864,
+	"currency": "usd",
+	"metadata": {},
+	"reason": None,
+	"receipt_number": None,
+	"source_transfer_reversal": None,
+	"status": "succeeded",
+	"transfer_reversal": None,
+}
+
+# Balance transaction associated with the refund
+FAKE_BALANCE_TRANSACTION_REFUND = {
+	"id": "txn_1E0he8KaGRDEd998TDswMZuN",
+	"amount": -1 * FAKE_CHARGE_REFUNDED["amount_refunded"],
+	"available_on": 1549425864,
+	"created": 1549425864,
+	"currency": "usd",
+	"description": "REFUND FOR CHARGE (Payment for invoice G432DF1C-0028)",
+	"exchange_rate": None,
+	"fee": 0,
+	"fee_details": [],
+	"net": -1 * FAKE_CHARGE_REFUNDED["amount_refunded"],
+	"object": "balance_transaction",
+	"source": FAKE_REFUND["id"],
+	"status": "available",
+	"type": "refund",
+}
+
+
+FAKE_CHARGE_REFUNDED["refunds"].update(
+	{"total_count": 1, "data": [deepcopy(FAKE_REFUND)]}
+)
+
 
 FAKE_COUPON = {
 	"id": "fake-coupon-1",


### PR DESCRIPTION
So charge.refunded webhook will create Refund objects.

Resolves #667