### PR TITLE
Fix signal handler creation for transfer.reversed

### DIFF
--- a/djstripe/signals.py
+++ b/djstripe/signals.py
@@ -130,7 +130,7 @@ WEBHOOK_SIGNALS = dict(
 			"topup.reversed",
 			"topup.succeeded",
 			"transfer.created",
-			"transfer.reversed" "transfer.reversed",
+			"transfer.reversed",
 			"transfer.updated",
 			"ping",
 		]


### PR DESCRIPTION
As you can see it looks like a copy-paste error, this fixes it.