### PR TITLE
Add note that jsonfield2>=3.1 doesn't support Django 2.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 2.2.0 (unreleased)
 ------------------
 
-- Changed ``JSONField`` dependency package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see `Warning about safe uninstall of jsonfield on upgrade`_).
+- Changed ``JSONField`` dependency package from `jsonfield`_ to `jsonfield2`_, for Django 3 compatibility (see `Warning about safe uninstall of jsonfield on upgrade`_). Note that Django 2.1 requires jsonfield<3.1.
 - Added support for Django 3.0 (requires jsonfield2>=3.0.3).
 - Added support for python 3.8.
 - Dropped previously-deprecated ``Account`` fields (see https://stripe.com/docs/upgrades#2019-02-19 ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     Django >= 2.1
-    # >= 3.0.3 needed for Django 3
+    # >= 3.0.3 needed for Django 3, < 3.1 needed for Django 2.1
     jsonfield2
     # >= 2.32.0 needed for stripe.SetupIntent
     # avoid 2.36.0, see https://github.com/dj-stripe/dj-stripe/issues/991

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ deps =
     mysql: mysqlclient
 
     django21: Django>=2.1,<2.2
+    # jsonfield2>=3.1 doesn't support Django 2.1
+    django21: jsonfield2<3.1
     django22: Django>=2.2,<2.3
     django30: Django>=3.0a1,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Limit jsonfield2 version in tox to resolve test failure.