### PR TITLE
Enable autospec=True on patch

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ Updated to API VERSION 2016-03-07 with bogus fields.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import sys
 from copy import deepcopy
 from datetime import datetime
 
@@ -18,6 +19,23 @@ from djstripe.webhooks import TEST_EVENT_ID
 logger = logging.getLogger(__name__)
 
 FUTURE_DATE = datetime(2100, 4, 30, tzinfo=timezone.utc)
+
+
+# Flags for various bugs with mock autospec
+# These can be removed once we drop support for the affected python versions
+
+# Don't try and use autospec=True on staticmethods on <py39
+# TODO - enable for appropriate minor versions of py3.7/3.8 once this is live
+# see https://bugs.python.org/issue23078
+IS_STATICMETHOD_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 9)
+
+# Don't try and use autospec=True with assert_called etc on py3.5
+# see https://bugs.python.org/issue28380
+IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 6)
+
+# Don't try and use autospec=True for functions that have a exception side-effect on py3.4
+# see https://bugs.python.org/issue23661
+IS_EXCEPTION_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 5)
 
 
 class AssertStripeFksMixin:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -9,12 +9,15 @@ from django.test.testcases import TestCase
 from djstripe.models import Account
 from djstripe.settings import STRIPE_SECRET_KEY
 
-from . import FAKE_ACCOUNT, FAKE_FILEUPLOAD, AssertStripeFksMixin
+from . import (
+	FAKE_ACCOUNT, FAKE_FILEUPLOAD,
+	IS_STATICMETHOD_AUTOSPEC_SUPPORTED, AssertStripeFksMixin
+)
 
 
 class TestAccount(AssertStripeFksMixin, TestCase):
-	@patch("stripe.Account.retrieve")
-	@patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD))
+	@patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+	@patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD), autospec=True)
 	def test_get_connected_account_from_token(
 		self, fileupload_retrieve_mock, account_retrieve_mock
 	):
@@ -26,8 +29,10 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(account, expected_blank_fks={})
 
-	@patch("stripe.Account.retrieve")
-	@patch("stripe.FileUpload.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD))
+	@patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+	@patch(
+		"stripe.FileUpload.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD), autospec=True
+	)
 	def test_get_default_account(self, fileupload_retrieve_mock, account_retrieve_mock):
 		account_retrieve_mock.return_value = FAKE_ACCOUNT
 
@@ -37,8 +42,10 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(account, expected_blank_fks={})
 
-	@patch("stripe.Account.retrieve")
-	@patch("stripe.FileUpload.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD))
+	@patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+	@patch(
+		"stripe.FileUpload.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD), autospec=True
+	)
 	def test_get_default_account_null_logo(
 		self, fileupload_retrieve_mock, account_retrieve_mock
 	):

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -56,7 +56,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(card, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Token.create")
+	@patch("stripe.Token.create", autospec=True)
 	def test_card_create_token(self, token_create_mock):
 		card = {"number": "4242", "exp_month": 5, "exp_year": 2012, "cvc": 445}
 		Card.create_token(**card)
@@ -81,15 +81,15 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		with self.assertRaisesMessage(StripeObjectManipulationException, exception_message):
 			Card.api_list(customer="fish")
 
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_api_create(self, customer_retrieve_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 
 		self.assertEqual(FAKE_CARD, stripe_card)
 
-	@patch("tests.CardDict.delete")
-	@patch("stripe.Card.retrieve", return_value=deepcopy(FAKE_CARD))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("tests.CardDict.delete", autospec=True)
+	@patch("stripe.Card.retrieve", return_value=deepcopy(FAKE_CARD), autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_remove(self, customer_retrieve_mock, card_retrieve_mock, card_delete_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 		Card.sync_from_stripe_data(stripe_card)
@@ -102,7 +102,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		self.assertEqual(0, self.customer.legacy_cards.count())
 		self.assertTrue(card_delete_mock.called)
 
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_remove_already_deleted_card(self, customer_retrieve_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 		Card.sync_from_stripe_data(stripe_card)
@@ -114,8 +114,8 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		card_object.remove()
 		self.assertEqual(self.customer.legacy_cards.count(), 0)
 
-	@patch("djstripe.models.Card._api_delete")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("djstripe.models.Card._api_delete", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_remove_no_such_source(self, customer_retrieve_mock, card_delete_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 		Card.sync_from_stripe_data(stripe_card)
@@ -130,8 +130,8 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		self.assertEqual(0, self.customer.legacy_cards.count())
 		self.assertTrue(card_delete_mock.called)
 
-	@patch("djstripe.models.Card._api_delete")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("djstripe.models.Card._api_delete", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_remove_no_such_customer(self, customer_retrieve_mock, card_delete_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 		Card.sync_from_stripe_data(stripe_card)
@@ -146,8 +146,8 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		self.assertEqual(0, self.customer.legacy_cards.count())
 		self.assertTrue(card_delete_mock.called)
 
-	@patch("djstripe.models.Card._api_delete")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("djstripe.models.Card._api_delete", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_remove_unexpected_exception(self, customer_retrieve_mock, card_delete_mock):
 		stripe_card = Card._api_create(customer=self.customer, source=FAKE_CARD["id"])
 		Card.sync_from_stripe_data(stripe_card)
@@ -161,7 +161,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
 		with self.assertRaisesMessage(InvalidRequestError, "Unexpected Exception"):
 			card.remove()
 
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_api_list(self, customer_retrieve_mock):
 		card_list = Card.api_list(customer=self.customer)
 

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -16,7 +16,8 @@ from djstripe.models import (
 from . import (
 	FAKE_ACCOUNT, FAKE_BALANCE_TRANSACTION, FAKE_BALANCE_TRANSACTION_REFUND, FAKE_CHARGE,
 	FAKE_CHARGE_REFUNDED, FAKE_CUSTOMER, FAKE_FILEUPLOAD, FAKE_INVOICE, FAKE_PRODUCT,
-	FAKE_REFUND, FAKE_SUBSCRIPTION, FAKE_TRANSFER, AssertStripeFksMixin, default_account
+	FAKE_REFUND, FAKE_SUBSCRIPTION, FAKE_TRANSFER, IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	IS_STATICMETHOD_AUTOSPEC_SUPPORTED, AssertStripeFksMixin, default_account
 )
 
 
@@ -57,8 +58,11 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 		charge.amount_refunded = 0
 		self.assertEqual(str(charge), "$50.00 USD")
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Charge.retrieve")
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Charge.retrieve", autospec=True)
 	def test_capture_charge(self, charge_retrieve_mock, default_account_mock):
 		default_account_mock.return_value = self.account
 
@@ -85,12 +89,21 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED and IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
 	def test_sync_from_stripe_data(
 		self,
 		subscription_retrieve_mock,
@@ -131,11 +144,18 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
 	def test_sync_from_stripe_data_refunded_on_update(
 		self,
 		subscription_retrieve_mock,
@@ -216,15 +236,22 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
 	@patch(
 		"stripe.BalanceTransaction.retrieve",
 		return_value=deepcopy(FAKE_BALANCE_TRANSACTION_REFUND),
 	)
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
 	def test_sync_from_stripe_data_refunded(
 		self,
 		subscription_retrieve_mock,
@@ -275,12 +302,21 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("djstripe.models.Account.get_default_account")
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
 	def test_sync_from_stripe_data_max_amount(
 		self,
 		default_account_mock,
@@ -318,12 +354,21 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
 	def test_sync_from_stripe_data_unsupported_source(
 		self,
 		invoice_retrieve_mock,
@@ -359,9 +404,14 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Charge.retrieve")
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
 	def test_sync_from_stripe_data_no_customer(
 		self, charge_retrieve_mock, balance_transaction_retrieve_mock, default_account_mock
 	):
@@ -394,13 +444,22 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.Transfer.retrieve")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("djstripe.models.Account.get_default_account")
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.Transfer.retrieve", autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
 	def test_sync_from_stripe_data_with_transfer(
 		self,
 		default_account_mock,
@@ -441,13 +500,19 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.Charge.retrieve")
-	@patch("stripe.Account.retrieve")
-	@patch("stripe.BalanceTransaction.retrieve")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE))
-	@patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD))
+	@patch("stripe.Charge.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+	@patch(
+		"stripe.BalanceTransaction.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True)
+	@patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD), autospec=True)
 	def test_sync_from_stripe_data_with_destination(
 		self,
 		file_retrive_mock,

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -30,7 +30,9 @@ class SubscriptionSerializerTest(TestCase):
 		)
 		self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
 	def test_valid_serializer(self):
@@ -65,7 +67,7 @@ class SubscriptionSerializerTest(TestCase):
 		)
 		self.assertEqual(serializer.errors, {})
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invalid_serializer(self, product_retrieve_mock):
 		now = timezone.now()
 		serializer = SubscriptionSerializer(
@@ -86,10 +88,14 @@ class SubscriptionSerializerTest(TestCase):
 
 class CreateSubscriptionSerializerTest(TestCase):
 	def setUp(self):
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
-	@patch("stripe.Token.create", return_value=PropertyMock(id="token_test"))
+	@patch(
+		"stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+	)
 	def test_valid_serializer(self, stripe_token_mock):
 		token = stripe_token_mock(card={})
 		serializer = CreateSubscriptionSerializer(
@@ -100,7 +106,9 @@ class CreateSubscriptionSerializerTest(TestCase):
 		self.assertIn("stripe_token", serializer.validated_data)
 		self.assertEqual(serializer.errors, {})
 
-	@patch("stripe.Token.create", return_value=PropertyMock(id="token_test"))
+	@patch(
+		"stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+	)
 	def test_valid_serializer_non_required_fields(self, stripe_token_mock):
 		"""Test the CreateSubscriptionSerializer is_valid method."""
 		token = stripe_token_mock(card={})

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -98,7 +98,9 @@ class RestSubscriptionTest(APITestCase):
 
 		Should return the correct data.
 		"""
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 		subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
 
@@ -110,7 +112,7 @@ class RestSubscriptionTest(APITestCase):
 			response.data["cancel_at_period_end"], subscription.cancel_at_period_end
 		)
 
-	@patch("djstripe.models.Subscription.cancel")
+	@patch("djstripe.models.Subscription.cancel", autospec=True)
 	def test_cancel_subscription(self, cancel_subscription_mock):
 		"""Test a DELETE to the SubscriptionRestView.
 
@@ -127,7 +129,9 @@ class RestSubscriptionTest(APITestCase):
 
 		fake_cancelled_subscription = deepcopy(FAKE_SUBSCRIPTION)
 
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			Subscription.sync_from_stripe_data(fake_cancelled_subscription)
 
 		cancel_subscription_mock.side_effect = _cancel_sub
@@ -143,7 +147,8 @@ class RestSubscriptionTest(APITestCase):
 		self.assertEqual(Subscription.objects.first().status, SubscriptionStatus.canceled)
 
 		cancel_subscription_mock.assert_called_once_with(
-			at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END
+			Subscription.objects.first(),
+			at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END,
 		)
 		self.assertTrue(self.user.is_authenticated)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -50,8 +50,8 @@ class TestSubscriptionPaymentRequired(TestCase):
 		response = self.test_view(request)
 		self.assertEqual(response.status_code, 302)
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_user_active_subscription(self, product_retrieve_mock, plan_retrieve_mock):
 		user = get_user_model().objects.create_user(
 			username="pydanny", email="pydanny@gmail.com"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -107,7 +107,7 @@ class EventTest(TestCase):
 	# Helpers
 	#
 
-	@patch("stripe.Event.retrieve")
+	@patch("stripe.Event.retrieve", autospec=True)
 	def _create_event(self, event_data, event_retrieve_mock):
 		event_data = deepcopy(event_data)
 		event_retrieve_mock.return_value = event_data

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -13,7 +13,8 @@ from djstripe.settings import STRIPE_SECRET_KEY
 
 from . import (
 	FAKE_CHARGE, FAKE_CUSTOMER, FAKE_INVOICE, FAKE_INVOICEITEM_II, FAKE_PLAN, FAKE_PRODUCT,
-	FAKE_SUBSCRIPTION, FAKE_UPCOMING_INVOICE, AssertStripeFksMixin, default_account
+	FAKE_SUBSCRIPTION, FAKE_UPCOMING_INVOICE, IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	IS_STATICMETHOD_AUTOSPEC_SUPPORTED, AssertStripeFksMixin, default_account
 )
 
 
@@ -25,10 +26,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 		)
 		self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_str(
 		self,
 		product_retrieve_mock,
@@ -53,11 +61,18 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.Invoice.retrieve")
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Invoice.retrieve", autospec=True)
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_retry_true(
 		self,
 		product_retrieve_mock,
@@ -90,11 +105,18 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.Invoice.retrieve")
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Invoice.retrieve", autospec=True)
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_retry_false(
 		self,
 		product_retrieve_mock,
@@ -124,10 +146,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_paid(
 		self,
 		product_retrieve_mock,
@@ -151,10 +180,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_open(
 		self,
 		product_retrieve_mock,
@@ -180,10 +216,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_forgiven(
 		self,
 		product_retrieve_mock,
@@ -209,10 +252,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_forgiven_deprecated(
 		self,
 		product_retrieve_mock,
@@ -231,10 +281,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
 		self.assertEqual(Invoice.STATUS_FORGIVEN, invoice.status)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_forgiven_default(
 		self,
 		product_retrieve_mock,
@@ -252,10 +309,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
 		self.assertEqual(Invoice.STATUS_OPEN, invoice.status)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_closed(
 		self,
 		product_retrieve_mock,
@@ -281,10 +345,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_closed_deprecated(
 		self,
 		product_retrieve_mock,
@@ -303,10 +374,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
 		self.assertEqual(Invoice.STATUS_CLOSED, invoice.status)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_status_closed_default(
 		self,
 		product_retrieve_mock,
@@ -325,11 +403,22 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
 		self.assertEqual(Invoice.STATUS_OPEN, invoice.status)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Plan.retrieve",
+		return_value=deepcopy(FAKE_PLAN),
+		autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_sync_no_subscription(
 		self,
 		product_retrieve_mock,
@@ -364,10 +453,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invoice_with_subscription_invoice_items(
 		self,
 		product_retrieve_mock,
@@ -397,10 +493,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invoice_with_no_invoice_items(
 		self,
 		product_retrieve_mock,
@@ -427,10 +530,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invoice_with_non_subscription_invoice_items(
 		self,
 		product_retrieve_mock,
@@ -458,10 +568,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invoice_plan_from_invoice_items(
 		self,
 		product_retrieve_mock,
@@ -487,10 +604,17 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_invoice_plan_from_subscription(
 		self,
 		product_retrieve_mock,
@@ -516,9 +640,16 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
 	def test_invoice_without_plan(
 		self, charge_retrieve_mock, subscription_retrieve_mock, default_account_mock
 	):
@@ -542,10 +673,22 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Invoice.upcoming", return_value=deepcopy(FAKE_UPCOMING_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch(
+		"stripe.Plan.retrieve",
+		return_value=deepcopy(FAKE_PLAN),
+		autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Invoice.upcoming",
+		return_value=deepcopy(FAKE_UPCOMING_INVOICE),
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_upcoming_invoice(
 		self,
 		product_retrieve_mock,
@@ -580,10 +723,18 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 		self.assertEqual(0, len(items))
 		self.assertIsNotNone(invoice.plan)
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Invoice.upcoming", return_value=deepcopy(FAKE_UPCOMING_INVOICE))
+	@patch("stripe.Plan.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Invoice.upcoming",
+		return_value=deepcopy(FAKE_UPCOMING_INVOICE),
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
 	def test_upcoming_invoice_with_subscription(
 		self,
 		invoice_upcoming_mock,
@@ -604,10 +755,18 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 		self.assertIsNotNone(invoice.plan)
 		self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Invoice.upcoming", return_value=deepcopy(FAKE_UPCOMING_INVOICE))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Plan.retrieve", autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Invoice.upcoming",
+		return_value=deepcopy(FAKE_UPCOMING_INVOICE),
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_upcoming_invoice_with_subscription_plan(
 		self,
 		product_retrieve_mock,

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -10,8 +10,9 @@ from djstripe.models import InvoiceItem
 from djstripe.settings import STRIPE_SECRET_KEY
 
 from . import (
-	FAKE_CHARGE_II, FAKE_CUSTOMER_II, FAKE_INVOICE_II, FAKE_INVOICEITEM, FAKE_PLAN_II,
-	FAKE_PRODUCT, FAKE_SUBSCRIPTION_III, AssertStripeFksMixin, default_account
+	FAKE_CHARGE_II, FAKE_CUSTOMER_II, FAKE_INVOICE_II, FAKE_INVOICEITEM,
+	FAKE_PLAN_II, FAKE_PRODUCT, FAKE_SUBSCRIPTION_III,
+	IS_STATICMETHOD_AUTOSPEC_SUPPORTED, AssertStripeFksMixin, default_account
 )
 
 
@@ -19,12 +20,23 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.account = default_account()
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION_III),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True)
+	@patch(
+		"stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
+	)
 	def test_str(
 		self,
 		invoice_retrieve_mock,
@@ -51,12 +63,23 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 			"<amount=20, date=2015-08-08 11:26:56+00:00, id=ii_16XVTY2eZvKYlo2Cxz5n3RaS>",
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION_III),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True)
+	@patch(
+		"stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
+	)
 	def test_sync_with_subscription(
 		self,
 		invoice_retrieve_mock,
@@ -92,12 +115,21 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 			api_key=STRIPE_SECRET_KEY, expand=[], id=FAKE_INVOICE_II["id"]
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
-	@patch("stripe.Invoice.retrieve")
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION_III),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True)
+	@patch("stripe.Invoice.retrieve", autospec=True)
 	def test_sync_expanded_invoice_with_subscription(
 		self,
 		invoice_retrieve_mock,
@@ -135,13 +167,24 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
-	@patch("stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II))
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION_III),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True)
+	@patch(
+		"stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
+	)
 	def test_sync_proration(
 		self,
 		invoice_retrieve_mock,
@@ -172,13 +215,22 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("djstripe.models.Account.get_default_account")
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_III))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
-	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II))
-	@patch("stripe.Invoice.retrieve")
+	@patch(
+		"djstripe.models.Account.get_default_account",
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION_III),
+		autospec=True,
+	)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
+	@patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True)
+	@patch("stripe.Invoice.retrieve", autospec=True)
 	def test_sync_null_invoice(
 		self,
 		invoice_retrieve_mock,

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -27,7 +27,9 @@ class SubscriptionManagerTest(TestCase):
 			2013, 1, 1, 0, 0, 1, tzinfo=timezone.utc
 		)  # more realistic start
 
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.plan = Plan.sync_from_stripe_data(FAKE_PLAN)
 			self.plan2 = Plan.sync_from_stripe_data(FAKE_PLAN_II)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -102,7 +102,9 @@ class MiddlewareLogicTest(TestCase):
 		self.customer.subscriber = self.user
 		self.customer.save()
 
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.subscription = Subscription.sync_from_stripe_data(FAKE_SUBSCRIPTION)
 
 		self.middleware = SubscriptionPaymentMiddleware()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -36,11 +36,13 @@ class TestPaymentsContextMixin(TestCase):
 
 class TestSubscriptionMixin(TestCase):
 	def setUp(self):
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 			Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN_II))
 
-	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_get_context_data(self, stripe_create_customer_mock):
 		class TestSuperView(object):
 			def get_context_data(self):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -27,13 +27,15 @@ class TestPlanAdmin(TestCase):
 		pass
 
 	def setUp(self):
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
 		self.site = AdminSite()
 		self.plan_admin = PlanAdmin(Plan, self.site)
 
-	@patch("stripe.Plan.retrieve")
+	@patch("stripe.Plan.retrieve", autospec=True)
 	def test_update_name(self, plan_retrieve_mock):
 		new_name = "Updated Plan Name"
 
@@ -43,8 +45,8 @@ class TestPlanAdmin(TestCase):
 		# Would throw DoesNotExist if it didn't work
 		Plan.objects.get(name="Updated Plan Name")
 
-	@patch("stripe.Plan.create", return_value=FAKE_PLAN_II)
-	@patch("stripe.Plan.retrieve")
+	@patch("stripe.Plan.create", return_value=FAKE_PLAN_II, autospec=True)
+	@patch("stripe.Plan.retrieve", autospec=True)
 	def test_that_admin_save_does_create_new_object(
 		self, plan_retrieve_mock, plan_create_mock
 	):
@@ -60,8 +62,8 @@ class TestPlanAdmin(TestCase):
 		# Would throw DoesNotExist if it didn't work
 		Plan.objects.get(id=plan_data["id"])
 
-	@patch("stripe.Plan.create")
-	@patch("stripe.Plan.retrieve")
+	@patch("stripe.Plan.create", autospec=True)
+	@patch("stripe.Plan.retrieve", autospec=True)
 	def test_that_admin_save_does_update_object(
 		self, plan_retrieve_mock, plan_create_mock
 	):
@@ -77,11 +79,13 @@ class TestPlanAdmin(TestCase):
 
 class PlanCreateTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.stripe_product = Product(id=FAKE_PRODUCT["id"]).api_retrieve()
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN), autospec=True)
 	def test_create_from_product_id(self, plan_create_mock, product_retrieve_mock):
 		fake_plan = deepcopy(FAKE_PLAN)
 		fake_plan["amount"] = fake_plan["amount"] / 100
@@ -96,8 +100,8 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN), autospec=True)
 	def test_create_from_stripe_product(self, plan_create_mock, product_retrieve_mock):
 		fake_plan = deepcopy(FAKE_PLAN)
 		fake_plan["product"] = self.stripe_product
@@ -115,8 +119,8 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN), autospec=True)
 	def test_create_from_djstripe_product(self, plan_create_mock, product_retrieve_mock):
 		fake_plan = deepcopy(FAKE_PLAN)
 		fake_plan["product"] = Product.sync_from_stripe_data(self.stripe_product)
@@ -129,8 +133,8 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Plan.create", return_value=deepcopy(FAKE_PLAN), autospec=True)
 	def test_create_with_metadata(self, plan_create_mock, product_retrieve_mock):
 		metadata = {"other_data": "more_data"}
 		fake_plan = deepcopy(FAKE_PLAN)
@@ -153,13 +157,15 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
 class PlanTest(AssertStripeFksMixin, TestCase):
 	def setUp(self):
 		self.plan_data = deepcopy(FAKE_PLAN)
-		with patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT)):
+		with patch(
+			"stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+		):
 			self.plan = Plan.sync_from_stripe_data(self.plan_data)
 
 	def test_str(self):
 		self.assertEqual(str(self.plan), self.plan_data["nickname"])
 
-	@patch("stripe.Plan.retrieve", return_value=FAKE_PLAN)
+	@patch("stripe.Plan.retrieve", return_value=FAKE_PLAN, autospec=True)
 	def test_stripe_plan(self, plan_retrieve_mock):
 		stripe_plan = self.plan.api_retrieve()
 		plan_retrieve_mock.assert_called_once_with(
@@ -171,7 +177,7 @@ class PlanTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Product.retrieve")
+	@patch("stripe.Product.retrieve", autospec=True)
 	def test_stripe_plan_null_product(self, product_retrieve_mock):
 		"""
 		assert that plan.Product can be null for backwards compatibility
@@ -185,7 +191,7 @@ class PlanTest(AssertStripeFksMixin, TestCase):
 			plan, expected_blank_fks={"djstripe.Customer.coupon", "djstripe.Plan.product"}
 		)
 
-	@patch("stripe.Plan.retrieve")
+	@patch("stripe.Plan.retrieve", autospec=True)
 	def test_stripe_tier_plan(self, plan_retrieve_mock):
 		tier_plan_data = deepcopy(FAKE_TIER_PLAN)
 		plan = Plan.sync_from_stripe_data(tier_plan_data)
@@ -195,7 +201,7 @@ class PlanTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve")
+	@patch("stripe.Plan.retrieve", autospec=True)
 	def test_stripe_metered_plan(self, plan_retrieve_mock):
 		plan_data = deepcopy(FAKE_PLAN_METERED)
 		plan = Plan.sync_from_stripe_data(plan_data)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -27,9 +27,9 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 		)
 		self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_str(self, customer_retrieve_mock, product_retrieve_mock, plan_retrieve_mock):
 		subscription_fake = deepcopy(FAKE_SUBSCRIPTION)
 		subscription = Subscription.sync_from_stripe_data(subscription_fake)
@@ -41,9 +41,9 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_is_status_temporarily_current(
 		self, customer_retrieve_mock, product_retrieve_mock, plan_retrieve_mock
 	):
@@ -63,9 +63,9 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_is_status_temporarily_current_false(
 		self, customer_retrieve_mock, product_retrieve_mock, plan_retrieve_mock
 	):
@@ -83,9 +83,9 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_is_status_temporarily_current_false_and_cancelled(
 		self, customer_retrieve_mock, product_retrieve_mock, plan_retrieve_mock
 	):
@@ -104,10 +104,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_extend(
 		self,
 		customer_retrieve_mock,
@@ -135,10 +135,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_extend_negative_delta(
 		self,
 		customer_retrieve_mock,
@@ -157,10 +161,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_extend_with_trial(
 		self,
 		customer_retrieve_mock,
@@ -186,10 +194,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_update(
 		self,
 		customer_retrieve_mock,
@@ -208,10 +220,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_update_set_empty_value(
 		self,
 		customer_retrieve_mock,
@@ -232,10 +244,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Subscription.retrieve",
+		return_value=deepcopy(FAKE_SUBSCRIPTION),
+		autospec=True,
+	)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_update_with_plan_model(
 		self,
 		customer_retrieve_mock,
@@ -257,10 +273,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(new_plan, expected_blank_fks={})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_cancel_now(
 		self,
 		customer_retrieve_mock,
@@ -298,10 +314,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_cancel_at_period_end(
 		self,
 		customer_retrieve_mock,
@@ -343,10 +359,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_cancel_during_trial_sets_at_period_end(
 		self,
 		customer_retrieve_mock,
@@ -382,10 +398,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN))
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Subscription.retrieve")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch("stripe.Subscription.retrieve", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_cancel_and_reactivate(
 		self,
 		customer_retrieve_mock,
@@ -422,8 +438,8 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("djstripe.models.Subscription._api_delete")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("djstripe.models.Subscription._api_delete", autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	@patch(
 		"stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_CANCELED)
 	)
@@ -443,8 +459,8 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("djstripe.models.Subscription._api_delete")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("djstripe.models.Subscription._api_delete", autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_cancel_error_in_cancel(self, product_retrieve_mock, subscription_delete_mock):
 		subscription_delete_mock.side_effect = InvalidRequestError("Unexpected error", "blah")
 
@@ -456,9 +472,11 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 
 		self.assert_fks(subscription, expected_blank_fks={"djstripe.Customer.coupon"})
 
-	@patch("stripe.Plan.retrieve")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
+	@patch("stripe.Plan.retrieve", autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
 	@patch(
 		"stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_MULTI_PLAN)
 	)
@@ -487,9 +505,11 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
 			},
 		)
 
-	@patch("stripe.Plan.retrieve")
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II))
+	@patch("stripe.Plan.retrieve", autospec=True)
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
+	@patch(
+		"stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True
+	)
 	@patch(
 		"stripe.Subscription.retrieve", return_value=deepcopy(FAKE_SUBSCRIPTION_METERED)
 	)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -35,11 +35,11 @@ class TestSyncSubscriber(TestCase):
 			username="testuser", email="test@example.com", password="123"
 		)
 
-	@patch("djstripe.models.Customer._sync_charges")
-	@patch("djstripe.models.Customer._sync_invoices")
-	@patch("djstripe.models.Customer._sync_subscriptions")
-	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER))
-	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("djstripe.models.Customer._sync_charges", autospec=True)
+	@patch("djstripe.models.Customer._sync_invoices", autospec=True)
+	@patch("djstripe.models.Customer._sync_subscriptions", autospec=True)
+	@patch("stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
+	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_sync_success(
 		self,
 		stripe_customer_create_mock,
@@ -55,13 +55,17 @@ class TestSyncSubscriber(TestCase):
 			FAKE_CUSTOMER, Customer.objects.get(subscriber=self.user).api_retrieve()
 		)
 
-		_sync_subscriptions_mock.assert_called_once_with()
-		_sync_invoices_mock.assert_called_once_with()
-		_sync_charges_mock.assert_called_once_with()
+		_sync_subscriptions_mock.assert_called_once_with(Customer.objects.first())
+		_sync_invoices_mock.assert_called_once_with(Customer.objects.first())
+		_sync_charges_mock.assert_called_once_with(Customer.objects.first())
 
-	@patch("djstripe.models.Customer._sync")
-	@patch("djstripe.models.Customer.api_retrieve", return_value=deepcopy(FAKE_CUSTOMER))
-	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER))
+	@patch("djstripe.models.Customer._sync", autospec=True)
+	@patch(
+		"djstripe.models.Customer.api_retrieve",
+		return_value=deepcopy(FAKE_CUSTOMER),
+		autospec=True,
+	)
+	@patch("stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER), autospec=True)
 	def test_sync_fail(self, stripe_customer_create_mock, api_retrieve_mock, _sync_mock):
 		_sync_mock.side_effect = InvalidRequestError("No such customer:", "blah")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,9 @@ from djstripe.utils import (
 	get_supported_currency_choices, subscriber_has_active_subscription
 )
 
-from . import FAKE_CUSTOMER, FAKE_PRODUCT, FAKE_SUBSCRIPTION
+from . import (
+	FAKE_CUSTOMER, FAKE_PRODUCT, FAKE_SUBSCRIPTION, IS_STATICMETHOD_AUTOSPEC_SUPPORTED
+)
 from .apps.testapp.models import Organization
 
 TZ_IS_UTC = time.tzname == ("UTC", "UTC")
@@ -52,7 +54,7 @@ class TestUserHasActiveSubscription(TestCase):
 	def test_user_has_inactive_subscription(self):
 		self.assertFalse(subscriber_has_active_subscription(self.user))
 
-	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT))
+	@patch("stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True)
 	def test_user_has_active_subscription(self, product_retrieve_mock):
 		subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
 		subscription.current_period_end = timezone.now() + timezone.timedelta(days=10)
@@ -100,7 +102,11 @@ class TestGetSupportedCurrencyChoices(TestCase):
 		"stripe.CountrySpec.retrieve",
 		return_value={"supported_payment_currencies": ["usd", "cad", "eur"]},
 	)
-	@patch("stripe.Account.retrieve", return_value={"country": "US"})
+	@patch(
+		"stripe.Account.retrieve",
+		return_value={"country": "US"},
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	)
 	def test_get_choices(
 		self, stripe_account_retrieve_mock, stripe_countryspec_retrieve_mock
 	):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -18,7 +18,8 @@ from djstripe.models import Event, WebhookEventTrigger
 from djstripe.webhooks import TEST_EVENT_ID, call_handlers, handler, handler_all
 
 from . import (
-	FAKE_EVENT_TEST_CHARGE_SUCCEEDED, FAKE_EVENT_TRANSFER_CREATED, FAKE_TRANSFER
+	FAKE_EVENT_TEST_CHARGE_SUCCEEDED, FAKE_EVENT_TRANSFER_CREATED, FAKE_TRANSFER,
+	IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED, IS_STATICMETHOD_AUTOSPEC_SUPPORTED
 )
 
 
@@ -48,8 +49,12 @@ class TestWebhook(TestCase):
 		self.assertTrue(event_trigger.is_test_event)
 
 	@override_settings(DJSTRIPE_WEBHOOK_VALIDATION="retrieve_event")
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve", return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch(
+		"stripe.Event.retrieve",
+		return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED),
+		autospec=True,
+	)
 	def test_webhook_retrieve_event_fail(
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
@@ -65,8 +70,12 @@ class TestWebhook(TestCase):
 		self.assertFalse(Event.objects.filter(id="evt_invalid").exists())
 
 	@override_settings(DJSTRIPE_WEBHOOK_VALIDATION="retrieve_event")
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve", return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch(
+		"stripe.Event.retrieve",
+		return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED),
+		autospec=True,
+	)
 	def test_webhook_retrieve_event_pass(
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
@@ -82,8 +91,12 @@ class TestWebhook(TestCase):
 	@override_settings(
 		DJSTRIPE_WEBHOOK_VALIDATION="verify_signature", DJSTRIPE_WEBHOOK_SECRET="whsec_XXXXX"
 	)
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve", return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch(
+		"stripe.Event.retrieve",
+		return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED),
+		autospec=True,
+	)
 	def test_webhook_invalid_verify_signature_fail(
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
@@ -101,9 +114,17 @@ class TestWebhook(TestCase):
 	@override_settings(
 		DJSTRIPE_WEBHOOK_VALIDATION="verify_signature", DJSTRIPE_WEBHOOK_SECRET="whsec_XXXXX"
 	)
-	@patch("stripe.WebhookSignature.verify_header", return_value=True)
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve", return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+	@patch(
+		"stripe.WebhookSignature.verify_header",
+		return_value=True,
+		autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED and IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch(
+		"stripe.Event.retrieve",
+		return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED),
+		autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
 	def test_webhook_verify_signature_pass(
 		self, event_retrieve_mock, transfer_retrieve_mock, verify_signature_mock
 	):
@@ -117,9 +138,13 @@ class TestWebhook(TestCase):
 		event_retrieve_mock.assert_not_called()
 
 	@override_settings(DJSTRIPE_WEBHOOK_VALIDATION=None)
-	@patch("stripe.WebhookSignature.verify_header")
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve", return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED))
+	@patch("stripe.WebhookSignature.verify_header", autospec=True)
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch(
+		"stripe.Event.retrieve",
+		return_value=deepcopy(FAKE_EVENT_TRANSFER_CREATED),
+		autospec=IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	)
 	def test_webhook_no_validation_pass(
 		self, event_retrieve_mock, transfer_retrieve_mock, verify_signature_mock
 	):
@@ -160,8 +185,10 @@ class TestWebhook(TestCase):
 		event_trigger = WebhookEventTrigger.objects.first()
 		self.assertEqual(event_trigger.remote_ip, "0.0.0.0")
 
-	@patch("djstripe.models.WebhookEventTrigger.validate", return_value=True)
-	@patch("djstripe.models.WebhookEventTrigger.process")
+	@patch(
+		"djstripe.models.WebhookEventTrigger.validate", return_value=True, autospec=True
+	)
+	@patch("djstripe.models.WebhookEventTrigger.process", autospec=True)
 	def test_webhook_reraise_exception(
 		self, webhook_event_process_mock, webhook_event_validate_mock
 	):
@@ -186,8 +213,8 @@ class TestWebhook(TestCase):
 	@patch.object(
 		djstripe_settings, "WEBHOOK_EVENT_CALLBACK", return_value=mock_webhook_handler
 	)
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve")
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch("stripe.Event.retrieve", autospec=True)
 	def test_webhook_with_custom_callback(
 		self, event_retrieve_mock, transfer_retrieve_mock, webhook_event_callback_mock
 	):
@@ -200,8 +227,8 @@ class TestWebhook(TestCase):
 		webhook_event_trigger = WebhookEventTrigger.objects.get()
 		webhook_event_callback_mock.called_once_with(webhook_event_trigger)
 
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve")
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch("stripe.Event.retrieve", autospec=True)
 	def test_webhook_with_transfer_event_duplicate(
 		self, event_retrieve_mock, transfer_retrieve_mock
 	):
@@ -219,8 +246,8 @@ class TestWebhook(TestCase):
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(1, Event.objects.filter(type="transfer.created").count())
 
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve")
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch("stripe.Event.retrieve", autospec=True)
 	def test_webhook_good(self, event_retrieve_mock, transfer_retrieve_mock):
 		djstripe_settings.WEBHOOK_SECRET = ""
 
@@ -236,8 +263,8 @@ class TestWebhook(TestCase):
 		self.assertEqual(event_trigger.is_test_event, False)
 
 	@patch.object(target=Event, attribute="invoke_webhook_handlers", autospec=True)
-	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER))
-	@patch("stripe.Event.retrieve")
+	@patch("stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True)
+	@patch("stripe.Event.retrieve", autospec=True)
 	def test_webhook_error(
 		self, event_retrieve_mock, transfer_retrieve_mock, mock_invoke_webhook_handlers
 	):


### PR DESCRIPTION
So that method signatures are checked.
