### PR TITLE
Make the squashed migration a normal one since the old migrations are gone

### DIFF
--- a/djstripe/migrations/0003_auto_20181117_2328_squashed_0004_auto_20190227_2114.py
+++ b/djstripe/migrations/0003_auto_20181117_2328_squashed_0004_auto_20190227_2114.py
@@ -103,11 +103,6 @@ class Migration(migrations.Migration):
 
 		super().__init__(*args, **kwargs)
 
-	replaces = [
-		("djstripe", "0003_auto_20181117_2328"),
-		("djstripe", "0004_auto_20190227_2114"),
-	]
-
 	dependencies = [("djstripe", "0002_auto_20180627_1121")]
 
 	operations = [


### PR DESCRIPTION
* This is per the django migration docs for squashed migrations:
  https://docs.djangoproject.com/en/dev/topics/migrations/#squashing-migrations

This fixes #882 and now un-applying and re-applying the djstripe migrations works as expected.