### PR TITLE
Fix TransactionManagementError in dj-stripe 2.0.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,8 @@ History
 
 This is a bugfix-only version:
 
-- When processing stripe event, wrap create object call in transaction (#877)
+- In ``_get_or_create_from_stripe_object``, wrap create ``_create_from_stripe_object`` in transaction,
+  fixes ``TransactionManagementError`` on race condition in webhook processing (#877/#903).
 
 2.0.2 (2019-06-09)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.0.3 (unreleased)
+------------------
+
+This is a bugfix-only version:
+
+- When processing stripe event, wrap create object call in transaction (#877)
+
 2.0.2 (2019-06-09)
 ------------------
 


### PR DESCRIPTION
I'm seeing an intermittent exception in webhook handling with dj-stripe 2.0.2, I think it's due the race condition in `_get_or_create_from_stripe_object` causing problems with the transaction that was added in #887.

This PR is #877 + a test that triggers the race condition (the test was failing without #877).

The exception I was getting was something like this:

```
Traceback (most recent call last):
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/env/lib/python3.7/site-packages/django/db/backends/mysql/base.py", line 71, in execute
    return self.cursor.execute(query, args)
  File "/env/lib/python3.7/site-packages/newrelic/hooks/database_dbapi2.py", line 25, in execute
    *args, **kwargs)
  File "/env/lib/python3.7/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/env/lib/python3.7/site-packages/MySQLdb/cursors.py", line 312, in _query
    db.query(q)
  File "/env/lib/python3.7/site-packages/MySQLdb/connections.py", line 224, in query
    _mysql.connection.query(self, query)
MySQLdb._exceptions.IntegrityError: (1062, "Duplicate entry 'txn_1EjdwGCeINRcFPOCySvgG0dx' for key 'id'")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 441, in _get_or_create_from_stripe_object
    data, current_ids=current_ids, pending_relations=pending_relations, save=save
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 365, in _create_from_stripe_object
    instance.save(force_insert=True)
  File "/env/lib/python3.7/site-packages/django/db/models/base.py", line 741, in save
    force_update=force_update, update_fields=update_fields)
  File "/env/lib/python3.7/site-packages/django/db/models/base.py", line 779, in save_base
    force_update, using, update_fields,
  File "/env/lib/python3.7/site-packages/django/db/models/base.py", line 870, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/env/lib/python3.7/site-packages/django/db/models/base.py", line 908, in _do_insert
    using=using, raw=raw)
  File "/env/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/env/lib/python3.7/site-packages/django/db/models/query.py", line 1186, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/env/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1335, in execute_sql
    cursor.execute(sql, params)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/env/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/env/lib/python3.7/site-packages/django/db/backends/mysql/base.py", line 71, in execute
    return self.cursor.execute(query, args)
  File "/env/lib/python3.7/site-packages/newrelic/hooks/database_dbapi2.py", line 25, in execute
    *args, **kwargs)
  File "/env/lib/python3.7/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/env/lib/python3.7/site-packages/MySQLdb/cursors.py", line 312, in _query
    db.query(q)
  File "/env/lib/python3.7/site-packages/MySQLdb/connections.py", line 224, in query
    _mysql.connection.query(self, query)
django.db.utils.IntegrityError: (1062, "Duplicate entry 'txn_1EjdwGCeINRcFPOCySvgG0dx' for key 'id'")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/env/lib/python3.7/site-packages/djstripe/models/webhooks.py", line 99, in from_request
    obj.process(save=False)
  File "/env/lib/python3.7/site-packages/djstripe/models/webhooks.py", line 179, in process
    self.event = Event.process(self.json_body)
  File "/env/lib/python3.7/site-packages/djstripe/models/core.py", line 1157, in process
    ret.invoke_webhook_handlers()
  File "/env/lib/python3.7/site-packages/djstripe/models/core.py", line 1169, in invoke_webhook_handlers
    webhooks.call_handlers(event=self)
  File "/env/lib/python3.7/site-packages/djstripe/webhooks.py", line 98, in call_handlers
    handler_func(event=event)
  File "/env/lib/python3.7/site-packages/djstripe/event_handlers.py", line 138, in other_object_webhook_handler
    _handle_crud_like_event(target_cls=target_cls, event=event)
  File "/env/lib/python3.7/site-packages/djstripe/event_handlers.py", line 264, in _handle_crud_like_event
    obj = target_cls.sync_from_stripe_data(data)
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 592, in sync_from_stripe_data
    data, field_name=field_name, current_ids=current_ids
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 441, in _get_or_create_from_stripe_object
    data, current_ids=current_ids, pending_relations=pending_relations, save=save
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 359, in _create_from_stripe_object
    data, current_ids=current_ids, pending_relations=pending_relations
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 187, in _stripe_object_to_record
    pending_relations=pending_relations,
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 273, in _stripe_object_field_to_foreign_key
    pending_relations=pending_relations,
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 441, in _get_or_create_from_stripe_object
    data, current_ids=current_ids, pending_relations=pending_relations, save=save
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 359, in _create_from_stripe_object
    data, current_ids=current_ids, pending_relations=pending_relations
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 187, in _stripe_object_to_record
    pending_relations=pending_relations,
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 273, in _stripe_object_field_to_foreign_key
    pending_relations=pending_relations,
  File "/env/lib/python3.7/site-packages/djstripe/models/base.py", line 446, in _get_or_create_from_stripe_object
    return cls.stripe_objects.get(id=id_), False
  File "/env/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/env/lib/python3.7/site-packages/django/db/models/query.py", line 402, in get
    num = len(clone)
  File "/env/lib/python3.7/site-packages/django/db/models/query.py", line 256, in __len__
    self._fetch_all()
  File "/env/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/env/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/env/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1100, in execute_sql
    cursor.execute(sql, params)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/env/lib/python3.7/site-packages/django/db/backends/utils.py", line 79, in _execute
    self.db.validate_no_broken_transaction()
  File "/env/lib/python3.7/site-packages/django/db/backends/base/base.py", line 438, in validate_no_broken_transaction
    "An error occurred in the current transaction. You can't "
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
```