### PR TITLE
Handle missing SubscriptionItem.quantity on metered plans

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,7 @@ This is a bugfix-only version:
   At some point 2018 Stripe silently changed the ID used for test events and
   ``evt_00000000000000`` is not used anymore.
 - Fixed OperationalError seen in migration 0003 on postgres (#850).
+- Fixup missing ``SubscriptionItem.quantity`` on Plans with ``usage_type="metered"`` (#865).
 
 2.0.0 (2019-03-01)
 ------------------

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1199,6 +1199,7 @@ class SubscriptionItem(StripeModel):
 		related_name="subscription_items",
 		help_text="The plan the customer is subscribed to.",
 	)
+	# TODO - quantity should be nullable, since it's not set for metered plans
 	quantity = models.PositiveIntegerField(
 		help_text=("The quantity of the plan to which the customer should be subscribed.")
 	)
@@ -1208,6 +1209,14 @@ class SubscriptionItem(StripeModel):
 		related_name="items",
 		help_text="The subscription this subscription item belongs to.",
 	)
+
+	@classmethod
+	def _manipulate_stripe_object_hook(cls, data):
+		# for metered plans quantity isn't set, so should be nullable
+		# arguably this should default to 1 instead of 0 (to match subscription)
+		data["quantity"] = data.get("quantity") or 0
+
+		return data
 
 
 class UsageRecord(StripeModel):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -770,6 +770,27 @@ FAKE_TIER_PLAN = {
 	],
 }
 
+FAKE_PLAN_METERED = {
+	"id": "plan_fakemetered",
+	"object": "plan",
+	"active": True,
+	"aggregate_usage": "sum",
+	"amount": 200,
+	"billing_scheme": "per_unit",
+	"created": 1552632817,
+	"currency": "usd",
+	"interval": "month",
+	"interval_count": 1,
+	"livemode": False,
+	"metadata": {},
+	"nickname": "Sum Metered Plan",
+	"tiers": None,
+	"tiers_mode": None,
+	"transform_usage": None,
+	"trial_period_days": None,
+	"usage_type": "metered",
+}
+
 
 class SubscriptionDict(dict):
 	def __setattr__(self, name, value):
@@ -778,7 +799,7 @@ class SubscriptionDict(dict):
 
 		# Special case for plan
 		if name == "plan":
-			for plan in [FAKE_PLAN, FAKE_PLAN_II]:
+			for plan in [FAKE_PLAN, FAKE_PLAN_II, FAKE_TIER_PLAN, FAKE_PLAN_METERED]:
 				if value == plan["id"]:
 					value = plan
 
@@ -921,6 +942,43 @@ FAKE_SUBSCRIPTION_MULTI_PLAN = SubscriptionDict(
 			"total_count": 2,
 			"url": "/v1/subscription_items?subscription=sub_E79FrmCOtMMxqp",
 		},
+	}
+)
+
+
+FAKE_SUBSCRIPTION_METERED = SubscriptionDict(
+	{
+		"id": "sub_1rn1dp7WgjMtx9",
+		"object": "subscription",
+		"application_fee_percent": None,
+		"billing": "charge_automatically",
+		"cancel_at_period_end": False,
+		"canceled_at": None,
+		"current_period_end": 1441907581,
+		"current_period_start": 1439229181,
+		"customer": "cus_6lsBvm5rJ0zyHc",
+		"discount": None,
+		"ended_at": None,
+		"metadata": {},
+		"items": {
+			"data": [
+				{
+					"created": 1441907581,
+					"id": "si_UXYmKmJp6aWTw6",
+					"metadata": {},
+					"object": "subscription_item",
+					"plan": deepcopy(FAKE_PLAN_METERED),
+					"subscription": "sub_1rn1dp7WgjMtx9",
+				}
+			]
+		},
+		"plan": deepcopy(FAKE_PLAN_METERED),
+		"quantity": 1,
+		"start": 1439229181,
+		"status": "active",
+		"tax_percent": None,
+		"trial_end": None,
+		"trial_start": None,
 	}
 )
 


### PR DESCRIPTION
Weirdly in the data from Stripe, `Subscription.quantity = 1` but `Subscription.items.quantity` isn't set.

I'm thinking that there's some legacy support reason for `Subscription.quantity = 1`, but that we should aim to change `SubscriptionItem.quantity` to nullable in a future migration, so it seems like a better idea to set it to 0 rather than 1 here for now.

Fixes #865