### PR TITLE
Fallback to 0.0.0.0 if REMOTE_ADDR is an empty string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 This is a bugfix-only version:
 
 - Don't save event objects if the webhook processing fails (#832).
+- Fixed IntegrityError when ``REMOTE_ADDR`` is an empty string.
 
 2.0.1 (2019-04-29)
 ------------------

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -80,7 +80,7 @@ class WebhookEventTrigger(models.Model):
 			body = "(error decoding body)"
 
 		ip = request.META.get("REMOTE_ADDR")
-		if ip is None:
+		if not ip:
 			warnings.warn(
 				"Could not determine remote IP (missing REMOTE_ADDR). "
 				"This is likely an issue with your wsgi/server setup."

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -169,7 +169,7 @@ class TestWebhook(TestCase):
 		self.assertEqual(resp.status_code, 400)
 		self.assertEqual(WebhookEventTrigger.objects.count(), 0)
 
-	def test_webhook_no_remote_addr(self):
+	def test_webhook_remote_addr_is_none(self):
 		self.assertEqual(WebhookEventTrigger.objects.count(), 0)
 		with warnings.catch_warnings():
 			warnings.simplefilter("ignore")
@@ -179,6 +179,22 @@ class TestWebhook(TestCase):
 				content_type="application/json",
 				HTTP_STRIPE_SIGNATURE="PLACEHOLDER",
 				REMOTE_ADDR=None,
+			)
+
+		self.assertEqual(WebhookEventTrigger.objects.count(), 1)
+		event_trigger = WebhookEventTrigger.objects.first()
+		self.assertEqual(event_trigger.remote_ip, "0.0.0.0")
+
+	def test_webhook_remote_addr_is_empty_string(self):
+		self.assertEqual(WebhookEventTrigger.objects.count(), 0)
+		with warnings.catch_warnings():
+			warnings.simplefilter("ignore")
+			Client().post(
+				reverse("djstripe:webhook"),
+				"{}",
+				content_type="application/json",
+				HTTP_STRIPE_SIGNATURE="PLACEHOLDER",
+				REMOTE_ADDR="",
 			)
 
 		self.assertEqual(WebhookEventTrigger.objects.count(), 1)


### PR DESCRIPTION
It complements 5ebc785543136479d7062523fb67ff8d4796c161 which fixes the
issue when REMOTE_ADDR evaluates to None. It appears that on some
environment it can also be an empty string. With this change, both cases
are supported.

See also #640