### PR TITLE
Fix not specifying jsonfield2 < 3.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.2.3 (Unreleased)
+------------------
+
+This is a bugfix-only version:
+
+- Use jsonfield2 < 3.1 to keep Django 2.1 support until we explicitly drop it.
+
 2.2.2 (2020-01-20)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ zip_safe = False
 install_requires =
     Django >= 2.1
     # >= 3.0.3 needed for Django 3, < 3.1 needed for Django 2.1
-    jsonfield2
+    jsonfield2 < 3.1
     # >= 2.32.0 needed for stripe.SetupIntent
     # avoid 2.36.0, see https://github.com/dj-stripe/dj-stripe/issues/991
     stripe >= 2.32.0, != 2.36.0


### PR DESCRIPTION
Attempt at fixing #1102 for 2.2.x, thought this might need to be cherry-picked across other stable version branches.

I based this off of stable/2.2, but can rebase it somewhere else if that's not the right base branch.