### PR TITLE
Fix Django 3.0 compatibility

### DIFF
--- a/djstripe/decorators.py
+++ b/djstripe/decorators.py
@@ -5,7 +5,6 @@ from functools import wraps
 
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
-from django.utils.decorators import available_attrs
 
 from .settings import SUBSCRIPTION_REDIRECT, subscriber_request_callback
 from .utils import subscriber_has_active_subscription
@@ -21,7 +20,7 @@ def subscriber_passes_pay_test(test_func, plan=None, pay_page=SUBSCRIPTION_REDIR
     """
 
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if test_func(subscriber_request_callback(request), plan):
                 return view_func(request, *args, **kwargs)


### PR DESCRIPTION
I'm pretty sure available_attrs can be removed safely, since on Django 2.2 it just returns functools.WRAPPER_ASSIGNMENTS, which is the default param of wraps (it doesn't do anything with the passed function).

Seems like it was a legacy python2 bugfix.

With this change and #1023 + https://github.com/rpkilby/jsonfield2/pull/16 tests are passing vs Django 3.0.

Refs #821.