### PR TITLE
 Drop mention of python 3.4  + some autospec fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 * Django >= 2.1
-* Python >= 3.4
+* Python >= 3.5
 * Supports Stripe exclusively. For PayPal, see `dj-paypal <https://github.com/HearthSim/dj-paypal>`_ instead.
 * PostgreSQL engine (recommended): >= 9.4
 * MySQL engine: MariaDB >= 10.2 or MySQL >= 5.7

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,8 @@ Django + Stripe Made Easy
 * Subscription management
 * Designed for easy implementation of post-registration subscription forms
 * Single-unit purchases
-* Works with Django >= 2.0
-* Works with Python >= 3.4
+* Works with Django >= 2.1
+* Works with Python >= 3.5
 * Built-in migrations
 * Dead-Easy installation
 * Leverages the best of the 3rd party Django package ecosystem

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,10 +37,6 @@ IS_STATICMETHOD_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 9)
 # see https://bugs.python.org/issue28380
 IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 6)
 
-# Don't try and use autospec=True for functions that have a exception side-effect on py3.4
-# see https://bugs.python.org/issue23661
-IS_EXCEPTION_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 5)
-
 
 class AssertStripeFksMixin:
 	def assert_fks(self, obj, expected_blank_fks, processed_stripe_ids=None):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,10 +28,9 @@ FIXTURE_DIR_PATH = Path(__file__).parent.joinpath("fixtures")
 # Flags for various bugs with mock autospec
 # These can be removed once we drop support for the affected python versions
 
-# Don't try and use autospec=True on staticmethods on <py39
-# TODO - enable for appropriate minor versions of py3.7/3.8 once this is live
+# Don't try and use autospec=True on staticmethods on <py3.7
 # see https://bugs.python.org/issue23078
-IS_STATICMETHOD_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 9)
+IS_STATICMETHOD_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 7, 4)
 
 # Don't try and use autospec=True with assert_called etc on py3.5
 # see https://bugs.python.org/issue28380

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -19,12 +19,12 @@ from djstripe.models import (
 from djstripe.settings import STRIPE_SECRET_KEY
 
 from . import (
-	FAKE_ACCOUNT, FAKE_BALANCE_TRANSACTION, FAKE_CARD, FAKE_CARD_V, FAKE_CHARGE,
-	FAKE_COUPON, FAKE_CUSTOMER, FAKE_CUSTOMER_II, FAKE_CUSTOMER_III,
-	FAKE_DISCOUNT_CUSTOMER, FAKE_INVOICE, FAKE_INVOICE_III, FAKE_INVOICEITEM,
-	FAKE_PLAN, FAKE_PRODUCT, FAKE_SOURCE, FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_II,
-	FAKE_UPCOMING_INVOICE, IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED,
-	IS_EXCEPTION_AUTOSPEC_SUPPORTED, IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+	FAKE_ACCOUNT, FAKE_BALANCE_TRANSACTION, FAKE_CARD, FAKE_CARD_V,
+	FAKE_CHARGE, FAKE_COUPON, FAKE_CUSTOMER, FAKE_CUSTOMER_II,
+	FAKE_CUSTOMER_III, FAKE_DISCOUNT_CUSTOMER, FAKE_INVOICE,
+	FAKE_INVOICE_III, FAKE_INVOICEITEM, FAKE_PLAN, FAKE_PRODUCT, FAKE_SOURCE,
+	FAKE_SUBSCRIPTION, FAKE_SUBSCRIPTION_II, FAKE_UPCOMING_INVOICE,
+	IS_ASSERT_CALLED_AUTOSPEC_SUPPORTED, IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 	AssertStripeFksMixin, StripeList, datetime_to_unix, default_account
 )
 
@@ -792,7 +792,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 	@patch(
 		"stripe.Invoice.list", return_value=StripeList(data=[deepcopy(FAKE_INVOICE_III)])
 	)
-	@patch("djstripe.models.Invoice.retry", autospec=IS_EXCEPTION_AUTOSPEC_SUPPORTED)
+	@patch("djstripe.models.Invoice.retry", autospec=True)
 	def test_retry_unpaid_invoices_expected_exception(
 		self,
 		invoice_retry_mock,
@@ -828,7 +828,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 	@patch(
 		"stripe.Invoice.list", return_value=StripeList(data=[deepcopy(FAKE_INVOICE_III)])
 	)
-	@patch("djstripe.models.Invoice.retry", autospec=IS_EXCEPTION_AUTOSPEC_SUPPORTED)
+	@patch("djstripe.models.Invoice.retry", autospec=True)
 	def test_retry_unpaid_invoices_unexpected_exception(
 		self,
 		invoice_retry_mock,


### PR DESCRIPTION
* Drop mention of python 3.4 support from docs  (should have been part of #824), 
* Remove IS_EXCEPTION_AUTOSPEC_SUPPORTED test flag, since we're dropped python 3.4 support

Also enable test autospec for python 3.7.4 (presumably it'll be in 3.8.0?), fix test bug that this found.