### PR TITLE
Switch jsonfield dependency to jsonfield2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,19 @@ History
 - Dropped previously-deprecated properties ``Invoice.application_fee``, ``Invoice.date``
 - Dropped previously-deprecated enum ``PaymentMethodType`` (use ``DjstripePaymentMethodType`` instead)
 - Change urls.py to use the new style urls.
+- Upgraded `jsonfield`_ dependency to `jsonfield2`_, for Django 3 forward-compatibility.
+
+.. warning::
+
+    Both **jsonfield** and **jsonfield2** use the same import path, so be sure
+    to install jsonfield2 *after* uninstalling jsonfield in an existing virtualenv.
+    Otherwise, a ``pip uninstall jsonfield`` will remove jsonfield2’s ``jsonfield``
+    module from ``site-packages``.
+
+.. _jsonfield: https://github.com/dmkoch/django-jsonfield/
+.. _jsonfield2: https://github.com/rpkilby/jsonfield2/
+
+    
 
 2.1.1 (2019-10-01)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 2.2.0 (unreleased)
 ------------------
 
+- Changed `JSONField` dependent package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see warning below).
 - Dropped previously-deprecated ``Account`` fields (see https://stripe.com/docs/upgrades#2019-02-19 ):
     - ``.business_name``
     - ``.business_primary_color``
@@ -27,14 +28,20 @@ History
 - Dropped previously-deprecated properties ``Invoice.application_fee``, ``Invoice.date``
 - Dropped previously-deprecated enum ``PaymentMethodType`` (use ``DjstripePaymentMethodType`` instead)
 - Change urls.py to use the new style urls.
-- Upgraded `jsonfield`_ dependency to `jsonfield2`_, for Django 3 forward-compatibility.
+
+Safe uninstall of jsonfield if upgrading from dj-stripe<2.2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
 
-    Both **jsonfield** and **jsonfield2** use the same import path, so be sure
-    to install jsonfield2 *after* uninstalling jsonfield in an existing virtualenv.
-    Otherwise, a ``pip uninstall jsonfield`` will remove jsonfield2’s ``jsonfield``
-    module from ``site-packages``.
+    Both **jsonfield** and **jsonfield2** use the same import path, so if upgrading to dj-stripe>=2.2
+    in an existing virtualenv, sure to uninstall jsonfield first.  eg::
+    
+    pip uninstall jsonfield -y && pip install "dj-stripe>=2.2.0dev"
+    
+    
+    Otherwise, ``pip uninstall jsonfield`` will remove jsonfield2’s ``jsonfield``
+    module from ``site-packages`` (running the above command should resolve this if you have hit this issue).
 
 .. _jsonfield: https://github.com/dmkoch/django-jsonfield/
 .. _jsonfield2: https://github.com/rpkilby/jsonfield2/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,7 +42,12 @@ Warning about safe uninstall of jsonfield on upgrade
 
 
     Otherwise, ``pip uninstall jsonfield`` will remove jsonfield2’s ``jsonfield``
-    module from ``site-packages``. running the above command should resolve this if you have hit this issue).
+    module from ``site-packages``, which would cause errors like ``ImportError: cannot import name 'JSONField' from 'jsonfield' (unknown location)``
+
+    If you have hit this ImportError already after upgrading, running this should resolve it::
+
+        # remove both jsonfield packages before reinstall to fix ImportError:
+        pip uninstall jsonfield jsonfield2 -y && pip install "dj-stripe>=2.2.0dev"
 
 .. _jsonfield: https://github.com/dmkoch/django-jsonfield/
 .. _jsonfield2: https://github.com/rpkilby/jsonfield2/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 2.2.0 (unreleased)
 ------------------
 
-- Changed `JSONField` dependent package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see warning below).
+- Changed ``JSONField`` dependency package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see `Warning about safe uninstall of jsonfield on upgrade`_).
 - Dropped previously-deprecated ``Account`` fields (see https://stripe.com/docs/upgrades#2019-02-19 ):
     - ``.business_name``
     - ``.business_primary_color``
@@ -29,24 +29,25 @@ History
 - Dropped previously-deprecated enum ``PaymentMethodType`` (use ``DjstripePaymentMethodType`` instead)
 - Change urls.py to use the new style urls.
 
-Safe uninstall of jsonfield if upgrading from dj-stripe<2.2
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning about safe uninstall of jsonfield on upgrade
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
 
     Both **jsonfield** and **jsonfield2** use the same import path, so if upgrading to dj-stripe>=2.2
     in an existing virtualenv, sure to uninstall jsonfield first.  eg::
-    
-    pip uninstall jsonfield -y && pip install "dj-stripe>=2.2.0dev"
-    
-    
+
+        # ensure jsonfield is uninstalled before we install jsonfield2
+        pip uninstall jsonfield -y && pip install "dj-stripe>=2.2.0dev"
+
+
     Otherwise, ``pip uninstall jsonfield`` will remove jsonfield2’s ``jsonfield``
-    module from ``site-packages`` (running the above command should resolve this if you have hit this issue).
+    module from ``site-packages``. running the above command should resolve this if you have hit this issue).
 
 .. _jsonfield: https://github.com/dmkoch/django-jsonfield/
 .. _jsonfield2: https://github.com/rpkilby/jsonfield2/
 
-    
+
 
 2.1.1 (2019-10-01)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     Django >= 2.1
-    jsonfield >= 2.0.2
+    jsonfield2
     # >= 2.32.0 needed for stripe.SetupIntent
     # avoid 2.36.0, see https://github.com/dj-stripe/dj-stripe/issues/991
     stripe >= 2.32.0, != 2.36.0


### PR DESCRIPTION
jsonfield is no longer maintained and doesn't support Django 3.x, whereas jsonfield2 does.

We use jsonfield2 in one of our projects @theatlantic, and an unfortunate side-effect of installing dj-stripe is that it replaces jsonfield2 in site-packages (the maintainer of jsonfield2 made the unfortunate decision to keep the same module name).

refs #821