### PR TITLE
Fix errors when re-creating a Customer after purge

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ History
 - ``enums.PaymentMethodType`` has been deprecated, use ``enums.DjstripePaymentMethodType``
 - Made ``SubscriptionItem.quantity`` nullable as per Plans with ``usage_type="metered"`` (follow-up to #865)
 - Added manage command ``djstripe_sync_models`` (#727, #89)
+- Fixed issue with re-creating a customer after `Customer.purge()` (#916)
 
 Changes from API 2018-11-08:
 

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -775,8 +775,8 @@ class Customer(StripeModel):
 			# Delete the idempotency key used by Customer.create()
 			# So re-creating a customer for this subscriber before the key expires
 			# doesn't return the older Customer data
-			idempotency_key = "customer:create:{}".format(self.subscriber.pk)
-			IdempotencyKey.objects.filter(action=idempotency_key).delete()
+			idempotency_key_action = "customer:create:{}".format(self.subscriber.pk)
+			IdempotencyKey.objects.filter(action=idempotency_key_action).delete()
 
 		self.subscriber = None
 

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -20,9 +20,10 @@ from djstripe.settings import STRIPE_SECRET_KEY
 
 from . import (
 	FAKE_ACCOUNT, FAKE_BALANCE_TRANSACTION, FAKE_CARD, FAKE_CARD_V, FAKE_CHARGE,
-	FAKE_COUPON, FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_DISCOUNT_CUSTOMER, FAKE_INVOICE,
-	FAKE_INVOICE_III, FAKE_INVOICEITEM, FAKE_PLAN, FAKE_PRODUCT, FAKE_SUBSCRIPTION,
-	FAKE_SUBSCRIPTION_II, FAKE_UPCOMING_INVOICE, IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
+	FAKE_COUPON, FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_CUSTOMER_III,
+	FAKE_DISCOUNT_CUSTOMER, FAKE_INVOICE, FAKE_INVOICE_III, FAKE_INVOICEITEM,
+	FAKE_PLAN, FAKE_PRODUCT, FAKE_SOURCE, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_II,
+	FAKE_UPCOMING_INVOICE, IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
 	IS_EXCEPTION_AUTOSPEC_SUPPORTED, IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 	AssertStripeFksMixin, StripeList, datetime_to_unix, default_account
 )
@@ -237,6 +238,29 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 		self.assertTrue(not customer.legacy_cards.all())
 		self.assertTrue(not customer.sources.all())
 		self.assertTrue(get_user_model().objects.filter(pk=self.user.pk).exists())
+
+	@patch("stripe.Customer.create", autospec=True)
+	def test_customer_purge_detaches_sources(self, customer_api_create_fake):
+		fake_customer = deepcopy(FAKE_CUSTOMER_III)
+		customer_api_create_fake.return_value = fake_customer
+
+		user = get_user_model().objects.create_user(
+			username="blah", email=FAKE_CUSTOMER_III["email"]
+		)
+
+		Customer.get_or_create(user)
+		customer = Customer.sync_from_stripe_data(deepcopy(FAKE_CUSTOMER_III))
+
+		self.assertIsNotNone(customer.default_source)
+		self.assertNotEqual(customer.sources.count(), 0)
+
+		with patch("stripe.Customer.retrieve", autospec=True), patch(
+			"stripe.Source.retrieve", return_value=deepcopy(FAKE_SOURCE), autospec=True
+		):
+			customer.purge()
+
+		self.assertIsNone(customer.default_source)
+		self.assertEqual(customer.sources.count(), 0)
 
 	@patch(
 		"stripe.Customer.create", return_value=deepcopy(FAKE_CUSTOMER_II), autospec=True

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -254,7 +254,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 		customer, created = Customer.get_or_create(user)
 		self.assertTrue(IdempotencyKey.objects.filter(action=idempotency_key_action).exists())
 
-		with patch("stripe.Customer.retrieve", autospec=True) as customer_retrieve_fake:
+		with patch("stripe.Customer.retrieve", autospec=True):
 			customer.purge()
 
 		self.assertFalse(


### PR DESCRIPTION
* Delete idempotency key during purge() so we don't get
  the old value
* Detach Sources in Customer.purge() as per Cards

Resolves #916

TODO 
- [x] Add a test