### PR TITLE
State field currency units in the help text

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ This is a bugfix-only version:
 - Fixed issue syncing PaymentIntent with destination charge (#960).
 - Fixed ``Customer.subscription`` & ``.valid_subscriptions()`` to ignore ``status=incomplete_expired`` (#1006).
 - Fixed error on ``paymentmethod.detached`` event with ``card_xxx`` payment methods (#967).
+- Updated ``help_text`` on all currency fields to make it clear if they're holding integer cents (``StripeQuantumCurrencyAmountField``)
+  or decimal dolllar (or euro etc) (``StripeQuantumCurrencyAmountField``) (#999)
 
 Upcoming migration of currency fields (storage as cents instead of dollars)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,8 +12,8 @@ This is a bugfix-only version:
 - Fixed issue syncing PaymentIntent with destination charge (#960).
 - Fixed ``Customer.subscription`` & ``.valid_subscriptions()`` to ignore ``status=incomplete_expired`` (#1006).
 - Fixed error on ``paymentmethod.detached`` event with ``card_xxx`` payment methods (#967).
-- Updated ``help_text`` on all currency fields to make it clear if they're holding integer cents (``StripeQuantumCurrencyAmountField``)
-  or decimal dolllar (or euro etc) (``StripeQuantumCurrencyAmountField``) (#999)
+- Updated ``help_text`` on all currency fields to make it clear if they're holding integer cents
+  (``StripeQuantumCurrencyAmountField``) or decimal dollar (or euro, pound etc) (``StripeDecimalCurrencyAmountField``) (#999)
 
 Upcoming migration of currency fields (storage as cents instead of dollars)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -594,14 +594,16 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
-                        decimal_places=2, help_text="Amount charged.", max_digits=8
+                        decimal_places=2,
+                        help_text="Amount charged (as decimal).",
+                        max_digits=8,
                     ),
                 ),
                 (
                     "amount_refunded",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="Amount refunded (can be less than the amount attribute on the charge if a partial refund was issued).",
+                        help_text="Amount (as decimal) refunded (can be less than the amount attribute on the charge if a partial refund was issued).",
                         max_digits=8,
                     ),
                 ),
@@ -804,7 +806,7 @@ class Migration(migrations.Migration):
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         blank=True,
                         decimal_places=2,
-                        help_text="Amount that will be taken off the subtotal of any invoices for this customer.",
+                        help_text="Amount (as decimal) that will be taken off the subtotal of any invoices for this customer.",
                         max_digits=8,
                         null=True,
                     ),
@@ -918,7 +920,7 @@ class Migration(migrations.Migration):
                 (
                     "account_balance",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Current balance, if any, being stored on the customer's account. If negative, the customer has credit to apply to the next invoice. If positive, the customer has an amount owed that will be added to the next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account for recurring billing purposes (i.e., subscriptions, invoices, invoice items)."
+                        help_text="Current balance (in cents), if any, being stored on the customer's account. If negative, the customer has credit to apply to the next invoice. If positive, the customer has an amount owed that will be added to the next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account for recurring billing purposes (i.e., subscriptions, invoices, invoice items)."
                     ),
                 ),
                 (
@@ -1030,7 +1032,7 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Disputed amount. Usually the amount of the charge, but can differ (usually because of currency fluctuation or because only part of the order is disputed)."
+                        help_text="Disputed amount (in cents). Usually the amount of the charge, but can differ (usually because of currency fluctuation or because only part of the order is disputed)."
                     ),
                 ),
                 (
@@ -1302,7 +1304,7 @@ class Migration(migrations.Migration):
                     "amount_due",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="Final amount due at this time for this invoice. If the invoice's total is smaller than the minimum charge amount, for example, or if there is account credit that can be applied to the invoice, the amount_due may be 0. If there is a positive starting_balance for the invoice (the customer owes money), the amount_due will also take that into account. The charge that gets generated for the invoice will be for the amount specified in amount_due.",
+                        help_text="Final amount due (as decimal) at this time for this invoice. If the invoice's total is smaller than the minimum charge amount, for example, or if there is account credit that can be applied to the invoice, the amount_due may be 0. If there is a positive starting_balance for the invoice (the customer owes money), the amount_due will also take that into account. The charge that gets generated for the invoice will be for the amount specified in amount_due.",
                         max_digits=8,
                     ),
                 ),
@@ -1310,7 +1312,7 @@ class Migration(migrations.Migration):
                     "amount_paid",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="The amount, in cents, that was paid.",
+                        help_text="The amount, (as decimal), that was paid.",
                         max_digits=8,
                         null=True,
                     ),
@@ -1319,7 +1321,7 @@ class Migration(migrations.Migration):
                     "amount_remaining",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="The amount remaining, in cents, that is due.",
+                        help_text="The amount remaining, (as decimal), that is due.",
                         max_digits=8,
                         null=True,
                     ),
@@ -1328,7 +1330,7 @@ class Migration(migrations.Migration):
                     "application_fee",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="The fee in cents that will be applied to the invoice and transferred to the application owner's Stripe account when the invoice is paid.",
+                        help_text="The fee (as decimal) that will be applied to the invoice and transferred to the application owner's Stripe account when the invoice is paid.",
                         max_digits=8,
                         null=True,
                     ),
@@ -1384,7 +1386,7 @@ class Migration(migrations.Migration):
                 (
                     "ending_balance",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Ending customer balance after attempting to pay invoice. If the invoice has not been attempted yet, this will be null.",
+                        help_text="Ending customer balance (in cents) after attempting to pay invoice. If the invoice has not been attempted yet, this will be null.",
                         null=True,
                     ),
                 ),
@@ -1459,7 +1461,7 @@ class Migration(migrations.Migration):
                 (
                     "starting_balance",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Starting customer balance before attempting to pay invoice. If the invoice has not been attempted yet, this will be the current customer balance."
+                        help_text="Starting customer balance (in cents) before attempting to pay invoice. If the invoice has not been attempted yet, this will be the current customer balance."
                     ),
                 ),
                 (
@@ -1483,7 +1485,7 @@ class Migration(migrations.Migration):
                     "subtotal",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="Only set for upcoming invoices that preview prorations. The time used to calculate prorations.",
+                        help_text="Total (as decimal) of all subscriptions, invoice items, and prorations on the invoice before any discount or tax is applied.",
                         max_digits=8,
                     ),
                 ),
@@ -1491,7 +1493,7 @@ class Migration(migrations.Migration):
                     "tax",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="The amount of tax included in the total, calculated from ``tax_percent`` and the subtotal. If no ``tax_percent`` is defined, this value will be null.",
+                        help_text="The amount (as decimal) of tax included in the total, calculated from ``tax_percent`` and the subtotal. If no ``tax_percent`` is defined, this value will be null.",
                         max_digits=8,
                         null=True,
                         blank=True,
@@ -1515,7 +1517,7 @@ class Migration(migrations.Migration):
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
                         max_digits=8,
-                        verbose_name="Total after discount.",
+                        verbose_name="Total (as decimal) after discount.",
                     ),
                 ),
                 (
@@ -1575,7 +1577,9 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
-                        decimal_places=2, help_text="Amount invoiced.", max_digits=8
+                        decimal_places=2,
+                        help_text="Amount invoiced (as decimal).",
+                        max_digits=8,
                     ),
                 ),
                 (
@@ -1695,7 +1699,7 @@ class Migration(migrations.Migration):
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="Amount to be transferred to your bank account or debit card.",
+                        help_text="Amount (as decimal) to be transferred to your bank account or debit card.",
                         max_digits=8,
                     ),
                 ),
@@ -1830,7 +1834,7 @@ class Migration(migrations.Migration):
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="Amount to be charged on the interval specified.",
+                        help_text="Amount (as decimal) to be charged on the interval specified.",
                         max_digits=8,
                     ),
                 ),
@@ -2220,7 +2224,7 @@ class Migration(migrations.Migration):
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         blank=True,
                         decimal_places=2,
-                        help_text="Amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single_use` sources.",
+                        help_text="Amount (as decimal) associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single_use` sources.",
                         max_digits=8,
                         null=True,
                     ),
@@ -2575,7 +2579,7 @@ class Migration(migrations.Migration):
                     "amount_reversed",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
                         decimal_places=2,
-                        help_text="The amount reversed (can be less than the amount attribute on the transfer if a partial reversal was issued).",
+                        help_text="The amount (as decimal) reversed (can be less than the amount attribute on the transfer if a partial reversal was issued).",
                         max_digits=8,
                         null=True,
                         blank=True,

--- a/djstripe/migrations/0003_auto_20181117_2328_squashed_0004_auto_20190227_2114.py
+++ b/djstripe/migrations/0003_auto_20181117_2328_squashed_0004_auto_20190227_2114.py
@@ -712,13 +712,13 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount earned."
+                        help_text="Amount earned, in cents."
                     ),
                 ),
                 (
                     "amount_refunded",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount refunded (can be less than the amount attribute on the fee if a partial refund was issued)"
+                        help_text="Amount in cents refunded (can be less than the amount attribute on the fee if a partial refund was issued)"
                     ),
                 ),
                 (
@@ -790,7 +790,7 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount refunded."
+                        help_text="Amount refunded, in cents."
                     ),
                 ),
                 (
@@ -1478,7 +1478,7 @@ class Migration(migrations.Migration):
             field=djstripe.fields.StripeDecimalCurrencyAmountField(
                 blank=True,
                 decimal_places=2,
-                help_text="Amount to be charged on the interval specified.",
+                help_text="Amount (as decimal) to be charged on the interval specified.",
                 max_digits=8,
                 null=True,
             ),

--- a/djstripe/migrations/0004_2_1.py
+++ b/djstripe/migrations/0004_2_1.py
@@ -414,19 +414,19 @@ class Migration(migrations.Migration):
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount intended to be collected by this PaymentIntent."
+                        help_text="Amount (in cents) intended to be collected by this PaymentIntent."
                     ),
                 ),
                 (
                     "amount_capturable",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount that can be captured from this PaymentIntent."
+                        help_text="Amount (in cents) that can be captured from this PaymentIntent."
                     ),
                 ),
                 (
                     "amount_received",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
-                        help_text="Amount that was collected by this PaymentIntent."
+                        help_text="Amount (in cents) that was collected by this PaymentIntent."
                     ),
                 ),
                 (

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -30,8 +30,8 @@ class Coupon(StripeModel):
     amount_off = StripeDecimalCurrencyAmountField(
         null=True,
         blank=True,
-        help_text="Amount that will be taken off the subtotal of any invoices "
-        "for this customer.",
+        help_text="Amount (as decimal) that will be taken off the subtotal of any "
+        "invoices for this customer.",
     )
     currency = StripeCurrencyCodeField(null=True, blank=True)
     duration = StripeEnumField(
@@ -152,7 +152,7 @@ class Invoice(StripeModel):
     stripe_dashboard_item_name = "invoices"
 
     amount_due = StripeDecimalCurrencyAmountField(
-        help_text="Final amount due at this time for this invoice. "
+        help_text="Final amount due (as decimal) at this time for this invoice. "
         "If the invoice's total is smaller than the minimum charge amount, "
         "for example, or if there is account credit that can be applied to the "
         "invoice, the amount_due may be 0. If there is a positive starting_balance "
@@ -162,11 +162,11 @@ class Invoice(StripeModel):
     )
     amount_paid = StripeDecimalCurrencyAmountField(
         null=True,  # XXX: This is not nullable, but it's a new field
-        help_text="The amount, in cents, that was paid.",
+        help_text="The amount, (as decimal), that was paid.",
     )
     amount_remaining = StripeDecimalCurrencyAmountField(
         null=True,  # XXX: This is not nullable, but it's a new field
-        help_text="The amount remaining, in cents, that is due.",
+        help_text="The amount remaining, (as decimal), that is due.",
     )
     auto_advance = models.NullBooleanField(
         help_text="Controls whether Stripe will perform automatic collection of the "
@@ -175,7 +175,7 @@ class Invoice(StripeModel):
     )
     application_fee_amount = StripeDecimalCurrencyAmountField(
         null=True,
-        help_text="The fee in cents that will be applied to the invoice and "
+        help_text="The fee (as decimal) that will be applied to the invoice and "
         "transferred to the application owner's "
         "Stripe account when the invoice is paid.",
     )
@@ -235,7 +235,7 @@ class Invoice(StripeModel):
     )
     ending_balance = StripeQuantumCurrencyAmountField(
         null=True,
-        help_text="Ending customer balance after attempting to pay invoice. "
+        help_text="Ending customer balance (in cents) after attempting to pay invoice. "
         "If the invoice has not been attempted yet, this will be null.",
     )
     # deprecated, will be removed in 2.2
@@ -307,9 +307,9 @@ class Invoice(StripeModel):
         ),
     )
     starting_balance = StripeQuantumCurrencyAmountField(
-        help_text="Starting customer balance before attempting to pay invoice. "
-        "If the invoice has not been attempted "
-        "yet, this will be the current customer balance."
+        help_text="Starting customer balance (in cents) before attempting to pay "
+        "invoice. If the invoice has not been attempted yet, this will be the "
+        "current customer balance."
     )
     statement_descriptor = models.CharField(
         max_length=22,
@@ -337,14 +337,14 @@ class Invoice(StripeModel):
         "The time used to calculate prorations.",
     )
     subtotal = StripeDecimalCurrencyAmountField(
-        help_text="Only set for upcoming invoices that preview prorations. "
-        "The time used to calculate prorations."
+        help_text="Total (as decimal) of all subscriptions, invoice items, "
+        "and prorations on the invoice before any discount or tax is applied."
     )
     tax = StripeDecimalCurrencyAmountField(
         null=True,
         blank=True,
-        help_text="The amount of tax included in the total, calculated from "
-        "``tax_percent`` and the subtotal. If no "
+        help_text="The amount (as decimal) of tax included in the total, calculated "
+        "from ``tax_percent`` and the subtotal. If no "
         "``tax_percent`` is defined, this value will be null.",
     )
     tax_percent = StripePercentField(
@@ -354,7 +354,7 @@ class Invoice(StripeModel):
         "This field is inherited from the subscription's ``tax_percent`` field, "
         "but can be changed before the invoice is paid. This field defaults to null.",
     )
-    total = StripeDecimalCurrencyAmountField("Total after discount.")
+    total = StripeDecimalCurrencyAmountField("Total (as decimal) after discount.")
     webhooks_delivered_at = StripeDateTimeField(
         null=True,
         help_text=(
@@ -639,7 +639,7 @@ class InvoiceItem(StripeModel):
 
     stripe_class = stripe.InvoiceItem
 
-    amount = StripeDecimalCurrencyAmountField(help_text="Amount invoiced.")
+    amount = StripeDecimalCurrencyAmountField(help_text="Amount invoiced (as decimal).")
     currency = StripeCurrencyCodeField()
     customer = models.ForeignKey(
         "Customer",
@@ -768,7 +768,7 @@ class Plan(StripeModel):
     amount = StripeDecimalCurrencyAmountField(
         null=True,
         blank=True,
-        help_text="Amount to be charged on the interval specified.",
+        help_text="Amount (as decimal) to be charged on the interval specified.",
     )
     billing_scheme = StripeEnumField(
         enum=enums.PlanBillingScheme,

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -385,9 +385,9 @@ class ApplicationFee(StripeModel):
 
     stripe_class = stripe.ApplicationFee
 
-    amount = StripeQuantumCurrencyAmountField(help_text="Amount earned.")
+    amount = StripeQuantumCurrencyAmountField(help_text="Amount earned, in cents.")
     amount_refunded = StripeQuantumCurrencyAmountField(
-        help_text="Amount refunded (can be less than the amount attribute "
+        help_text="Amount in cents refunded (can be less than the amount attribute "
         "on the fee if a partial refund was issued)"
     )
     # TODO application = ...
@@ -424,7 +424,7 @@ class ApplicationFeeRefund(StripeModel):
 
     description = None
 
-    amount = StripeQuantumCurrencyAmountField(help_text="Amount refunded.")
+    amount = StripeQuantumCurrencyAmountField(help_text="Amount refunded, in cents.")
     balance_transaction = models.ForeignKey(
         "BalanceTransaction",
         on_delete=models.CASCADE,
@@ -502,8 +502,8 @@ class Transfer(StripeModel):
     amount_reversed = StripeDecimalCurrencyAmountField(
         null=True,
         blank=True,
-        help_text="The amount reversed (can be less than the amount attribute on the"
-        " transfer if a partial reversal was issued).",
+        help_text="The amount (as decimal) reversed (can be less than the amount "
+        "attribute on the transfer if a partial reversal was issued).",
     )
     balance_transaction = models.ForeignKey(
         "BalanceTransaction",

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -78,11 +78,11 @@ class Charge(StripeModel):
     expand_fields = ["balance_transaction"]
     stripe_dashboard_item_name = "payments"
 
-    amount = StripeDecimalCurrencyAmountField(help_text="Amount charged.")
+    amount = StripeDecimalCurrencyAmountField(help_text="Amount charged (as decimal).")
     amount_refunded = StripeDecimalCurrencyAmountField(
         help_text=(
-            "Amount refunded (can be less than the amount attribute on the charge "
-            "if a partial refund was issued)."
+            "Amount (as decimal) refunded (can be less than the amount attribute on the "
+            "charge if a partial refund was issued)."
         )
     )
     # TODO: application, application_fee
@@ -401,7 +401,8 @@ class Customer(StripeModel):
     address = JSONField(null=True, blank=True, help_text="The customer's address.")
     balance = StripeQuantumCurrencyAmountField(
         help_text=(
-            "Current balance, if any, being stored on the customer's account. "
+            "Current balance (in cents), if any, being stored on the customer's "
+            "account. "
             "If negative, the customer has credit to apply to the next invoice. "
             "If positive, the customer has an amount owed that will be added to the "
             "next invoice. The balance does not refer to any unpaid invoices; it "
@@ -1275,7 +1276,8 @@ class Dispute(StripeModel):
 
     amount = StripeQuantumCurrencyAmountField(
         help_text=(
-            "Disputed amount. Usually the amount of the charge, but can differ "
+            "Disputed amount (in cents). Usually the amount of the charge, "
+            "but can differ "
             "(usually because of currency fluctuation or because only part of "
             "the order is disputed)."
         )
@@ -1448,13 +1450,13 @@ class PaymentIntent(StripeModel):
     stripe_dashboard_item_name = "payments"
 
     amount = StripeQuantumCurrencyAmountField(
-        help_text="Amount intended to be collected by this PaymentIntent."
+        help_text="Amount (in cents) intended to be collected by this PaymentIntent."
     )
     amount_capturable = StripeQuantumCurrencyAmountField(
-        help_text="Amount that can be captured from this PaymentIntent."
+        help_text="Amount (in cents) that can be captured from this PaymentIntent."
     )
     amount_received = StripeQuantumCurrencyAmountField(
-        help_text="Amount that was collected by this PaymentIntent."
+        help_text="Amount (in cents) that was collected by this PaymentIntent."
     )
     # application
     # application_fee_amount
@@ -1759,7 +1761,8 @@ class Payout(StripeModel):
     stripe_dashboard_item_name = "payouts"
 
     amount = StripeDecimalCurrencyAmountField(
-        help_text="Amount to be transferred to your bank account or debit card."
+        help_text="Amount (as decimal) to be transferred to your bank account or "
+        "debit card."
     )
     arrival_date = StripeDateTimeField(
         help_text=(

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -81,8 +81,8 @@ class Charge(StripeModel):
     amount = StripeDecimalCurrencyAmountField(help_text="Amount charged (as decimal).")
     amount_refunded = StripeDecimalCurrencyAmountField(
         help_text=(
-            "Amount (as decimal) refunded (can be less than the amount attribute on the "
-            "charge if a partial refund was issued)."
+            "Amount (as decimal) refunded (can be less than the amount attribute on "
+            "the charge if a partial refund was issued)."
         )
     )
     # TODO: application, application_fee

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -382,7 +382,7 @@ class Source(StripeModel):
         null=True,
         blank=True,
         help_text=(
-            "Amount associated with the source. "
+            "Amount (as decimal) associated with the source. "
             "This is the amount for which the source will be chargeable once ready. "
             "Required for `single_use` sources."
         ),


### PR DESCRIPTION
* Fixes a few that were misleading (Invoice.amount_paid, .amount_remaining, .application_fee_amount all stated they were in cents but were actually decimal)
* Fixes Invoice.subtotal (was copypasta)

Resolves #999

PS, if anyone's aware of a tool that would semi-automate these sorts of non-schema-changing migration re-writes, please let me know!