### PR TITLE
Handle test webhook properly in recent versions of Stripe

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ History
 This is a bugfix-only version:
 
 - Fixed an error on ``invoiceitem.updated`` (#848).
+- Handle test webhook properly in recent versions of Stripe API (#779).
+  At some point 2018 Stripe silently changed the ID used for test events and
+  ``evt_00000000000000`` is not used anymore.
 
 2.0.0 (2019-03-01)
 ------------------

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -124,7 +124,8 @@ class WebhookEventTrigger(models.Model):
 
 	@property
 	def is_test_event(self):
-		return self.json_body.get("id").endswith("_00000000000000")
+		event_id = self.json_body.get("id")
+		return event_id and event_id.endswith("_00000000000000")
 
 	def validate(self, api_key=None):
 		"""

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -7,7 +7,6 @@ from django.db import models
 from django.utils.functional import cached_property
 
 from .. import settings as djstripe_settings
-from .. import webhooks
 from ..context_managers import stripe_temporary_api_version
 from ..fields import JSONField
 from ..signals import webhook_processing_error

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -124,7 +124,7 @@ class WebhookEventTrigger(models.Model):
 
 	@property
 	def is_test_event(self):
-		return self.json_body.get("id") == webhooks.TEST_EVENT_ID
+		return self.json_body.get("id").endswith("_00000000000000")
 
 	def validate(self, api_key=None):
 		"""

--- a/djstripe/webhooks.py
+++ b/djstripe/webhooks.py
@@ -25,6 +25,8 @@ __all__ = ["handler", "handler_all", "call_handlers"]
 registrations = defaultdict(list)
 registrations_global = list()
 
+# Legacy. In previous versions of Stripe API, all test events used this ID.
+# Check out issue #779 for more information.
 TEST_EVENT_ID = "evt_00000000000000"
 
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -222,13 +222,10 @@ class TestWebhook(TestCase):
 	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
 	@patch("stripe.Event.retrieve")
 	def test_webhook_good(
-		self, event_retrieve_mock, transfer_retrieve_mock
+		self, event_retrieve_mock, transfer_retrieve_mock, verify_signature_mock
 	):
-		fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
-		event_retrieve_mock.return_value = fake_event
+		resp = self._send_event(FAKE_EVENT_TRANSFER_CREATED)
 
-		djstripe_settings.WEBHOOK_SECRET = ""
-		resp = self._send_event(fake_event)
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(Event.objects.count(), 1)
 		self.assertEqual(WebhookEventTrigger.objects.count(), 1)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -224,6 +224,7 @@ class TestWebhook(TestCase):
 	def test_webhook_good(
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
+		djstripe_settings.WEBHOOK_SECRET = ""
 		resp = self._send_event(FAKE_EVENT_TRANSFER_CREATED)
 
 		self.assertEqual(resp.status_code, 200)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -225,7 +225,10 @@ class TestWebhook(TestCase):
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
 		djstripe_settings.WEBHOOK_SECRET = ""
-		resp = self._send_event(FAKE_EVENT_TRANSFER_CREATED)
+
+		fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
+		event_retrieve_mock.return_value = fake_event
+		resp = self._send_event(fake_event)
 
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(Event.objects.count(), 1)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,7 @@ class TestWebhook(TestCase):
 		self.assertEqual(WebhookEventTrigger.objects.count(), 1)
 		event_trigger = WebhookEventTrigger.objects.first()
 		self.assertEqual(event_trigger.remote_ip, "0.0.0.0")
+		self.assertEqual(event_trigger.is_test_event, True)
 
 	@patch("djstripe.models.WebhookEventTrigger.validate", return_value=True)
 	@patch("djstripe.models.WebhookEventTrigger.process")
@@ -178,6 +179,7 @@ class TestWebhook(TestCase):
 		self.assertEqual(WebhookEventTrigger.objects.count(), 1)
 		event_trigger = WebhookEventTrigger.objects.first()
 		self.assertEqual(event_trigger.exception, exception_message)
+		self.assertEqual(event_trigger.is_test_event, False)
 
 	@patch.object(
 		djstripe_settings, "WEBHOOK_EVENT_CALLBACK", return_value=mock_webhook_handler

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -222,7 +222,7 @@ class TestWebhook(TestCase):
 	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
 	@patch("stripe.Event.retrieve")
 	def test_webhook_good(
-		self, event_retrieve_mock, transfer_retrieve_mock, verify_signature_mock
+		self, event_retrieve_mock, transfer_retrieve_mock
 	):
 		resp = self._send_event(FAKE_EVENT_TRANSFER_CREATED)
 


### PR DESCRIPTION
Fixes #779

Apparently Stripe used to send test events with id `evt_00000000000000`. However it recent versions of the API this behavior has changed and the event id changes depending on the event type.

For example `account.external_account.created` test events come with id `account.external_00000000000000`. Similarly for `charge.expired` events, event id is `charge.expired_00000000000000`.

This change fixes test event handling in recent versions while keeps backward compatibility with previous event ids.