### PR TITLE
Don't save event objects if the webhook processing fails

### DIFF
--- a/docs/usage/webhooks.rst
+++ b/docs/usage/webhooks.rst
@@ -12,6 +12,7 @@ or trial period is ending.
 This is how you use them:
 
 .. code-block:: python
+
     from djstripe import webhooks
 
     @webhooks.handler("customer.subscription.trial_will_end")
@@ -22,6 +23,7 @@ This is how you use them:
 You can handle all events related to customers like this:
 
 .. code-block:: python
+
     from djstripe import webhooks
 
     @webhooks.handler("customer")
@@ -32,6 +34,7 @@ You can handle all events related to customers like this:
 You can also handle different events in the same handler:
 
 .. code-block:: python
+
     from djstripe import webhooks
 
     @webhooks.handler("plan", "product")
@@ -41,8 +44,29 @@ You can also handle different events in the same handler:
 .. warning:: In order to get registrations picked up, you need to put them in a module is imported like models.py or make sure you import it manually.
 
 
+Webhook event creation and processing is now wrapped in a ``transaction.atomic()`` block to better handle webhook errors.
+This will prevent any additional database modifications you may perform in your custom handler from being committed should
+something in the webhook processing chain fail. You can also take advantage of Django's ``transaction.on_commit()`` function
+to only perform an action if the transaction successfully commits (meaning the Event processing worked):
+
+.. code-block:: python
+
+    from django.db import transaction
+    from djstripe import webhooks
+
+    def do_something():
+        pass  # send a mail, invalidate a cache, fire off a Celery task, etc.
+
+    @webhooks.handler("plan", "product")
+    def my_handler(event, **kwargs):
+        transaction.on_commit(do_something)
+
+
 Official documentation
 ----------------------
 
 Stripe docs for types of Events: https://stripe.com/docs/api/events/types
+
 Stripe docs for Webhooks: https://stripe.com/docs/webhooks
+
+Django docs for transactions: https://docs.djangoproject.com/en/dev/topics/db/transactions/#performing-actions-after-commit

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -52,6 +52,57 @@ class EventTest(TestCase):
 		event.valid = False
 		event.invoke_webhook_handlers()
 
+	@patch(target="djstripe.models.core.transaction.atomic", autospec=True)
+	@patch.object(target=Event, attribute="_create_from_stripe_object", autospec=True)
+	@patch.object(target=Event, attribute="objects", autospec=True)
+	def test_process_event(
+		self, mock_objects, mock__create_from_stripe_object, mock_atomic
+	):
+		"""Test that process event creates a new event and invokes webhooks
+		when the event doesn't already exist.
+		"""
+		# Set up mocks
+		mock_objects.filter.return_value.exists.return_value = False
+		mock_data = {"id": "foo_id", "other_stuff": "more_things"}
+
+		result = Event.process(data=mock_data)
+
+		# Check that all the expected work was performed
+		mock_objects.filter.assert_called_once_with(id=mock_data["id"])
+		mock_objects.filter.return_value.exists.assert_called_once_with()
+		mock_atomic.return_value.__enter__.assert_called_once_with()
+		mock__create_from_stripe_object.assert_called_once_with(mock_data)
+		mock__create_from_stripe_object.return_value.invoke_webhook_handlers.assert_called_once_with()
+		# Make sure the event was returned.
+		self.assertEqual(mock__create_from_stripe_object.return_value, result)
+
+	@patch(target="djstripe.models.core.transaction.atomic", autospec=True)
+	@patch.object(target=Event, attribute="_create_from_stripe_object", autospec=True)
+	@patch.object(target=Event, attribute="objects", autospec=True)
+	def test_process_event_exists(
+		self, mock_objects, mock__create_from_stripe_object, mock_atomic
+	):
+		"""Test that process event returns the existing event and skips webhook processing
+		when the event already exists.
+		"""
+		# Set up mocks
+		mock_objects.filter.return_value.exists.return_value = True
+		mock_data = {"id": "foo_id", "other_stuff": "more_things"}
+
+		result = Event.process(data=mock_data)
+
+		# Make sure that the db was queried and the existing results used.
+		mock_objects.filter.assert_called_once_with(id=mock_data["id"])
+		mock_objects.filter.return_value.exists.assert_called_once_with()
+		mock_objects.filter.return_value.first.assert_called_once_with()
+		# Make sure the webhook actions and event object creation were not performed.
+		mock_atomic.return_value.__enter__.assert_not_called()
+		# Using assert_not_called() doesn't work on this in Python 3.5
+		self.assertEqual(mock__create_from_stripe_object.call_count, 0)
+		mock__create_from_stripe_object.return_value.invoke_webhook_handlers.assert_not_called()
+		# Make sure the existing event was returned.
+		self.assertEqual(mock_objects.filter.return_value.first.return_value, result)
+
 	#
 	# Helpers
 	#


### PR DESCRIPTION
An attempt at fixing #832. The `transaction.atomic()` should also provide the added benefit of rolling back any database operations that were performed in any handlers that succeeded before an exception was raised, preventing database inconsistencies.

This doesn't help with any partial webhook handler processing that wasn't database related. Handling that properly would require some sort of webhook handler rollback hook so that registered webhook handlers could (optionally) rollback any non-database operations on a failure.