### PR TITLE
Only pre-sync the InvoiceItem.invoice on first sync + fixed issue with sync of expanded

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.0.1 (unreleased)
+------------------
+
+This is a bugfix-only version:
+
+- Fixed an error on ``invoiceitem.updated`` (#848).
+
 2.0.0 (2019-03-01)
 ------------------
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -575,7 +575,7 @@ class StripeModel(models.Model):
 
 		if data.get(field_name, None):
 			# stop nested objects from trying to retrieve this object before initial sync is complete
-			current_ids.add(data.get(field_name))
+			current_ids.add(cls._id_from_data(data.get(field_name)))
 
 		instance, created = cls._get_or_create_from_stripe_object(
 			data, field_name=field_name, current_ids=current_ids

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dj-stripe
-version = 2.0.0
+version = 2.0.1.dev0
 description = Django + Stripe Made Easy
 author = Alexander Kavanaugh
 author_email = alex@kavdev.io

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -93,6 +93,48 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 		)
 
 	@patch("djstripe.models.Account.get_default_account")
+	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
+	@patch("stripe.Invoice.retrieve")
+	def test_sync_expanded_invoice_with_subscription(
+		self,
+		invoice_retrieve_mock,
+		charge_retrieve_mock,
+		customer_retrieve_mock,
+		subscription_retrieve_mock,
+		default_account_mock,
+	):
+		default_account_mock.return_value = self.account
+
+		invoiceitem_data = deepcopy(FAKE_INVOICEITEM)
+		# Expand the Invoice data
+		invoiceitem_data.update(
+			{
+				"subscription": FAKE_SUBSCRIPTION_III["id"],
+				"invoice": deepcopy(dict(FAKE_INVOICE_II)),
+			}
+		)
+		invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
+
+		expected_blank_fks = {
+			"djstripe.Account.business_logo",
+			"djstripe.Charge.dispute",
+			"djstripe.Charge.transfer",
+			"djstripe.Customer.coupon",
+			"djstripe.Customer.subscriber",
+			"djstripe.Plan.product",
+			"djstripe.InvoiceItem.plan",
+		}
+
+		self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
+
+		# Coverage of sync of existing data
+		invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
+
+		self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
+
+	@patch("djstripe.models.Account.get_default_account")
 	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
 	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
 	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))


### PR DESCRIPTION
Avoids problem with the dummy invoice data we're passing in if the Invoice is already in the database.  Resolves #848

This function was already a bit hacky, and this is making it a bit hackier.  The bug is that the `data` param we're passing to `Invoice.sync_from_stripe_data()` isn't a close enough match for what stripe would send - it's enough to cause a sync of Invoice from stripe if it doesn't exist yet in the DB, but if it's already in the DB we hit the `if not created:` code path in `sync_from_stripe_data`, which fails.

This PR works around this by only doing the pre-emptive sync_from_stripe_data if it's needed.

If we didn't have the special case of `InvoiceItem.sync_from_stripe_data` this wouldn't be needed - maybe there's a smarter way of handling that.
