### PR TITLE
Highlight that DJ-stripe now supports SCA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Features
 * Individual charges
 * Stripe Sources
 * Stripe v2 and v3 support
+* Supports SCA regulations, Checkout Sessions, and Payment Intents
 * Tested with Stripe API `2019-05-16` (see https://dj-stripe.readthedocs.io/en/latest/api_versions.html )
-* Supports `SCA regulations, Checkout Sessions, and Payment Intents <https://github.com/dj-stripe/dj-stripe/commit/23ab8577e314d9a4720ce401ab743f3a4f382b01>`_
 
 Requirements
 ------------

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Features
 * Stripe Sources
 * Stripe v2 and v3 support
 * Tested with Stripe API `2019-05-16` (see https://dj-stripe.readthedocs.io/en/latest/api_versions.html )
+* Supports `SCA regulations, Checkout Sessions, and Payment Intents <https://github.com/dj-stripe/dj-stripe/commit/23ab8577e314d9a4720ce401ab743f3a4f382b01>`_
 
 Requirements
 ------------


### PR DESCRIPTION
Add some detail that DJ-stripe supports the new SCA-related payment methods / models