### PR TITLE
Add support for sync of reverse OneToOneFields

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -208,6 +208,8 @@ class Invoice(StripeModel):
         "Charge",
         on_delete=models.CASCADE,
         null=True,
+        # TODO - seems like this should just be called "invoice" ?
+        #  (currently that classes with a ForeignKey though)
         related_name="latest_invoice",
         help_text="The latest charge generated for this invoice, if any.",
     )

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -209,7 +209,7 @@ class Invoice(StripeModel):
         on_delete=models.CASCADE,
         null=True,
         # TODO - seems like this should just be called "invoice" ?
-        #  (currently that classes with a ForeignKey though)
+        #  (currently that clashes with a ForeignKey though)
         related_name="latest_invoice",
         help_text="The latest charge generated for this invoice, if any.",
     )

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -316,6 +316,10 @@ class Charge(StripeModel):
             data=source_data, source_type=source_type
         )
 
+        # TODO - this shouldn't be necessary, but payment_intent is failing to sync
+        #   due to issue with OneToOne field handling
+        self.payment_intent = cls._stripe_object_to_payment_intent(target_cls=PaymentIntent, data=data)
+
     def _calculate_refund_amount(self, amount=None):
         """
         :rtype: int

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -5,34 +5,83 @@ from copy import deepcopy
 from unittest.mock import patch
 
 from django.test import TestCase
-from tests import FAKE_CUSTOMER, FAKE_PAYMENT_INTENT_I, AssertStripeFksMixin
+from tests import (
+    FAKE_ACCOUNT,
+    FAKE_BALANCE_TRANSACTION,
+    FAKE_CHARGE,
+    FAKE_CUSTOMER,
+    FAKE_FILEUPLOAD_ICON,
+    FAKE_FILEUPLOAD_LOGO,
+    FAKE_INVOICE,
+    FAKE_PAYMENT_INTENT_I,
+    FAKE_PRODUCT,
+    FAKE_SUBSCRIPTION,
+    AssertStripeFksMixin,
+)
 
 from djstripe.models import PaymentIntent
 
 
 class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     @patch(
+        "stripe.Account.retrieve", return_value=deepcopy(FAKE_ACCOUNT), autospec=True
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_sync_from_stripe_data(self, customer_retrieve_mock):
+    @patch(
+        "stripe.FileUpload.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    def test_sync_from_stripe_data(
+        self,
+        subscription_retrieve_mock,
+        product_retrieve_mock,
+        invoice_retrieve_mock,
+        file_retrieve_mock,
+        customer_retrieve_mock,
+        charge_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        account_retrieve_mock,
+    ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
 
         payment_intent = PaymentIntent.sync_from_stripe_data(fake_payment_intent)
 
+        # Check this specifically, since it's an example of reverse OneToOneField sync
+        self.assertIsNotNone(payment_intent.invoice)
+
         self.assert_fks(
             payment_intent,
             expected_blank_fks={
+                "djstripe.Charge.dispute",
+                "djstripe.Charge.transfer",
                 "djstripe.Customer.coupon",
                 "djstripe.Customer.default_payment_method",
                 "djstripe.Customer.subscriber",
-                "djstripe.PaymentIntent.invoice (related name)",
                 "djstripe.PaymentIntent.on_behalf_of",
                 "djstripe.PaymentIntent.payment_method",
+                "djstripe.Subscription.pending_setup_intent",
             },
         )
-
-        # TODO - PaymentIntent should probably sync invoice (reverse OneToOneField)
-        # self.assertIsNotNone(payment_intent.invoice)
 
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -16,6 +16,7 @@ from tests import (
     FAKE_PAYMENT_INTENT_I,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -24,7 +25,9 @@ from djstripe.models import PaymentIntent
 
 class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     @patch(
-        "stripe.Account.retrieve", return_value=deepcopy(FAKE_ACCOUNT), autospec=True
+        "stripe.Account.retrieve",
+        return_value=deepcopy(FAKE_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -84,9 +87,46 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         )
 
     @patch(
+        "stripe.Account.retrieve",
+        return_value=deepcopy(FAKE_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_status_enum(self, customer_retrieve_mock):
+    @patch(
+        "stripe.FileUpload.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    def test_status_enum(
+        self,
+        subscription_retrieve_mock,
+        product_retrieve_mock,
+        invoice_retrieve_mock,
+        file_retrieve_mock,
+        customer_retrieve_mock,
+        charge_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        account_retrieve_mock,
+    ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
 
         for status in (
@@ -105,9 +145,46 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
             payment_intent.full_clean()
 
     @patch(
+        "stripe.Account.retrieve",
+        return_value=deepcopy(FAKE_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_canceled_intent(self, customer_retrieve_mock):
+    @patch(
+        "stripe.FileUpload.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    def test_cancelled_intent(
+        self,
+        subscription_retrieve_mock,
+        product_retrieve_mock,
+        invoice_retrieve_mock,
+        file_retrieve_mock,
+        customer_retrieve_mock,
+        charge_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        account_retrieve_mock,
+    ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
 
         fake_payment_intent["status"] = "canceled"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -17,6 +17,7 @@ from tests import (
     FAKE_PRODUCT,
     FAKE_SESSION_I,
     FAKE_SUBSCRIPTION,
+    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -25,7 +26,9 @@ from djstripe.models import Session
 
 class SessionTest(AssertStripeFksMixin, TestCase):
     @patch(
-        "stripe.Account.retrieve", return_value=deepcopy(FAKE_ACCOUNT), autospec=True
+        "stripe.Account.retrieve",
+        return_value=deepcopy(FAKE_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,9 +6,17 @@ from unittest.mock import patch
 
 from django.test import TestCase
 from tests import (
+    FAKE_ACCOUNT,
+    FAKE_BALANCE_TRANSACTION,
+    FAKE_CHARGE,
     FAKE_CUSTOMER,
+    FAKE_FILEUPLOAD_ICON,
+    FAKE_FILEUPLOAD_LOGO,
+    FAKE_INVOICE,
     FAKE_PAYMENT_INTENT_I,
+    FAKE_PRODUCT,
     FAKE_SESSION_I,
+    FAKE_SUBSCRIPTION,
     AssertStripeFksMixin,
 )
 
@@ -17,15 +25,49 @@ from djstripe.models import Session
 
 class SessionTest(AssertStripeFksMixin, TestCase):
     @patch(
+        "stripe.Account.retrieve", return_value=deepcopy(FAKE_ACCOUNT), autospec=True
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.FileUpload.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
         return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
     def test_sync_from_stripe_data(
-        self, payment_intent_retrieve_mock, customer_retrieve_mock
+        self,
+        subscription_retrieve_mock,
+        product_retrieve_mock,
+        payment_intent_retrieve_mock,
+        invoice_retrieve_mock,
+        file_retrieve_mock,
+        customer_retrieve_mock,
+        charge_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        account_retrieve_mock,
     ):
         fake_payment_intent = deepcopy(FAKE_SESSION_I)
 
@@ -34,12 +76,14 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         self.assert_fks(
             session,
             expected_blank_fks={
+                "djstripe.Charge.dispute",
+                "djstripe.Charge.transfer",
                 "djstripe.Customer.coupon",
                 "djstripe.Customer.default_payment_method",
                 "djstripe.Customer.subscriber",
-                "djstripe.PaymentIntent.invoice (related name)",
                 "djstripe.PaymentIntent.on_behalf_of",
                 "djstripe.PaymentIntent.payment_method",
                 "djstripe.Session.subscription",
+                "djstripe.Subscription.pending_setup_intent",
             },
         )


### PR DESCRIPTION
Attempt to resolve #970 

eg so PaymentIntent syncs Invoice (due to Invoice.payment_intent OneToOneField)

Work in progress, not working currently (tests failing)