### PR TITLE
Implement PaymentMethod.detach()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ This is a bugfix-only version:
 - Fixed issue syncing PaymentIntent with destination charge (#960).
 - Fixed ``Customer.subscription`` & ``.valid_subscriptions()`` to ignore ``status=incomplete_expired`` (#1006).
 - Fixed error on ``paymentmethod.detached`` event with ``card_xxx`` payment methods (#967).
+- Added ``PaymentMethod.detach()`` (#943).
 - Updated ``help_text`` on all currency fields to make it clear if they're holding integer cents
   (``StripeQuantumCurrencyAmountField``) or decimal dollar (or euro, pound etc) (``StripeDecimalCurrencyAmountField``) (#999)
 - Documented our preferred Django model field types (#986)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -269,11 +269,6 @@ class CardDict(LegacySourceDict):
 
 FAKE_CARD = CardDict(load_fixture("card_card_fakefakefakefakefake0001.json"))
 
-# FAKE_CARD, but accessed as a PaymentMethod
-FAKE_CARD_AS_PAYMENT_METHOD = load_fixture(
-    "payment_method_card_fakefakefakefakefake0001.json"
-)
-
 FAKE_CARD_II = CardDict(load_fixture("card_card_fakefakefakefakefake0002.json"))
 
 FAKE_CARD_III = CardDict(
@@ -408,6 +403,11 @@ class PaymentMethodDict(dict):
 
 FAKE_PAYMENT_METHOD_I = PaymentMethodDict(
     load_fixture("payment_method_pm_fakefakefakefake0001.json")
+)
+
+# FAKE_CARD, but accessed as a PaymentMethod
+FAKE_CARD_AS_PAYMENT_METHOD = PaymentMethodDict(
+    load_fixture("payment_method_card_fakefakefakefakefake0001.json")
 )
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -398,7 +398,18 @@ FAKE_SOURCE_II = SourceDict(
 
 
 FAKE_PAYMENT_INTENT_I = load_fixture("payment_intent_pi_fakefakefakefakefake0001.json")
-FAKE_PAYMENT_METHOD_I = load_fixture("payment_method_pm_fakefakefakefake0001.json")
+
+
+class PaymentMethodDict(dict):
+    def detach(self):
+        self.pop("customer")
+        return self
+
+
+FAKE_PAYMENT_METHOD_I = PaymentMethodDict(
+    load_fixture("payment_method_pm_fakefakefakefake0001.json")
+)
+
 
 # TODO - add to regenerate_test_fixtures and replace this with a JSON fixture
 FAKE_SETUP_INTENT_I = {

--- a/tests/test_payment_method.py
+++ b/tests/test_payment_method.py
@@ -12,6 +12,7 @@ from stripe.error import InvalidRequestError
 from djstripe.models import PaymentMethod
 
 from . import (
+    FAKE_CARD_AS_PAYMENT_METHOD,
     FAKE_CUSTOMER,
     FAKE_PAYMENT_METHOD_I,
     AssertStripeFksMixin,
@@ -142,30 +143,75 @@ class PaymentMethodTest(AssertStripeFksMixin, TestCase):
                 payment_method.detach(), "Second call to detach should return false"
             )
 
+    def test_detach_card(self):
+        original_detach = PaymentMethodDict.detach
+
+        # "card_" payment methods are deleted after detach
+        deleted_card_exception = InvalidRequestError(
+            message="No such payment_method: card_xxxx",
+            param="payment_method",
+            code="resource_missing",
+        )
+
+        def mocked_detach(*args, **kwargs):
+            return original_detach(*args, **kwargs)
+
+        with patch(
+            "stripe.PaymentMethod.retrieve",
+            return_value=deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
+            autospec=True,
+        ):
+            PaymentMethod.sync_from_stripe_data(deepcopy(FAKE_CARD_AS_PAYMENT_METHOD))
+
         self.assertEqual(1, self.customer.payment_methods.count())
 
         payment_method = self.customer.payment_methods.first()
 
+        self.assertTrue(
+            payment_method.id.startswith("card_"), "We expect this to be a 'card_'"
+        )
+
         with patch(
             "tests.PaymentMethodDict.detach", side_effect=mocked_detach, autospec=True
-        ) as mock_detach:
-            payment_method.detach()
+        ) as mock_detach, patch(
+            "stripe.PaymentMethod.retrieve",
+            return_value=deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
+            autospec=True,
+        ):
+            self.assertTrue(payment_method.detach())
 
         self.assertEqual(0, self.customer.payment_methods.count())
-        # need to refresh_from_db since default_payment_method was cleared with a query
-        self.customer.refresh_from_db()
         self.assertIsNone(self.customer.default_payment_method)
 
-        self.assertIsNone(payment_method.customer)
+        self.assertEqual(
+            PaymentMethod.objects.filter(id=payment_method.id).count(),
+            0,
+            "We expect PaymentMethod id = card_* to be deleted",
+        )
 
         if sys.version_info >= (3, 6):
             # this mock isn't working on py34, py35, but it's not strictly necessary
             # for the test
             mock_detach.assert_called()
 
-        self.assert_fks(
-            payment_method, expected_blank_fks={"djstripe.PaymentMethod.customer"}
-        )
+        with patch(
+            "tests.PaymentMethodDict.detach",
+            side_effect=InvalidRequestError(
+                message="A source must be attached to a customer to be used "
+                "as a `payment_method`",
+                param="payment_method",
+            ),
+            autospec=True,
+        ) as mock_detach, patch(
+            "stripe.PaymentMethod.retrieve",
+            side_effect=deleted_card_exception,
+            autospec=True,
+        ) as payment_method_retrieve_mock:
+            payment_method_retrieve_mock.return_value["customer"] = None
+
+            self.assertFalse(
+                payment_method.detach(), "Second call to detach should return false"
+            )
 
     def test_sync_null_customer(self):
         payment_method = PaymentMethod.sync_from_stripe_data(


### PR DESCRIPTION
Closely modelled on Source.detach(), the difference being

a) This handles the special case of legacy "card"-type PaymentMethods as per #967 
b) This does a refresh_from_db with non-"card"-type payment methods (in anticipation of changing the other similar methods #1016)

Resolves #943

- [x] Test