### PR TITLE
Change to a non-universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ exclude =
     tests.*
 
 [bdist_wheel]
-universal = 1
+universal = 0


### PR DESCRIPTION
Since we're not python 2 compatible, there seems to be no point?