### PR TITLE
Fix Customer.subscription/.valid_subscriptions()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ This is a bugfix-only version:
 
 - Updated webhook signals list (#1000)
 - Fixed issue syncing PaymentIntent with destination charge (#960)
+- Fixed `Customer.subscription` & `.valid_subscriptions()` to ignore `status=incomplete_expired` (#1006)
 
 Upcoming migration of currency fields (storage as cents instead of dollars)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1068,9 +1068,14 @@ class Customer(StripeModel):
     def valid_subscriptions(self):
         """
         Returns this customer's valid subscriptions
-        (subscriptions that aren't cancelled).
+        (subscriptions that aren't canceled or incomplete_expired).
         """
-        return self.subscriptions.exclude(status=enums.SubscriptionStatus.canceled)
+        return self.subscriptions.exclude(
+            status__in=[
+                enums.SubscriptionStatus.canceled,
+                enums.SubscriptionStatus.incomplete_expired,
+            ]
+        )
 
     @property
     def subscription(self):


### PR DESCRIPTION
To ignore status=incomplete_expired, since it's a terminal state.  Resolves #1006