### PR TITLE
Use StripeQuantumCurrencyAmountField for balance

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -917,7 +917,7 @@ class Migration(migrations.Migration):
                 ("djstripe_updated", models.DateTimeField(auto_now=True)),
                 (
                     "account_balance",
-                    models.IntegerField(
+                    djstripe.fields.StripeQuantumCurrencyAmountField(
                         help_text="Current balance, if any, being stored on the customer's account. If negative, the customer has credit to apply to the next invoice. If positive, the customer has an amount owed that will be added to the next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account for recurring billing purposes (i.e., subscriptions, invoices, invoice items)."
                     ),
                 ),
@@ -1383,7 +1383,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "ending_balance",
-                    models.IntegerField(
+                    djstripe.fields.StripeQuantumCurrencyAmountField(
                         help_text="Ending customer balance after attempting to pay invoice. If the invoice has not been attempted yet, this will be null.",
                         null=True,
                     ),
@@ -1458,7 +1458,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "starting_balance",
-                    models.IntegerField(
+                    djstripe.fields.StripeQuantumCurrencyAmountField(
                         help_text="Starting customer balance before attempting to pay invoice. If the invoice has not been attempted yet, this will be the current customer balance."
                     ),
                 ),

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -18,6 +18,7 @@ from ..fields import (
     StripeEnumField,
     StripeIdField,
     StripePercentField,
+    StripeQuantumCurrencyAmountField,
 )
 from ..managers import SubscriptionManager
 from ..utils import QuerySetMock, get_friendly_currency_amount
@@ -232,7 +233,7 @@ class Invoice(StripeModel):
             "This value will be null for invoices where billing=charge_automatically."
         ),
     )
-    ending_balance = models.IntegerField(
+    ending_balance = StripeQuantumCurrencyAmountField(
         null=True,
         help_text="Ending customer balance after attempting to pay invoice. "
         "If the invoice has not been attempted yet, this will be null.",
@@ -305,7 +306,7 @@ class Invoice(StripeModel):
             "sent for this invoice."
         ),
     )
-    starting_balance = models.IntegerField(
+    starting_balance = StripeQuantumCurrencyAmountField(
         help_text="Starting customer balance before attempting to pay invoice. "
         "If the invoice has not been attempted "
         "yet, this will be the current customer balance."

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -376,7 +376,7 @@ class Customer(StripeModel):
     stripe_dashboard_item_name = "customers"
 
     address = JSONField(null=True, blank=True, help_text="The customer's address.")
-    balance = models.IntegerField(
+    balance = StripeQuantumCurrencyAmountField(
         help_text=(
             "Current balance, if any, being stored on the customer's account. "
             "If negative, the customer has credit to apply to the next invoice. "


### PR DESCRIPTION
Instead of a plain IntegerField.  Note that this is non-breaking change since it's still an integer number of cents.

Resolves #971