### PR TITLE
Remove tab-specific TODO from flake8 config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,9 +78,7 @@ directory = cover
 [flake8]
 max-complexity = 10
 exclude = djstripe/migrations/, .tox/, build/lib/
-# TODO - stop ignoring E117 once fix for
-#  https://github.com/PyCQA/pycodestyle/issues/836 is released
-ignore = W191, W503, E203, E117
+ignore = W191, W503, E203
 max-line-length = 88
 
 [isort]


### PR DESCRIPTION
Since we've switched to spaces (followup to #930)