### PR TITLE
Update documentation to reflect API version used in Stripe requests.

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -2,7 +2,7 @@
 Settings
 ========
 
-STRIPE_API_VERSION (='2017-02-14')
+STRIPE_API_VERSION (='2018-05-21')
 ==================================
 
 The API version used to communicate with the Stripe API is configurable, and


### PR DESCRIPTION
Just update the version documentation to the latest version used.

https://github.com/dj-stripe/dj-stripe/blob/4490fda09e5888da82499f1e17ecf883b00b36c6/djstripe/settings.py#L12

~According to the [documentation](https://dj-stripe.readthedocs.io/en/stable-2.0/reference/settings.html#stripe-api-version-2017-02-14) `STRIPE_API_VERSION` defaults to the latest version that has been tested as working, which is 2019-02-19 now.~