### PR TITLE
Update versions - drop py34, added Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ matrix:
   fast_finish: true
 
   include:
-    - { python: "3.4", env: TOXENV=py34-django20 }
+    - { python: "3.5", env: TOXENV=py35-django20 }
     - { python: "3.5", env: TOXENV=py35-django21 }
+    - { python: "3.5", env: TOXENV=py35-django22 }
     - { python: "3.6", env: TOXENV=py36-django20 }
     - { python: "3.6", env: TOXENV=py36-django21 }
+    - { python: "3.6", env: TOXENV=py36-django22 }
+    - { python: "3.7", env: TOXENV=py37-django20 }
     - { python: "3.7", env: TOXENV=py37-django21 }
+    - { python: "3.7", env: TOXENV=py37-django22 }
     - { python: "3.7", env: TOXENV=py37-djangomaster }
     - { python: "3.7", env: TOXENV=checkmigrations }
     - { python: "3.7", env: TOXENV=flake8 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
 	Framework :: Django
 	Framework :: Django :: 2.0
 	Framework :: Django :: 2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-	py34-django20
-	py35-django{20,21,master}
-	py36-django{20,21,master}
-	py36-django20-checkmigrations
+	py35-django{20,21,22}
+	py36-django{20,21,22}
+	py37-django{20,21,22,master}
+	py37-django21-checkmigrations
 	flake8
 
 [testenv]
@@ -15,6 +15,7 @@ commands = pytest {posargs}
 deps =
 	django20: Django>=2.0,<2.1
 	django21: Django>=2.1,<2.2
+	django22: Django>=2.2b1,<2.3
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	djangorestframework
 	psycopg2
@@ -33,12 +34,12 @@ commands =
 [testenv:checkmigrations]
 commands = python makemigrations.py --check
 deps =
-	Django>=2.0,<2.1
+	Django>=2.1,<2.2
 
 [testenv:makemigrations]
 commands = python makemigrations.py
 deps =
-	Django>=2.0,<2.1
+	Django>=2.1,<2.2
 
 [testenv:makemessages]
 whitelist_externals = mkdir
@@ -47,7 +48,7 @@ commands =
 	- mkdir -p {toxinidir}/djstripe/locale
 	- django-admin.py makemessages {posargs}
 deps =
-	Django>=2.0,<2.1
+	Django>=2.1,<2.2
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Keeping Django 2.0 for now for coverage of a Django<2.1 code path
