### PR TITLE
Avoid stripe==2.36.0 due to regression (stable 2.0 branch)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.0.5 (unreleased)
+------------------
+
+This is a bugfix-only version:
+
+- Avoid stripe==2.36.0 due to regression (#991)
+
 2.0.4 (2019-09-09)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dj-stripe
-version = 2.0.4
+version = 2.0.5dev
 description = Django + Stripe Made Easy
 author = Alexander Kavanaugh
 author_email = alex@kavdev.io
@@ -30,7 +30,8 @@ zip_safe = False
 install_requires =
 	Django >= 2.0
 	jsonfield >= 2.0.2
-	stripe >= 2.3.0
+	# avoid 2.36.0, see https://github.com/dj-stripe/dj-stripe/issues/991
+	stripe >= 2.3.0, != 2.36.0
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Resolves #991