### PR TITLE
Do signature_validation of test webhook events

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -145,10 +145,6 @@ class WebhookEventTrigger(models.Model):
         if "id" not in local_data or "livemode" not in local_data:
             return False
 
-        if self.is_test_event:
-            logger.info("Test webhook received: {}".format(local_data))
-            return False
-
         if djstripe_settings.WEBHOOK_VALIDATION is None:
             # validation disabled
             return True

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -8,6 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
+from . import settings as djstripe_settings
 from .models import WebhookEventTrigger
 
 logger = logging.getLogger(__name__)
@@ -34,8 +35,12 @@ class ProcessWebhookView(View):
 
         trigger = WebhookEventTrigger.from_request(request)
 
-        if trigger.is_test_event:
-            # Since we don't do signature verification, we have to skip trigger.valid
+        if (
+            trigger.is_test_event
+            and djstripe_settings.WEBHOOK_VALIDATION != "verify_signature"
+        ):
+            # Since we're not doing signature verification,
+            # we have to skip trigger.valid
             return HttpResponse("Test webhook successfully received!")
 
         if not trigger.valid:


### PR DESCRIPTION
Work in progress on potential fix for #1002 .

Needs more work because currently test events will try to create objects, and fail with a server error since they don't exist in stripe db - I'm not sure what point we should stop them.