### PR TITLE
Dont delete canceled subscriptions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,8 @@ History
 - Change urls.py to use the new style urls.
 - Update forward relation fields in the admin to be raw id fields.
 - Updated ``StripeQuantumCurrencyAmountField`` and ``StripeDecimalCurrencyAmountField`` to support Stripe Large Charges (#1045).
+- Update event handling so ``customer.subscription.deleted`` updates subscriptions to ``status="canceled"`` instead of
+  deleting it from our database,  to match Stripe's behaviour (#599).
 
 Warning about safe uninstall of jsonfield on upgrade
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -111,7 +111,12 @@ def customer_subscription_webhook_handler(event):
     Docs an example subscription webhook response:
     https://stripe.com/docs/api#subscription_object
     """
-    _handle_crud_like_event(target_cls=models.Subscription, event=event)
+
+    # Don't delete canceled subscriptions - https://github.com/dj-stripe/dj-stripe/issues/599#issuecomment-460143642
+    crud_type = CrudType.determine(event=event)
+    if crud_type.deleted:
+        crud_type = CrudType(updated=True)
+    _handle_crud_like_event(target_cls=models.Subscription, event=event, crud_type=crud_type)
 
 
 @webhooks.handler("payment_method")

--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -112,11 +112,15 @@ def customer_subscription_webhook_handler(event):
     https://stripe.com/docs/api#subscription_object
     """
 
-    # Don't delete canceled subscriptions - https://github.com/dj-stripe/dj-stripe/issues/599#issuecomment-460143642
+    # customer.subscription.deleted doesn't actually delete the subscription
+    # on the stripe side, it updates it to canceled status, so override
+    # crud_type to update to match.
     crud_type = CrudType.determine(event=event)
     if crud_type.deleted:
         crud_type = CrudType(updated=True)
-    _handle_crud_like_event(target_cls=models.Subscription, event=event, crud_type=crud_type)
+    _handle_crud_like_event(
+        target_cls=models.Subscription, event=event, crud_type=crud_type
+    )
 
 
 @webhooks.handler("payment_method")


### PR DESCRIPTION
Based on @unformatt's #858, updated to point at master, and fixed a test issue (need to tell the mock to use the cancelled version).

Resolves #599 , (see also the general case - #576).