### PR TITLE
Django 3.0 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,6 @@ matrix:
     - { python: "3.7", env: TOXENV=lint }
     - { python: "3.7", env: TOXENV=docs }
   allow_failures:
-    - env: TOXENV=py36-django30-postgres
-    - env: TOXENV=py37-django30-postgres
-    - env: TOXENV=py37-django30-mysql
-    - env: TOXENV=py37-django30-sqlite
-    - env: TOXENV=py37-django30-postgres_native_json
     - env: TOXENV=py37-djangomaster-postgres
 
 services:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ------------------
 
 - Changed ``JSONField`` dependency package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see `Warning about safe uninstall of jsonfield on upgrade`_).
+- Added support for Django 3.0 (requires jsonfield2>=3.0.3).
 - Dropped previously-deprecated ``Account`` fields (see https://stripe.com/docs/upgrades#2019-02-19 ):
     - ``.business_name``
     - ``.business_primary_color``

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 2.1
     Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
 
 [options]
 packages = find:
@@ -28,6 +29,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     Django >= 2.1
+    # >= 3.0.3 needed for Django 3
     jsonfield2
     # >= 2.32.0 needed for stripe.SetupIntent
     # avoid 2.36.0, see https://github.com/dj-stripe/dj-stripe/issues/991


### PR DESCRIPTION
Remove Django 3.0 from allowed failures now that jsonfield2>=3.0.3 supports Django 3.0

Resolves #821