### PR TITLE
Rename PaymentMethod -> DjstripePaymentMethod

### DIFF
--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -89,7 +89,7 @@ def customer_source_webhook_handler(event):
 			# NOTE: for now, customer.sources still points to Card
 			# Also, https://github.com/dj-stripe/dj-stripe/issues/576
 			models.Card.objects.filter(id=customer_data.get("id", "")).delete()
-			models.PaymentMethod.objects.filter(id=customer_data.get("id", "")).delete()
+			models.DjstripePaymentMethod.objects.filter(id=customer_data.get("id", "")).delete()
 		else:
 			_handle_crud_like_event(target_cls=models.Card, event=event)
 

--- a/djstripe/fields.py
+++ b/djstripe/fields.py
@@ -17,7 +17,7 @@ else:
 
 class PaymentMethodForeignKey(models.ForeignKey):
 	def __init__(self, **kwargs):
-		kwargs.setdefault("to", "PaymentMethod")
+		kwargs.setdefault("to", "DjstripePaymentMethod")
 		super().__init__(**kwargs)
 
 

--- a/djstripe/migrations/0003_auto_20181117_2328.py
+++ b/djstripe/migrations/0003_auto_20181117_2328.py
@@ -7,6 +7,19 @@ import djstripe.fields
 
 
 class Migration(migrations.Migration):
+	def __init__(self, *args, **kwargs):
+		try:
+			# Hack to support sqlite for quick testing. Without this migrations fail with:
+			#    "django.db.utils.NotSupportedError: Renaming the 'djstripe_paymentmethod' table while in a transaction
+			#    is not supported on SQLite because it would break referential integrity.
+			#    Try adding `atomic = False` to the Migration class."
+			from django.db import connection
+
+			if connection.vendor == "sqlite":
+				self.atomic = False
+		except Exception:
+			pass
+		super().__init__(*args, **kwargs)
 
 	dependencies = [("djstripe", "0002_auto_20180627_1121")]
 

--- a/djstripe/migrations/0003_auto_20181117_2328.py
+++ b/djstripe/migrations/0003_auto_20181117_2328.py
@@ -1290,4 +1290,12 @@ class Migration(migrations.Migration):
 				help_text="Whether or not the invoice has been forgiven. Forgiving an invoice instructs us to update the subscription status as if the invoice were successfully paid. Once an invoice has been forgiven, it cannot be unforgiven or reopened.",
 			),
 		),
+		migrations.AlterModelTable(name="PaymentMethod", table="djstripe_paymentmethod"),
+		migrations.RenameModel(old_name="PaymentMethod", new_name="DjstripePaymentMethod"),
+		migrations.CreateModel(
+			name="PaymentMethod",
+			fields=[],
+			options={"proxy": True, "indexes": []},
+			bases=("djstripe.djstripepaymentmethod",),
+		),
 	]

--- a/djstripe/models/__init__.py
+++ b/djstripe/models/__init__.py
@@ -28,7 +28,13 @@ from .core import (
 	Product,
 	Refund,
 )
-from .payment_methods import BankAccount, Card, PaymentMethod, Source
+from .payment_methods import (
+	BankAccount,
+	Card,
+	DjstripePaymentMethod,
+	PaymentMethod,
+	Source,
+)
 from .sigma import ScheduledQueryRun
 from .webhooks import WebhookEventTrigger
 
@@ -45,6 +51,7 @@ __all__ = [
 	"Coupon",
 	"Customer",
 	"Dispute",
+	"DjstripePaymentMethod",
 	"Event",
 	"FileUpload",
 	"IdempotencyKey",

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -9,7 +9,9 @@ from django.contrib.auth import get_user_model
 from django.test.testcases import TestCase
 
 from djstripe.enums import ChargeStatus, LegacySourceType
-from djstripe.models import Account, Charge, Dispute, PaymentMethod
+from djstripe.models import (
+	Account, Charge, Dispute, DjstripePaymentMethod, PaymentMethod
+)
 
 from . import (
 	FAKE_ACCOUNT, FAKE_BALANCE_TRANSACTION, FAKE_BALANCE_TRANSACTION_REFUND, FAKE_CHARGE,
@@ -333,7 +335,10 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 		charge = Charge.sync_from_stripe_data(fake_charge_copy)
 		self.assertEqual("test_id", charge.source_id)
 		self.assertEqual("unsupported", charge.source.type)
-		self.assertEqual(charge.source, PaymentMethod.objects.get(id="test_id"))
+		self.assertEqual(charge.source, DjstripePaymentMethod.objects.get(id="test_id"))
+
+		with self.assertWarns(DeprecationWarning):
+			self.assertEqual(charge.source, PaymentMethod.objects.get(id="test_id"))
 
 		charge_retrieve_mock.assert_not_called()
 		balance_transaction_retrieve_mock.assert_not_called()

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -14,7 +14,7 @@ from stripe.error import InvalidRequestError
 from djstripe import settings as djstripe_settings
 from djstripe.exceptions import MultipleSubscriptionException
 from djstripe.models import (
-	Card, Charge, Coupon, Customer, Invoice, PaymentMethod, Plan, Subscription
+	Card, Charge, Coupon, Customer, DjstripePaymentMethod, Invoice, Plan, Subscription
 )
 from djstripe.settings import STRIPE_SECRET_KEY
 
@@ -38,7 +38,9 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 		)
 		self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
-		self.payment_method, _ = PaymentMethod._get_or_create_source(FAKE_CARD, "card")
+		self.payment_method, _ = DjstripePaymentMethod._get_or_create_source(
+			FAKE_CARD, "card"
+		)
 		self.card = self.payment_method.resolve()
 
 		self.customer.default_source = self.payment_method
@@ -94,7 +96,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 		self.assertEqual(0, synced_customer.sources.count())
 		self.assertEqual(
 			synced_customer.default_source,
-			PaymentMethod.objects.get(id=fake_customer["default_source"]["id"]),
+			DjstripePaymentMethod.objects.get(id=fake_customer["default_source"]["id"]),
 		)
 
 	def test_customer_sync_has_subscriber_metadata(self):

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -9,8 +9,8 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from djstripe.models import (
-	Card, Charge, Coupon, Customer, Dispute, Event, Invoice,
-	InvoiceItem, PaymentMethod, Plan, Subscription, Transfer
+	Card, Charge, Coupon, Customer, Dispute, DjstripePaymentMethod,
+	Event, Invoice, InvoiceItem, Plan, Subscription, Transfer
 )
 
 from . import (
@@ -183,7 +183,7 @@ class TestCustomerEvents(EventTestCase):
 		)
 
 	def test_customer_default_source_deleted(self):
-		self.customer.default_source = PaymentMethod.objects.get(id=FAKE_CARD["id"])
+		self.customer.default_source = DjstripePaymentMethod.objects.get(id=FAKE_CARD["id"])
 		self.customer.save()
 		self.assertIsNotNone(self.customer.default_source)
 		self.assertTrue(self.customer.has_valid_source())


### PR DESCRIPTION
To avoid clash with upcoming stripe object - resolves #841

* Preserve the existing table name to hopefully reduce migration pain (I wouldn't object to a table rename as well)
* Added DeprecationWarning on `PaymentMethod.__init__`, via a proxy model
* Tested on mysql
* added a migration hack to support SQlite (cheeky I know, my app uses sqlite for quick testing, but I think this is safe)