### PR TITLE
Fix Plan.create

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -109,6 +109,10 @@ class StripeModel(models.Model):
 		:type api_key: string
 		"""
 
+		for key in kwargs:
+			if isinstance(kwargs[key], StripeModel):
+				kwargs[key] = kwargs[key].id
+
 		return cls.stripe_class.create(api_key=api_key, **kwargs)
 
 	def _api_delete(self, api_key=None, **kwargs):

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -109,10 +109,6 @@ class StripeModel(models.Model):
 		:type api_key: string
 		"""
 
-		for key in kwargs:
-			if isinstance(kwargs[key], StripeModel):
-				kwargs[key] = kwargs[key].id
-
 		return cls.stripe_class.create(api_key=api_key, **kwargs)
 
 	def _api_delete(self, api_key=None, **kwargs):

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -799,9 +799,9 @@ class Plan(StripeModel):
 		# A few minor things are changed in the api-version of the create call
 		api_kwargs = dict(kwargs)
 		api_kwargs["amount"] = int(api_kwargs["amount"] * 100)
-		cls._api_create(**api_kwargs)
 
-		plan = Plan.objects.create(**kwargs)
+		stripe_plan = cls._api_create(**api_kwargs)
+		plan = cls.sync_from_stripe_data(stripe_plan)
 
 		return plan
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -800,6 +800,9 @@ class Plan(StripeModel):
 		api_kwargs = dict(kwargs)
 		api_kwargs["amount"] = int(api_kwargs["amount"] * 100)
 
+		if isinstance(api_kwargs.get("product"), StripeModel):
+			api_kwargs["product"] = api_kwargs["product"].id
+
 		stripe_plan = cls._api_create(**api_kwargs)
 		plan = cls.sync_from_stripe_data(stripe_plan)
 


### PR DESCRIPTION
Allows Plan.create to accept product as any of a string id, dj-stripe object, or stripe dict.

* Use sync_from_stripe_data in Plan.create() for consistency
* Make StripeModel._api_create() convert any djstripe object kwargs to id
* Added test of Plan.create() with product as id, dj-stripe object, or stripe dict

Resolves #870