### PR TITLE
Deprecate field_name parameter to sync_from_stripe_data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ This is a bugfix-only version:
 
 - Don't save event objects if the webhook processing fails (#832).
 - Fixed IntegrityError when ``REMOTE_ADDR`` is an empty string.
+- Deprecated ``field_name`` parameter to ``sync_from_stripe_data``
 
 2.0.1 (2019-04-29)
 ------------------

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import warnings
 from datetime import timedelta
 
 import django
@@ -564,7 +565,7 @@ class StripeModel(models.Model):
 			setattr(self, attr, value)
 
 	@classmethod
-	def sync_from_stripe_data(cls, data, field_name="id"):
+	def sync_from_stripe_data(cls, data, field_name=None):
 		"""
 		Syncs this object from the stripe data provided.
 
@@ -574,6 +575,14 @@ class StripeModel(models.Model):
 		:type data: dict
 		"""
 		current_ids = set()
+
+		if field_name is None:
+			field_name = "id"
+		else:
+			warnings.warn(
+				"field_name parameter to sync_from_stripe_data is deprecated and will be removed in 2.1.0",
+				DeprecationWarning,
+			)
 
 		if data.get(field_name, None):
 			# stop nested objects from trying to retrieve this object before initial sync is complete

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -620,7 +620,7 @@ class InvoiceItem(StripeModel):
 		return data
 
 	@classmethod
-	def sync_from_stripe_data(cls, data, field_name="id"):
+	def sync_from_stripe_data(cls, data, field_name=None):
 		invoice_data = data.get("invoice")
 
 		if invoice_data:


### PR DESCRIPTION
This was an implementation detail added in 2.0.0, the need for which was removed in 2.0.1
(see #849 / b7516e0c3e49b419f0d3a57777534b2dae5b8f7c).