### PR TITLE
Handle special case of paymentmethod.detached with card_xxx

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ This is a bugfix-only version:
 - Updated webhook signals list (#1000).
 - Fixed issue syncing PaymentIntent with destination charge (#960).
 - Fixed ``Customer.subscription`` & ``.valid_subscriptions()`` to ignore ``status=incomplete_expired`` (#1006).
+- Fixed error on ``paymentmethod.detached`` event with ``card_xxx`` payment methods (#967).
 
 Upcoming migration of currency fields (storage as cents instead of dollars)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -114,6 +114,35 @@ def customer_subscription_webhook_handler(event):
     _handle_crud_like_event(target_cls=models.Subscription, event=event)
 
 
+@webhooks.handler("payment_method")
+def payment_method_handler(event):
+    """
+    Handle updates to payment_method objects
+    :param event:
+    :return:
+
+    Docs for:
+    - payment_method: https://stripe.com/docs/api/payment_methods
+    """
+    id_ = event.data.get("object", {}).get("id", None)
+
+    if (
+        event.parts == ["payment_method", "detached"]
+        and id_
+        and id_.startswith("card_")
+    ):
+        # Special case to handle a quirk in stripe's wrapping of legacy "card" objects
+        # with payment_methods - card objects are deleted on detach, so treat this as
+        # a delete event
+        _handle_crud_like_event(
+            target_cls=models.PaymentMethod,
+            event=event,
+            crud_type=CrudType(deleted=True),
+        )
+    else:
+        _handle_crud_like_event(target_cls=models.PaymentMethod, event=event)
+
+
 @webhooks.handler(
     "transfer",
     "charge",
@@ -121,7 +150,6 @@ def customer_subscription_webhook_handler(event):
     "invoice",
     "invoiceitem",
     "payment_intent",
-    "payment_method",
     "plan",
     "product",
     "setup_intent",
@@ -129,8 +157,8 @@ def customer_subscription_webhook_handler(event):
 )
 def other_object_webhook_handler(event):
     """
-    Handle updates to transfer, charge, invoice, invoiceitem, plan, product
-    and source objects.
+    Handle updates to transfer, charge, coupon, invoice, invoiceitem, payment_intent,
+    plan, product, setup_intent and source objects.
 
     Docs for:
     - charge: https://stripe.com/docs/api#charges
@@ -140,7 +168,6 @@ def other_object_webhook_handler(event):
     - plan: https://stripe.com/docs/api#plans
     - product: https://stripe.com/docs/api#products
     - source: https://stripe.com/docs/api#sources
-    - payment_method: https://stripe.com/docs/api/payment_methods
     - payment_intent: https://stripe.com/docs/api/payment_intents
     """
 
@@ -155,7 +182,6 @@ def other_object_webhook_handler(event):
             "invoice": models.Invoice,
             "invoiceitem": models.InvoiceItem,
             "payment_intent": models.PaymentIntent,
-            "payment_method": models.PaymentMethod,
             "plan": models.Plan,
             "product": models.Product,
             "transfer": models.Transfer,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1463,6 +1463,45 @@ FAKE_EVENT_PAYMENT_METHOD_ATTACHED = {
     "type": "payment_method.attached",
 }
 
+FAKE_EVENT_PAYMENT_METHOD_DETACHED = {
+    "id": "evt_1FDOwDKatMEEd998o5Fdadfds",
+    "object": "event",
+    "api_version": "2019-08-14",
+    "created": 1567228549,
+    "data": {"object": deepcopy(FAKE_PAYMENT_METHOD_I)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": {"id": "req_9c9djVqxcxgdfg", "idempotency_key": None},
+    "type": "payment_method.detached",
+}
+FAKE_EVENT_PAYMENT_METHOD_DETACHED["data"]["object"]["customer"] = None
+
+FAKE_EVENT_CARD_PAYMENT_METHOD_ATTACHED = {
+    "id": "evt_1FDOwDKatMEEd998o5Fghgfh",
+    "object": "event",
+    "api_version": "2019-08-14",
+    "created": 1567228549,
+    "data": {"object": deepcopy(FAKE_CARD_AS_PAYMENT_METHOD)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": {"id": "req_9c9djVqxUhgfh", "idempotency_key": None},
+    "type": "payment_method.attached",
+}
+
+FAKE_EVENT_CARD_PAYMENT_METHOD_DETACHED = {
+    "id": "evt_1FDOwDKatMEEd998o5435345",
+    "object": "event",
+    "api_version": "2019-08-14",
+    "created": 1567228549,
+    "data": {"object": deepcopy(FAKE_CARD_AS_PAYMENT_METHOD)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": {"id": "req_9c9djVqx6tgeg", "idempotency_key": None},
+    "type": "payment_method.detached",
+}
+# Note that the event from Stripe doesn't have customer = None
+
+
 FAKE_EVENT_PLAN_CREATED = {
     "id": "evt_1877X72eZvKYlo2CLK6daFxu",
     "object": "event",


### PR DESCRIPTION
Special case to handle a quirk in stripe's wrapping of legacy "card" objects with payment_methods - card objects are deleted on detach, so treat this as a delete event.

Resolves #967