### PR TITLE
Improve REST apis for subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ docs/_static
 
 # SQLite
 *.sqlite3
-
-# IntelliJ / PyCharm etc.
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/_static
 
 # SQLite
 *.sqlite3
+
+# IntelliJ / PyCharm etc.
+.idea

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -1,8 +1,8 @@
 from rest_framework.serializers import ModelSerializer
 from rest_framework.views import APIView
 
-from ...settings import subscriber_request_callback, STRIPE_LIVE_MODE
 from ...models import Customer
+from ...settings import STRIPE_LIVE_MODE, subscriber_request_callback
 
 
 class AutoCreateCustomerMixin(APIView):
@@ -20,7 +20,9 @@ class AutoCreateCustomerMixin(APIView):
         """
         result = super().dispatch(request, *args, **kwargs)
         if not request.user.is_anonymous:
-            Customer.objects.get_or_create(subscriber=subscriber_request_callback(self.request))
+            Customer.objects.get_or_create(
+                subscriber=subscriber_request_callback(self.request)
+            )
         return result
 
 
@@ -31,10 +33,11 @@ class AutoCustomerModelSerializerMixin(ModelSerializer):
 
     @property
     def customer(self):
-        subscriber = subscriber_request_callback(self.context.get('request'))
+        subscriber = subscriber_request_callback(self.context.get("request"))
         try:
-            customer = Customer.objects.get(subscriber=subscriber,
-                                            livemode=STRIPE_LIVE_MODE)
+            customer = Customer.objects.get(
+                subscriber=subscriber, livemode=STRIPE_LIVE_MODE
+            )
         except Customer.DoesNotExist:
             return None
         else:

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -1,0 +1,41 @@
+from rest_framework.serializers import ModelSerializer
+from rest_framework.views import APIView
+
+from ...settings import subscriber_request_callback, STRIPE_LIVE_MODE
+from ...models import Customer
+
+
+class AutoCreateCustomerMixin(APIView):
+    """Small mixin that can be included in REST API Views.
+
+    If included, it will automatically create a Customer instance
+    for the authenticated user, if does not yet exist.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        """Automatically creates a Customer if it does not exists yet.
+
+        The dispatch method is called after permissions and auth have been resolved,
+        but before the actual get/create/update methods are called.
+        """
+        result = super().dispatch(request, *args, **kwargs)
+        if not request.user.is_anonymous:
+            Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+        return result
+
+
+class AutoCustomerModelSerializerMixin(ModelSerializer):
+    """Small mixin to easily provide access to the relevant customer
+    inside ModelSerializers.
+    """
+
+    @property
+    def customer(self):
+        subscriber = subscriber_request_callback(self.context.get('request'))
+        try:
+            customer = Customer.objects.get(subscriber=subscriber,
+                                            livemode=STRIPE_LIVE_MODE)
+        except Customer.DoesNotExist:
+            return None
+        else:
+            return customer

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -5,7 +5,7 @@ from ...models import Customer
 from ...settings import STRIPE_LIVE_MODE, subscriber_request_callback
 
 
-class AutoCreateCustomerMixin(APIView):
+class AutoCreateCustomerMixin:
     """Small mixin that can be included in REST API Views.
 
     If included, it will automatically create a Customer instance
@@ -26,7 +26,7 @@ class AutoCreateCustomerMixin(APIView):
         return result
 
 
-class AutoCustomerModelSerializerMixin(ModelSerializer):
+class AutoCustomerModelSerializerMixin:
     """Small mixin to easily provide access to the relevant customer
     inside ModelSerializers.
     """

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -34,6 +34,8 @@ class AutoCustomerModelSerializerMixin:
     @property
     def customer(self):
         subscriber = subscriber_request_callback(self.context.get("request"))
+        if subscriber.is_anonymous:
+            return None
         try:
             customer = Customer.objects.get(
                 subscriber=subscriber, livemode=STRIPE_LIVE_MODE

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -20,7 +20,7 @@ class AutoCreateCustomerMixin(APIView):
         """
         result = super().dispatch(request, *args, **kwargs)
         if not request.user.is_anonymous:
-            Customer.get_or_create(subscriber=subscriber_request_callback(self.request))
+            Customer.objects.get_or_create(subscriber=subscriber_request_callback(self.request))
         return result
 
 

--- a/djstripe/contrib/rest_framework/mixins.py
+++ b/djstripe/contrib/rest_framework/mixins.py
@@ -1,6 +1,3 @@
-from rest_framework.serializers import ModelSerializer
-from rest_framework.views import APIView
-
 from ...models import Customer
 from ...settings import STRIPE_LIVE_MODE, subscriber_request_callback
 

--- a/djstripe/contrib/rest_framework/permissions.py
+++ b/djstripe/contrib/rest_framework/permissions.py
@@ -44,4 +44,4 @@ class IsSubscriptionOwner(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         subscriber = subscriber_request_callback(request)
-        return obj.subscriber == subscriber
+        return obj.customer.subscriber == subscriber

--- a/djstripe/contrib/rest_framework/permissions.py
+++ b/djstripe/contrib/rest_framework/permissions.py
@@ -31,3 +31,17 @@ class DJStripeSubscriptionPermission(BasePermission):
             subscriber_has_active_subscription(subscriber_request_callback(request))
         except AttributeError:
             return False
+
+
+class IsSubscriptionOwner(BasePermission):
+    """
+    Check if the subscriber associated with the request is the owner of the
+     requested subscription.
+
+    Returns false if:
+        * the request subscriber isn't the same as the subscription subscriber.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        subscriber = subscriber_request_callback(request)
+        return obj.subscriber == subscriber

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -33,7 +33,7 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
     application_fee_percent = serializers.DecimalField(
         required=False, max_digits=5, decimal_places=2
     )
-    billing = serializers.CharField(required=False)
+    collection_method = serializers.CharField(required=False)
     billing_cycle_anchor = serializers.DateTimeField(required=False)
     cancel_at_period_end = serializers.NullBooleanField(required=False)
     canceled_at = serializers.DateTimeField(required=False)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Subscription, Customer, SetupIntent
+from djstripe.models import Subscription, Customer, SetupIntent, Plan
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
 from .mixins import AutoCustomerModelSerializerMixin
 
@@ -25,7 +25,9 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
         exclude = ["default_tax_rates"]
 
     # required at deserialization
-    plan = serializers.CharField(max_length=50, required=True)
+    plan = serializers.PrimaryKeyRelatedField(
+        required=True, queryset=Plan.objects.all()
+    )
 
     # not required
     id = serializers.CharField(required=False)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -56,6 +56,11 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
     trial_end = serializers.DateTimeField(required=False)
     trial_start = serializers.DateTimeField(required=False)
 
+    def validate_status(self, value):
+        if value not in dir(SubscriptionStatus):
+            raise ValidationError({'detail': 'Invalid SubscriptionStatus {}'.format(value)})
+        return value
+
     def create(self, validated_data):
         raise MethodNotAllowed("POST")
 

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -24,12 +24,10 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
         model = Subscription
         exclude = ["default_tax_rates"]
 
-    # required at deserialization
     plan = serializers.PrimaryKeyRelatedField(
-        required=True, queryset=Plan.objects.all()
+        required=False, queryset=Plan.objects.all()
     )
 
-    # not required
     id = serializers.CharField(required=False)
     application_fee_percent = serializers.DecimalField(
         required=False, max_digits=5, decimal_places=2
@@ -85,6 +83,11 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
     """Extend the standard SubscriptionSerializer for the case of creation,
     which must include a stripe_token field, although it doesn't belong
     to the model itself."""
+
+    # Required on creation
+    plan = serializers.PrimaryKeyRelatedField(
+        required=True, queryset=Plan.objects.all()
+    )
 
     stripe_token = serializers.CharField(max_length=200, required=True)
     charge_immediately = serializers.NullBooleanField(required=False, default=True)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Customer, Plan, Product, SetupIntent, Subscription
+from djstripe.models import Plan, Subscription
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
 
 from .mixins import AutoCustomerModelSerializerMixin
@@ -136,8 +136,8 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
             # to succeed.
             subscription.plan = validated_data.get("plan")
             # It is key to attach a 'stripe_token' attribute to the instance to fake
-            # a model property, and let the subsequent representation of the new instance
-            # (recursive call to .to_representation() method) succeeds.
+            # a model property, and let the subsequent representation of the new
+            # instance (recursive call to .to_representation() method) succeeds.
             subscription.stripe_token = stripe_token
             return subscription
 

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -159,3 +159,27 @@ class PlanSerializer(ModelSerializer):
 
     name = serializers.CharField(required=False)
     statement_descriptor = serializers.CharField(required=False)
+
+
+########################################################################################
+# Deprecated serializers (used in deprecated API view)
+########################################################################################
+class DeprecatedSubscriptionSerializer(ModelSerializer):
+    """A serializer used for the Subscription model."""
+
+    class Meta:
+        """Model class options."""
+
+        model = Subscription
+        exclude = ["default_tax_rates"]
+
+
+class DeprecatedCreateSubscriptionSerializer(serializers.Serializer):
+    """A serializer used to create a Subscription."""
+
+    stripe_token = serializers.CharField(max_length=200)
+    plan = serializers.CharField(max_length=50)
+    charge_immediately = serializers.NullBooleanField(required=False)
+    tax_percent = serializers.DecimalField(
+        required=False, max_digits=5, decimal_places=2
+    )

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Customer, Plan, SetupIntent, Subscription, Product
+from djstripe.models import Customer, Plan, Product, SetupIntent, Subscription
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
 
 from .mixins import AutoCustomerModelSerializerMixin

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -106,3 +106,9 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
             raise ValidationError(detail=msg)
         else:
             return subscription
+
+
+class PlanSerializer(ModelSerializer):
+    class Meta:
+        model = Plan
+        fields = '__all__'

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -98,9 +98,11 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
         # nested nature when validating the final data. This can't be done in a
         # specialized validate_plan function (where the value will appear as provided
         # in POST request, that is, the correct ID slug string.)
-        attrs.update(plan=attrs.pop('plan').get('id'))
+        plan_id = attrs.pop('plan').get('id')
 
-        if not Plan.objects.filter(id=attrs.get('plan')).exists():
+        if Plan.objects.filter(id=plan_id).exists():
+            attrs.update(plan=Plan.objects.get(id=plan_id))
+        else:
             msg = "Unknown / invalid Plan id: " + str(attrs.get('plan'))
             raise ValidationError(detail=msg)
 

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -20,8 +20,6 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
     """A serializer used for the Subscription model."""
 
     class Meta:
-        """Model class options."""
-
         model = Subscription
         exclude = ["default_tax_rates"]
 

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -115,10 +115,12 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
 class PlanSerializer(ModelSerializer):
     class Meta:
         model = Plan
-        fields = ('active', 'aggregate_usage', 'amount', 'billing_scheme', 'currency',
-                  'interval', 'interval_count', 'nickname', 'product', 'tiers',
-                  'tiers_mode', 'transform_usage', 'trial_period_days', 'usage_type',
-                  'name', 'statement_descriptor')
+        fields = ('id', 'active', 'aggregate_usage', 'amount', 'billing_scheme',
+                  'currency', 'interval', 'interval_count', 'nickname', 'product',
+                  'tiers', 'tiers_mode', 'transform_usage', 'trial_period_days',
+                  'usage_type', 'name', 'statement_descriptor')
+
+    id = serializers.SlugField()
 
     active = serializers.BooleanField()
     aggregate_usage = serializers.CharField(required=False)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -25,28 +25,42 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
         model = Subscription
         exclude = ["default_tax_rates"]
 
-    plan = serializers.SlugField(required=False, source="plan.id")
-
+    # StripeModel fields
     id = serializers.CharField(required=False)
+    created = serializers.DateTimeField(required=False)
+    metadata = serializers.JSONField(required=False)
+    description = serializers.CharField(required=False)
+
+    # Subscription-specific fields
     application_fee_percent = serializers.DecimalField(
         required=False, max_digits=5, decimal_places=2
     )
-    collection_method = serializers.CharField(required=False)
     billing_cycle_anchor = serializers.DateTimeField(required=False)
     cancel_at_period_end = serializers.NullBooleanField(required=False)
     canceled_at = serializers.DateTimeField(required=False)
+    collection_method = serializers.CharField(required=False)
     current_period_end = serializers.DateTimeField(required=False)
     current_period_start = serializers.DateTimeField(required=False)
-    customer = serializers.PrimaryKeyRelatedField(
-        required=False, queryset=Customer.objects.all()
-    )
+    customer = serializers.SlugField(required=False, source="customer.id")
     days_until_due = serializers.IntegerField(required=False)
-    ended_at = serializers.DateTimeField(required=False)
-    pending_setup_intent = serializers.PrimaryKeyRelatedField(
-        required=False, queryset=SetupIntent.objects.all()
+    default_payment_method = serializers.SlugField(
+        required=False, source="default_payment_method.id"
     )
+    default_source = serializers.SlugField(
+        required=False, source="default_source.id"
+    )
+    discount = serializers.JSONField(required=False)
+    ended_at = serializers.DateTimeField(required=False)
+    next_pending_invoice_item_invoice = serializers.DateTimeField(required=False)
+    pending_invoice_item_interval = serializers.JSONField(required=False)
+    pending_setup_intent = serializers.SlugField(
+        required=False, source="pending_setup_intent.id"
+    )
+    pending_update = serializers.JSONField(required=False)
+    plan = serializers.SlugField(required=False, source="plan.id")
     quantity = serializers.IntegerField(required=False)
     start = serializers.DateTimeField(required=False)
+    start_date = serializers.DateTimeField(required=False)
     status = serializers.CharField(required=False)
     tax_percent = serializers.DecimalField(
         required=False, max_digits=5, decimal_places=2
@@ -131,13 +145,19 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
 class PlanSerializer(ModelSerializer):
     class Meta:
         model = Plan
-        fields = ('id', 'active', 'aggregate_usage', 'amount', 'billing_scheme',
+        fields = ('id', 'created', 'metadata', 'description',
+                  'active', 'aggregate_usage', 'amount', 'billing_scheme',
                   'currency', 'interval', 'interval_count', 'nickname', 'product',
                   'tiers', 'tiers_mode', 'transform_usage', 'trial_period_days',
                   'usage_type', 'name', 'statement_descriptor')
 
-    id = serializers.SlugField()
+    # StripeModel fields
+    id = serializers.SlugField(required=False)
+    created = serializers.DateTimeField(required=False)
+    metadata = serializers.JSONField(required=False)
+    description = serializers.CharField(required=False)
 
+    # Plan-specific fields
     active = serializers.BooleanField()
     aggregate_usage = serializers.CharField(required=False)
     amount = serializers.DecimalField(
@@ -148,15 +168,14 @@ class PlanSerializer(ModelSerializer):
     interval = serializers.CharField()
     interval_count = serializers.IntegerField(required=False)
     nickname = serializers.CharField(required=False)
-    product = serializers.PrimaryKeyRelatedField(
-        required=False, queryset=Product.objects.all()
-    )
+    product = serializers.SlugField(required=True, source="product.id")
     tiers = serializers.JSONField(required=False)
     tiers_mode = serializers.CharField(required=False)
     transform_usage = serializers.JSONField(required=False)
     trial_period_days = serializers.IntegerField(required=False)
     usage_type = serializers.CharField()
 
+    # Legacy fields (pre 2017-08-15)
     name = serializers.CharField(required=False)
     statement_descriptor = serializers.CharField(required=False)
 

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -46,7 +46,7 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
 
         status = validated_data.get('status')
 
-        # It is usual ambiguity of expressing a ACTION through REST APIs which
+        # It is a usual ambiguity of expressing an ACTION through REST APIs which
         # are fundamentally based on manipulating resources.
         if status == SubscriptionStatus.canceled != instance.status:
             try:
@@ -73,6 +73,10 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
         self.customer.add_card(stripe_token)
         try:
             subscription = self.customer.subscribe(**validated_data)
+            # It is key to attach a 'stripe_token' attribute to the instance to fake
+            # a model property, and let the subsequent representation of the new instance
+            # (recursive call to .to_representation() method) succeeds.
+            subscription.stripe_token = stripe_token
         except Exception as e:
             msg = 'Something went wrong processing the payment: ' + str(e)
             raise ValidationError(detail=msg)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -25,9 +25,7 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
         model = Subscription
         exclude = ["default_tax_rates"]
 
-    plan = serializers.PrimaryKeyRelatedField(
-        required=False, queryset=Plan.objects.all()
-    )
+    plan = serializers.SlugField(required=False, source="plan.id")
 
     id = serializers.CharField(required=False)
     application_fee_percent = serializers.DecimalField(

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -46,9 +46,7 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
     default_payment_method = serializers.SlugField(
         required=False, source="default_payment_method.id"
     )
-    default_source = serializers.SlugField(
-        required=False, source="default_source.id"
-    )
+    default_source = serializers.SlugField(required=False, source="default_source.id")
     discount = serializers.JSONField(required=False)
     ended_at = serializers.DateTimeField(required=False)
     next_pending_invoice_item_invoice = serializers.DateTimeField(required=False)
@@ -70,7 +68,9 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
 
     def validate_status(self, value):
         if value not in dir(SubscriptionStatus):
-            raise ValidationError({'detail': 'Invalid SubscriptionStatus {}'.format(value)})
+            raise ValidationError(
+                {"detail": "Invalid SubscriptionStatus {}".format(value)}
+            )
         return value
 
     def create(self, validated_data):
@@ -112,12 +112,12 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
         # nested nature when validating the final data. This can't be done in a
         # specialized validate_plan function (where the value will appear as provided
         # in POST request, that is, the correct ID slug string.)
-        plan_id = attrs.pop('plan').get('id')
+        plan_id = attrs.pop("plan").get("id")
 
         if Plan.objects.filter(id=plan_id).exists():
             attrs.update(plan=Plan.objects.get(id=plan_id))
         else:
-            msg = "Unknown / invalid Plan id: " + str(attrs.get('plan'))
+            msg = "Unknown / invalid Plan id: " + str(attrs.get("plan"))
             raise ValidationError(detail=msg)
 
         return attrs
@@ -134,7 +134,7 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
             # Plan instance is missing after subscribe. Bug in _api_create()?
             # But plan instance is nonetheless mandatory for to_representation()
             # to succeed.
-            subscription.plan = validated_data.get('plan')
+            subscription.plan = validated_data.get("plan")
             # It is key to attach a 'stripe_token' attribute to the instance to fake
             # a model property, and let the subsequent representation of the new instance
             # (recursive call to .to_representation() method) succeeds.
@@ -145,11 +145,28 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
 class PlanSerializer(ModelSerializer):
     class Meta:
         model = Plan
-        fields = ('id', 'created', 'metadata', 'description',
-                  'active', 'aggregate_usage', 'amount', 'billing_scheme',
-                  'currency', 'interval', 'interval_count', 'nickname', 'product',
-                  'tiers', 'tiers_mode', 'transform_usage', 'trial_period_days',
-                  'usage_type', 'name', 'statement_descriptor')
+        fields = (
+            "id",
+            "created",
+            "metadata",
+            "description",
+            "active",
+            "aggregate_usage",
+            "amount",
+            "billing_scheme",
+            "currency",
+            "interval",
+            "interval_count",
+            "nickname",
+            "product",
+            "tiers",
+            "tiers_mode",
+            "transform_usage",
+            "trial_period_days",
+            "usage_type",
+            "name",
+            "statement_descriptor",
+        )
 
     # StripeModel fields
     id = serializers.SlugField(required=False)
@@ -160,9 +177,7 @@ class PlanSerializer(ModelSerializer):
     # Plan-specific fields
     active = serializers.BooleanField()
     aggregate_usage = serializers.CharField(required=False)
-    amount = serializers.DecimalField(
-        required=False, max_digits=11, decimal_places=2
-    )
+    amount = serializers.DecimalField(required=False, max_digits=11, decimal_places=2)
     billing_scheme = serializers.CharField(required=False)
     currency = serializers.CharField(required=False)
     interval = serializers.CharField()

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Subscription
+from djstripe.models import Subscription, Customer
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
 from .mixins import AutoCustomerModelSerializerMixin
 
@@ -24,6 +24,17 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
         model = Subscription
         exclude = ["default_tax_rates"]
 
+    # not required
+    id = serializers.CharField(required=False)
+    billing = serializers.CharField(required=False)
+    current_period_end = serializers.DateTimeField(required=False)
+    current_period_start = serializers.DateTimeField(required=False)
+    start = serializers.DateTimeField(required=False)
+    status = serializers.CharField(required=False)
+    customer = serializers.PrimaryKeyRelatedField(required=False, queryset=Customer.objects.all())
+    charge_immediately = serializers.NullBooleanField(required=False, default=True)
+
+    # required
     plan = serializers.CharField(max_length=50, required=True)
 
     def create(self, validated_data):

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Customer, Plan, SetupIntent, Subscription
+from djstripe.models import Customer, Plan, SetupIntent, Subscription, Product
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
 
 from .mixins import AutoCustomerModelSerializerMixin
@@ -117,4 +117,29 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
 class PlanSerializer(ModelSerializer):
     class Meta:
         model = Plan
-        fields = "__all__"
+        fields = ('active', 'aggregate_usage', 'amount', 'billing_scheme', 'currency',
+                  'interval', 'interval_count', 'nickname', 'product', 'tiers',
+                  'tiers_mode', 'transform_usage', 'trial_period_days', 'usage_type',
+                  'name', 'statement_descriptor')
+
+    active = serializers.BooleanField()
+    aggregate_usage = serializers.CharField(required=False)
+    amount = serializers.DecimalField(
+        required=False, max_digits=11, decimal_places=2
+    )
+    billing_scheme = serializers.CharField(required=False)
+    currency = serializers.CharField(required=False)
+    interval = serializers.CharField()
+    interval_count = serializers.IntegerField(required=False)
+    nickname = serializers.CharField(required=False)
+    product = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=Product.objects.all()
+    )
+    tiers = serializers.JSONField(required=False)
+    tiers_mode = serializers.CharField(required=False)
+    transform_usage = serializers.JSONField(required=False)
+    trial_period_days = serializers.IntegerField(required=False)
+    usage_type = serializers.CharField()
+
+    name = serializers.CharField(required=False)
+    statement_descriptor = serializers.CharField(required=False)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -27,17 +27,11 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
 
     stripe_token = serializers.CharField(max_length=200, required=True)
     plan = serializers.CharField(max_length=50, required=True)
-    charge_immediately = serializers.NullBooleanField(required=False)
-    tax_percent = serializers.DecimalField(
-        required=False, max_digits=5, decimal_places=2
-    )
 
     def create(self, validated_data: dict):
-        self.customer.add_card(validated_data.get("stripe_token"))
-        charge_immediately = validated_data.get("charge_immediately", True)
+        self.customer.add_card(validated_data.pop("stripe_token"))
         try:
-            subscription = self.customer.subscribe(validated_data.get("plan"),
-                                                   charge_immediately)
+            subscription = self.customer.subscribe(**validated_data)
         except Exception as e:
             msg = 'Something went wrong processing the payment: ' + str(e)
             raise ValidationError(detail=msg)

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,8 +12,9 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.serializers import ModelSerializer, ValidationError
 
 from djstripe.enums import SubscriptionStatus
-from djstripe.models import Subscription, Customer, SetupIntent, Plan
+from djstripe.models import Customer, Plan, SetupIntent, Subscription
 from djstripe.settings import CANCELLATION_AT_PERIOD_END
+
 from .mixins import AutoCustomerModelSerializerMixin
 
 
@@ -56,13 +57,13 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
     trial_start = serializers.DateTimeField(required=False)
 
     def create(self, validated_data):
-        raise MethodNotAllowed('POST')
+        raise MethodNotAllowed("POST")
 
     def update(self, instance: Subscription, validated_data: dict):
         # We use UPDATE instead of DELETE to cancel a subscription, since
         # cancelling means change the internal state, but not remove it from the DB.
 
-        status = validated_data.get('status')
+        status = validated_data.get("status")
 
         # It is a usual ambiguity of expressing an ACTION through REST APIs which
         # are fundamentally based on manipulating resources.
@@ -70,7 +71,7 @@ class SubscriptionSerializer(AutoCustomerModelSerializerMixin, ModelSerializer):
             try:
                 instance.cancel(at_period_end=CANCELLATION_AT_PERIOD_END)
             except Exception as e:
-                msg = 'Something went wrong cancelling the subscription: ' + str(e)
+                msg = "Something went wrong cancelling the subscription: " + str(e)
                 raise ValidationError(detail=msg)
 
         # Applying the update of all other fields.
@@ -102,7 +103,7 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
             # (recursive call to .to_representation() method) succeeds.
             subscription.stripe_token = stripe_token
         except Exception as e:
-            msg = 'Something went wrong processing the payment: ' + str(e)
+            msg = "Something went wrong processing the payment: " + str(e)
             raise ValidationError(detail=msg)
         else:
             return subscription
@@ -111,4 +112,4 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
 class PlanSerializer(ModelSerializer):
     class Meta:
         model = Plan
-        fields = '__all__'
+        fields = "__all__"

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -117,6 +117,10 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
             msg = "Something went wrong processing the payment: " + str(e)
             raise ValidationError(detail=msg)
         else:
+            # Plan instance is missing after subscribe. Bug in _api_create()?
+            # But plan instance is nonetheless mandatory for to_representation()
+            # to succeed.
+            subscription.plan = validated_data.get('plan')
             # It is key to attach a 'stripe_token' attribute to the instance to fake
             # a model property, and let the subsequent representation of the new instance
             # (recursive call to .to_representation() method) succeeds.

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -113,14 +113,14 @@ class CreateSubscriptionSerializer(SubscriptionSerializer):
         self.customer.add_card(stripe_token)
         try:
             subscription = self.customer.subscribe(**validated_data)
-            # It is key to attach a 'stripe_token' attribute to the instance to fake
-            # a model property, and let the subsequent representation of the new instance
-            # (recursive call to .to_representation() method) succeeds.
-            subscription.stripe_token = stripe_token
         except Exception as e:
             msg = "Something went wrong processing the payment: " + str(e)
             raise ValidationError(detail=msg)
         else:
+            # It is key to attach a 'stripe_token' attribute to the instance to fake
+            # a model property, and let the subsequent representation of the new instance
+            # (recursive call to .to_representation() method) succeeds.
+            subscription.stripe_token = stripe_token
             return subscription
 
 

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -34,14 +34,13 @@ urlpatterns = [
     # Identification is made with Django's model "pk", but it could possibly be
     # extended to other (id, dj_stripeid...)
     path(
-        "subscriptions/<int:pk>",
+        "subscriptions/<str:id>",
         views.SubscriptionDetailView.as_view(),
         name="subscription-detail",
     ),
     # Read-only Endpoint for accessing list of Plans
     path("plans/", views.PlanListView.as_view(), name="plan-list"),
     # Read-only Endpoint for accessing the detail of one Plan.
-    # Identification is made with Django's model "pk", but it could possibly be
-    # extended to other (id, dj_stripeid...)
-    path("plans/<int:pk>", views.PlanDetailView.as_view(), name="plan-detail"),
+    # Identification is made with Stripe ID (which is a string).
+    path("plans/<str:id>", views.PlanDetailView.as_view(), name="plan-detail"),
 ]

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -23,6 +23,9 @@ from . import views
 app_name = "djstripe_rest_framework"
 
 urlpatterns = [
+    # Deprecated endpoint, replaced by the. Use the two endpoints below instead.
+    path("subscription/", views.SubscriptionRestView.as_view(), name="subscription"),
+
     # Authenticated Endpoint for accessing list of Subscriptions
     path(
         "subscriptions/", views.SubscriptionListView.as_view(), name="subscription-list"

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -24,26 +24,21 @@ app_name = "djstripe_rest_framework"
 
 urlpatterns = [
     # Authenticated Endpoint for accessing list of Subscriptions
-    path("subscriptions/",
-         views.SubscriptionListView.as_view(),
-         name="subscription-list"),
-
+    path(
+        "subscriptions/", views.SubscriptionListView.as_view(), name="subscription-list"
+    ),
     # Authenticated Endpoint for accessing the detail of one Subscription.
     # Identification is made with Django's model "pk", but it could possibly be
     # extended to other (id, dj_stripeid...)
-    path("subscriptions/<int:pk>",
-         views.SubscriptionDetailView.as_view(),
-         name="subscription-detail"),
-
+    path(
+        "subscriptions/<int:pk>",
+        views.SubscriptionDetailView.as_view(),
+        name="subscription-detail",
+    ),
     # Read-only Endpoint for accessing list of Plans
-    path("plans/",
-         views.PlanListView.as_view(),
-         name="plan-list"),
-
+    path("plans/", views.PlanListView.as_view(), name="plan-list"),
     # Read-only Endpoint for accessing the detail of one Plan.
     # Identification is made with Django's model "pk", but it could possibly be
     # extended to other (id, dj_stripeid...)
-    path("plans/<int:pk>",
-         views.PlanDetailView.as_view(),
-         name="plan-detail")
+    path("plans/<int:pk>", views.PlanDetailView.as_view(), name="plan-detail"),
 ]

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -23,6 +23,15 @@ from . import views
 app_name = "djstripe_rest_framework"
 
 urlpatterns = [
-    # REST api
-    path("subscription/", views.SubscriptionRestView.as_view(), name="subscription")
+    # Authenticated Endpoint for accessing list of Subscriptions
+    path("subscriptions/",
+         views.SubscriptionListView.as_view(),
+         name="subscription-list"),
+
+    # Authenticated Endpoint for accessing the detail of one Subscription.
+    # Identification is made with Django's model "pk", but it could possibly be
+    # extended to other (id, dj_stripeid...)
+    path("subscriptions/<int:pk>",
+         views.SubscriptionDetailView.as_view(),
+         name="subscription-detail")
 ]

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -24,7 +24,7 @@ app_name = "djstripe_rest_framework"
 
 urlpatterns = [
     # Deprecated endpoint. Use the two endpoints below instead.
-    path("subscription/", views.SubscriptionRestView.as_view(), name="subscription"),
+    path("subscription/", views.DeprecatedSubscriptionRestView.as_view(), name="subscription"),
 
     # Authenticated Endpoint for accessing list of Subscriptions
     path(

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -24,8 +24,11 @@ app_name = "djstripe_rest_framework"
 
 urlpatterns = [
     # Deprecated endpoint. Use the two endpoints below instead.
-    path("subscription/", views.DeprecatedSubscriptionRestView.as_view(), name="subscription"),
-
+    path(
+        "subscription/",
+        views.DeprecatedSubscriptionRestView.as_view(),
+        name="subscription",
+    ),
     # Authenticated Endpoint for accessing list of Subscriptions
     path(
         "subscriptions/", views.SubscriptionListView.as_view(), name="subscription-list"

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -23,7 +23,7 @@ from . import views
 app_name = "djstripe_rest_framework"
 
 urlpatterns = [
-    # Deprecated endpoint, replaced by the. Use the two endpoints below instead.
+    # Deprecated endpoint. Use the two endpoints below instead.
     path("subscription/", views.SubscriptionRestView.as_view(), name="subscription"),
 
     # Authenticated Endpoint for accessing list of Subscriptions

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -33,5 +33,17 @@ urlpatterns = [
     # extended to other (id, dj_stripeid...)
     path("subscriptions/<int:pk>",
          views.SubscriptionDetailView.as_view(),
-         name="subscription-detail")
+         name="subscription-detail"),
+
+    # Read-only Endpoint for accessing list of Plans
+    path("plans/",
+         views.PlanListView.as_view(),
+         name="plan-list"),
+
+    # Read-only Endpoint for accessing the detail of one Plan.
+    # Identification is made with Django's model "pk", but it could possibly be
+    # extended to other (id, dj_stripeid...)
+    path("plans/<int:pk>",
+         views.PlanDetailView.as_view(),
+         name="plan-detail")
 ]

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -6,6 +6,10 @@
 .. moduleauthor:: Philippe Luickx (@philippeluickx)
 
 """
+import warnings
+
+from rest_framework import status
+from rest_framework.views import APIView
 
 from rest_framework.generics import (
     ListAPIView,
@@ -14,9 +18,12 @@ from rest_framework.generics import (
     RetrieveUpdateAPIView,
 )
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
-from ...models import Plan, Subscription
-from ...settings import subscriber_request_callback
+from ...enums import SubscriptionStatus
+from ...models import Plan, Subscription, Customer
+from ...settings import CANCELLATION_AT_PERIOD_END, subscriber_request_callback
+
 from .mixins import AutoCreateCustomerMixin
 from .permissions import IsSubscriptionOwner
 from .serializers import (
@@ -24,6 +31,79 @@ from .serializers import (
     PlanSerializer,
     SubscriptionSerializer,
 )
+
+
+class SubscriptionRestView(APIView):
+    """API Endpoints for the Subscription object."""
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, **kwargs):
+        """
+        Return the customer's valid subscriptions.
+
+        Returns with status code 200.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        customer, _created = Customer.get_or_create(
+            subscriber=subscriber_request_callback(self.request)
+        )
+
+        serializer = SubscriptionSerializer(customer.subscription)
+        return Response(serializer.data)
+
+    def post(self, request, **kwargs):
+        """
+        Create a new current subscription for the user.
+
+        Returns with status code 201.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        serializer = CreateSubscriptionSerializer(data=request.data)
+
+        if serializer.is_valid():
+            try:
+                customer, _created = Customer.get_or_create(
+                    subscriber=subscriber_request_callback(self.request)
+                )
+                customer.add_card(serializer.data["stripe_token"])
+                charge_immediately = serializer.data.get("charge_immediately")
+                if charge_immediately is None:
+                    charge_immediately = True
+
+                customer.subscribe(serializer.data["plan"], charge_immediately)
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            except Exception:
+                # TODO: Better error messages
+                return Response(
+                    "Something went wrong processing the payment.",
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, **kwargs):
+        """
+        Mark the customers current subscription as canceled.
+
+        Returns with status code 204.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        try:
+            customer, _created = Customer.get_or_create(
+                subscriber=subscriber_request_callback(self.request)
+            )
+            customer.subscription.cancel(at_period_end=CANCELLATION_AT_PERIOD_END)
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Exception:
+            return Response(
+                "Something went wrong cancelling the subscription.",
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -30,80 +30,9 @@ from .serializers import (
     CreateSubscriptionSerializer,
     PlanSerializer,
     SubscriptionSerializer,
+    DeprecatedSubscriptionSerializer,
+    DeprecatedCreateSubscriptionSerializer
 )
-
-
-class SubscriptionRestView(APIView):
-    """API Endpoints for the Subscription object."""
-
-    permission_classes = (IsAuthenticated,)
-
-    def get(self, request, **kwargs):
-        """
-        Return the customer's valid subscriptions.
-
-        Returns with status code 200.
-        """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
-
-        customer, _created = Customer.get_or_create(
-            subscriber=subscriber_request_callback(self.request)
-        )
-
-        serializer = SubscriptionSerializer(customer.subscription)
-        return Response(serializer.data)
-
-    def post(self, request, **kwargs):
-        """
-        Create a new current subscription for the user.
-
-        Returns with status code 201.
-        """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
-
-        serializer = CreateSubscriptionSerializer(data=request.data)
-
-        if serializer.is_valid():
-            try:
-                customer, _created = Customer.get_or_create(
-                    subscriber=subscriber_request_callback(self.request)
-                )
-                customer.add_card(serializer.data["stripe_token"])
-                charge_immediately = serializer.data.get("charge_immediately")
-                if charge_immediately is None:
-                    charge_immediately = True
-
-                customer.subscribe(serializer.data["plan"], charge_immediately)
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            except Exception:
-                # TODO: Better error messages
-                return Response(
-                    "Something went wrong processing the payment.",
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-    def delete(self, request, **kwargs):
-        """
-        Mark the customers current subscription as canceled.
-
-        Returns with status code 204.
-        """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
-
-        try:
-            customer, _created = Customer.get_or_create(
-                subscriber=subscriber_request_callback(self.request)
-            )
-            customer.subscription.cancel(at_period_end=CANCELLATION_AT_PERIOD_END)
-
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        except Exception:
-            return Response(
-                "Something went wrong cancelling the subscription.",
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
 
 class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
@@ -176,3 +105,79 @@ class PlanDetailView(RetrieveAPIView):
     permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = PlanSerializer
     lookup_field = "id"
+
+
+########################################################################################
+# Deprecated API View
+########################################################################################
+class DeprecatedSubscriptionRestView(APIView):
+    """API Endpoints for the Subscription object."""
+
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, **kwargs):
+        """
+        Return the customer's valid subscriptions.
+
+        Returns with status code 200.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        customer, _created = Customer.get_or_create(
+            subscriber=subscriber_request_callback(self.request)
+        )
+
+        serializer = DeprecatedSubscriptionSerializer(customer.subscription)
+        return Response(serializer.data)
+
+    def post(self, request, **kwargs):
+        """
+        Create a new current subscription for the user.
+
+        Returns with status code 201.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        serializer = DeprecatedCreateSubscriptionSerializer(data=request.data)
+
+        if serializer.is_valid():
+            try:
+                customer, _created = Customer.get_or_create(
+                    subscriber=subscriber_request_callback(self.request)
+                )
+                customer.add_card(serializer.data["stripe_token"])
+                charge_immediately = serializer.data.get("charge_immediately")
+                if charge_immediately is None:
+                    charge_immediately = True
+
+                customer.subscribe(serializer.data["plan"], charge_immediately)
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            except Exception:
+                # TODO: Better error messages
+                return Response(
+                    "Something went wrong processing the payment.",
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, **kwargs):
+        """
+        Mark the customers current subscription as canceled.
+
+        Returns with status code 204.
+        """
+        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+
+        try:
+            customer, _created = Customer.get_or_create(
+                subscriber=subscriber_request_callback(self.request)
+            )
+            customer.subscription.cancel(at_period_end=CANCELLATION_AT_PERIOD_END)
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Exception:
+            return Response(
+                "Something went wrong cancelling the subscription.",
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from ...models import Subscription
 from ...settings import subscriber_request_callback
-from .serializers import SubscriptionSerializer
+from .serializers import SubscriptionSerializer, CreateSubscriptionSerializer
 from .permissions import IsSubscriptionOwner
 from .mixins import AutoCreateCustomerMixin
 
@@ -25,7 +25,11 @@ class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
     """
 
     permission_classes = (IsAuthenticated,)
-    serializer_class = SubscriptionSerializer
+
+    def get_serializer_class(self):
+        if self.request.method.upper() == 'POST':
+            return CreateSubscriptionSerializer
+        return SubscriptionSerializer
 
     def get_queryset(self):
         """Override of the class property `queryset` to ensure the Subscriptions

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -83,11 +83,11 @@ class SubscriptionDetailView(RetrieveUpdateAPIView):
         # See https://stackoverflow.com/a/21262262/707984 for explanations about
         # _mutable.
         mutable = False
-        if getattr(request.data, '_mutable', None) is not None:
+        if getattr(request.data, "_mutable", None) is not None:
             mutable = request.data._mutable
             request.data._mutable = True
         request.data.update(status=SubscriptionStatus.canceled)
-        if getattr(request.data, '_mutable', None) is not None:
+        if getattr(request.data, "_mutable", None) is not None:
             request.data._mutable = mutable
         return self.partial_update(request, *args, **kwargs)
 
@@ -119,7 +119,7 @@ class DeprecatedSubscriptionRestView(APIView):
 
         Returns with status code 200.
         """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+        warnings.warn("This view is deprecated. Use the new REST endpoints instead.")
 
         customer, _created = Customer.get_or_create(
             subscriber=subscriber_request_callback(self.request)
@@ -134,7 +134,7 @@ class DeprecatedSubscriptionRestView(APIView):
 
         Returns with status code 201.
         """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+        warnings.warn("This view is deprecated. Use the new REST endpoints instead.")
 
         serializer = DeprecatedCreateSubscriptionSerializer(data=request.data)
 
@@ -165,7 +165,7 @@ class DeprecatedSubscriptionRestView(APIView):
 
         Returns with status code 204.
         """
-        warnings.warn('This view is deprecated. Use the new REST endpoints instead.')
+        warnings.warn("This view is deprecated. Use the new REST endpoints instead.")
 
         try:
             customer, _created = Customer.get_or_create(

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -147,6 +147,7 @@ class SubscriptionDetailView(RetrieveUpdateAPIView):
     queryset = Subscription.objects.all()
     permission_classes = (IsAuthenticated, IsSubscriptionOwner)
     serializer_class = SubscriptionSerializer
+    lookup_field = "id"
 
     def delete(self, request, *args, **kwargs):
         # To stick to Stripe way of doing, we must enable the DELETE method to cancel
@@ -171,3 +172,4 @@ class PlanDetailView(RetrieveAPIView):
     queryset = Plan.objects.all()
     permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = PlanSerializer
+    lookup_field = "id"

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -7,12 +7,14 @@
 
 """
 
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, ListAPIView, RetrieveAPIView
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 
-from ...models import Subscription
+from ...models import Subscription, Plan
 from ...settings import subscriber_request_callback
-from .serializers import SubscriptionSerializer, CreateSubscriptionSerializer
+from .serializers import (
+    SubscriptionSerializer, CreateSubscriptionSerializer, PlanSerializer
+)
 from .permissions import IsSubscriptionOwner
 from .mixins import AutoCreateCustomerMixin
 
@@ -42,9 +44,8 @@ class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
         return Subscription.objects.filter(customer__subscriber=subscriber)
 
 
-
 class SubscriptionDetailView(RetrieveUpdateAPIView):
-    """API Endpoints for one Subscription object.
+    """API Endpoint for one Subscription object.
 
     The View does not include the Destroy (DELETE method) keyword, preventing
     to actually delete a Subscription instance. To *cancel* a subscription,
@@ -58,3 +59,15 @@ class SubscriptionDetailView(RetrieveUpdateAPIView):
     queryset = Subscription.objects.all()
     permission_classes = (IsAuthenticated, IsSubscriptionOwner)
     serializer_class = SubscriptionSerializer
+
+
+class PlanListView(ListAPIView):
+    queryset = Plan.objects.all()
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    serializer_class = PlanSerializer
+
+
+class PlanDetailView(RetrieveAPIView):
+    queryset = Plan.objects.all()
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    serializer_class = PlanSerializer

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -151,14 +151,17 @@ class SubscriptionDetailView(RetrieveUpdateAPIView):
 
     def delete(self, request, *args, **kwargs):
         # To stick to Stripe way of doing, we must enable the DELETE method to cancel
-        # a subscription. Bur the default implementation truly deletes the object.
+        # a subscription. But the default implementation truly deletes the object.
         # Hence we override it here to simulate a partial update (PATCH).
         # See https://stackoverflow.com/a/21262262/707984 for explanations about
         # _mutable.
-        mutable = request.data._mutable
-        request.data._mutable = True
+        mutable = False
+        if getattr(request.data, '_mutable', None) is not None:
+            mutable = request.data._mutable
+            request.data._mutable = True
         request.data.update(status=SubscriptionStatus.canceled)
-        request.data._mutable = mutable
+        if getattr(request.data, '_mutable', None) is not None:
+            request.data._mutable = mutable
         return self.partial_update(request, *args, **kwargs)
 
 

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -7,16 +7,23 @@
 
 """
 
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, ListAPIView, RetrieveAPIView
+from rest_framework.generics import (
+    ListAPIView,
+    ListCreateAPIView,
+    RetrieveAPIView,
+    RetrieveUpdateAPIView,
+)
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 
-from ...models import Subscription, Plan
+from ...models import Plan, Subscription
 from ...settings import subscriber_request_callback
-from .serializers import (
-    SubscriptionSerializer, CreateSubscriptionSerializer, PlanSerializer
-)
-from .permissions import IsSubscriptionOwner
 from .mixins import AutoCreateCustomerMixin
+from .permissions import IsSubscriptionOwner
+from .serializers import (
+    CreateSubscriptionSerializer,
+    PlanSerializer,
+    SubscriptionSerializer,
+)
 
 
 class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
@@ -29,7 +36,7 @@ class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
     permission_classes = (IsAuthenticated,)
 
     def get_serializer_class(self):
-        if self.request.method.upper() == 'POST':
+        if self.request.method.upper() == "POST":
             return CreateSubscriptionSerializer
         return SubscriptionSerializer
 

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -9,8 +9,6 @@
 import warnings
 
 from rest_framework import status
-from rest_framework.views import APIView
-
 from rest_framework.generics import (
     ListAPIView,
     ListCreateAPIView,
@@ -19,19 +17,19 @@ from rest_framework.generics import (
 )
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from ...enums import SubscriptionStatus
-from ...models import Plan, Subscription, Customer
+from ...models import Customer, Plan, Subscription
 from ...settings import CANCELLATION_AT_PERIOD_END, subscriber_request_callback
-
 from .mixins import AutoCreateCustomerMixin
 from .permissions import IsSubscriptionOwner
 from .serializers import (
     CreateSubscriptionSerializer,
+    DeprecatedCreateSubscriptionSerializer,
+    DeprecatedSubscriptionSerializer,
     PlanSerializer,
     SubscriptionSerializer,
-    DeprecatedSubscriptionSerializer,
-    DeprecatedCreateSubscriptionSerializer
 )
 
 

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -134,9 +134,10 @@ class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
 class SubscriptionDetailView(RetrieveUpdateAPIView):
     """API Endpoint for one Subscription object.
 
-    The View does not include the Destroy (DELETE method) keyword, preventing
+    The View does not include the Destroy (DELETE HTTP method) keyword, preventing
     to actually delete a Subscription instance. To *cancel* a subscription,
-    one must change its "status" through an PUT method.
+    one must change its "status" through PUT/PATCH methods (but see delete method
+    implementation below).
 
     AutoCreateCustomerMixin is NOT included, as it makes no real sense
     to create a non-existing Customer when accessing an existing Subscription

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -39,7 +39,8 @@ class SubscriptionListView(AutoCreateCustomerMixin, ListCreateAPIView):
         # nor that of a _Subscription_ endpoint to check for an existing customer,
         # or create one if necessary. See AutoCreateCustomerMixin.
         subscriber = subscriber_request_callback(self.request)
-        return Subscription.objects.filter(subscriber=subscriber)
+        return Subscription.objects.filter(customer__subscriber=subscriber)
+
 
 
 class SubscriptionDetailView(RetrieveUpdateAPIView):

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -148,6 +148,18 @@ class SubscriptionDetailView(RetrieveUpdateAPIView):
     permission_classes = (IsAuthenticated, IsSubscriptionOwner)
     serializer_class = SubscriptionSerializer
 
+    def delete(self, request, *args, **kwargs):
+        # To stick to Stripe way of doing, we must enable the DELETE method to cancel
+        # a subscription. Bur the default implementation truly deletes the object.
+        # Hence we override it here to simulate a partial update (PATCH).
+        # See https://stackoverflow.com/a/21262262/707984 for explanations about
+        # _mutable.
+        mutable = request.data._mutable
+        request.data._mutable = True
+        request.data.update(status=SubscriptionStatus.canceled)
+        request.data._mutable = mutable
+        return self.partial_update(request, *args, **kwargs)
+
 
 class PlanListView(ListAPIView):
     queryset = Plan.objects.all()

--- a/tests/test_contrib/test_mixins.py
+++ b/tests/test_contrib/test_mixins.py
@@ -1,0 +1,37 @@
+"""
+.. module:: dj-stripe.tests.test_contrib.test_mixins
+    :synopsis: dj-stripe REST APIs Mixins Tests.
+
+.. moduleauthor:: Cedric Foellmi (@onekiloparsec)
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from .. import FAKE_CUSTOMER
+
+
+class AutoCreateCustomerMixinTest(APITestCase):
+    @patch(
+        "djstripe.models.Customer.objects.get_or_create", autospec=True
+    )
+    def test_customer_create_when_authenticated(self, mock_get_or_create):
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com", password="password"
+        )
+        self.assertTrue(self.client.login(username="pydanny", password="password"))
+        self.customer = FAKE_CUSTOMER.create_for_user(self.user)
+        url = reverse("rest_djstripe:subscription-list")
+        response = self.client.get(url)
+        mock_get_or_create.assert_called_once()
+
+    @patch(
+        "djstripe.models.Customer.objects.get_or_create", autospec=True
+    )
+    def test_customer_create_when_anonymous(self, mock_get_or_create):
+        url = reverse("rest_djstripe:subscription-list")
+        response = self.client.get(url)
+        mock_get_or_create.assert_not_called()

--- a/tests/test_contrib/test_mixins.py
+++ b/tests/test_contrib/test_mixins.py
@@ -26,13 +26,13 @@ class AutoCreateCustomerMixinTest(APITestCase):
         self.assertTrue(self.client.login(username="pydanny", password="password"))
         self.customer = FAKE_CUSTOMER.create_for_user(self.user)
         url = reverse("rest_djstripe:subscription-list")
-        response = self.client.get(url)
+        self.client.get(url)
         mock_get_or_create.assert_called_once()
 
     @patch("djstripe.models.Customer.objects.get_or_create", autospec=True)
     def test_customer_create_when_anonymous(self, mock_get_or_create):
         url = reverse("rest_djstripe:subscription-list")
-        response = self.client.get(url)
+        self.client.get(url)
         mock_get_or_create.assert_not_called()
 
 

--- a/tests/test_contrib/test_mixins.py
+++ b/tests/test_contrib/test_mixins.py
@@ -8,8 +8,11 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from rest_framework.request import Request
 from rest_framework.reverse import reverse
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
+
+from djstripe.contrib.rest_framework.serializers import SubscriptionSerializer
 
 from .. import FAKE_CUSTOMER
 
@@ -35,3 +38,47 @@ class AutoCreateCustomerMixinTest(APITestCase):
         url = reverse("rest_djstripe:subscription-list")
         response = self.client.get(url)
         mock_get_or_create.assert_not_called()
+
+
+class AutoCustomerModelSerializerMixinTest(APITestCase):
+    def test_customer_accessor_when_authenticated(self):
+        # Preparing user and customer
+        user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com", password="password"
+        )
+        self.assertTrue(self.client.login(username="pydanny", password="password"))
+        customer = FAKE_CUSTOMER.create_for_user(user)
+
+        # Preparing request context
+        factory = APIRequestFactory()
+        wsgi_request = factory.get('/')
+        force_authenticate(wsgi_request, user=user)
+
+        # Performing test
+        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        self.assertEqual(serializer.customer, customer)
+
+    def test_customer_accessor_when_authenticated_but_no_customer(self):
+        # Preparing user and customer
+        user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com", password="password"
+        )
+        self.assertTrue(self.client.login(username="pydanny", password="password"))
+
+        # Preparing request context
+        factory = APIRequestFactory()
+        wsgi_request = factory.get('/')
+        force_authenticate(wsgi_request, user=user)
+
+        # Performing test
+        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        self.assertIsNone(serializer.customer)
+
+    def test_customer_accessor_when_anonymous(self):
+        # Preparing request context
+        factory = APIRequestFactory()
+        wsgi_request = factory.get('/')
+
+        # Performing test
+        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        self.assertIsNone(serializer.customer)

--- a/tests/test_contrib/test_mixins.py
+++ b/tests/test_contrib/test_mixins.py
@@ -18,9 +18,7 @@ from .. import FAKE_CUSTOMER
 
 
 class AutoCreateCustomerMixinTest(APITestCase):
-    @patch(
-        "djstripe.models.Customer.objects.get_or_create", autospec=True
-    )
+    @patch("djstripe.models.Customer.objects.get_or_create", autospec=True)
     def test_customer_create_when_authenticated(self, mock_get_or_create):
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com", password="password"
@@ -31,9 +29,7 @@ class AutoCreateCustomerMixinTest(APITestCase):
         response = self.client.get(url)
         mock_get_or_create.assert_called_once()
 
-    @patch(
-        "djstripe.models.Customer.objects.get_or_create", autospec=True
-    )
+    @patch("djstripe.models.Customer.objects.get_or_create", autospec=True)
     def test_customer_create_when_anonymous(self, mock_get_or_create):
         url = reverse("rest_djstripe:subscription-list")
         response = self.client.get(url)
@@ -51,11 +47,11 @@ class AutoCustomerModelSerializerMixinTest(APITestCase):
 
         # Preparing request context
         factory = APIRequestFactory()
-        wsgi_request = factory.get('/')
+        wsgi_request = factory.get("/")
         force_authenticate(wsgi_request, user=user)
 
         # Performing test
-        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        serializer = SubscriptionSerializer(context={"request": Request(wsgi_request)})
         self.assertEqual(serializer.customer, customer)
 
     def test_customer_accessor_when_authenticated_but_no_customer(self):
@@ -67,18 +63,18 @@ class AutoCustomerModelSerializerMixinTest(APITestCase):
 
         # Preparing request context
         factory = APIRequestFactory()
-        wsgi_request = factory.get('/')
+        wsgi_request = factory.get("/")
         force_authenticate(wsgi_request, user=user)
 
         # Performing test
-        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        serializer = SubscriptionSerializer(context={"request": Request(wsgi_request)})
         self.assertIsNone(serializer.customer)
 
     def test_customer_accessor_when_anonymous(self):
         # Preparing request context
         factory = APIRequestFactory()
-        wsgi_request = factory.get('/')
+        wsgi_request = factory.get("/")
 
         # Performing test
-        serializer = SubscriptionSerializer(context={'request': Request(wsgi_request)})
+        serializer = SubscriptionSerializer(context={"request": Request(wsgi_request)})
         self.assertIsNone(serializer.customer)

--- a/tests/test_contrib/test_mixins.py
+++ b/tests/test_contrib/test_mixins.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from rest_framework.request import Request
 from rest_framework.reverse import reverse
-from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 
 from djstripe.contrib.rest_framework.serializers import SubscriptionSerializer
 

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -73,30 +73,6 @@ class SubscriptionSerializerTest(TestCase):
         serializer = SubscriptionSerializer(self.subscription)
         self.assertEqual(serializer.data['plan'], self.plan.id)
 
-    # This test is ambiguous as it is originally used for PUT/update methods. However,
-    # creating a serializer only with data={} parameter is for creating instances,
-    # hence checking the billing fields contradicts the other test below which uses the
-    # dedicated CreateSubscriptionSerializer class.
-    # @patch(
-    #     "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
-    # )
-    # def test_invalid_serializer_existing_instance(self, product_retrieve_mock):
-    #     now = timezone.now()
-    #     serializer = SubscriptionSerializer(
-    #         data={
-    #             "id": "sub_6lsC8pt7IcFpjA",
-    #             "customer": self.customer.djstripe_id,
-    #             "plan": self.plan.djstripe_id,
-    #             "start": now,
-    #             "status": SubscriptionStatus.active,
-    #             "current_period_end": now + timezone.timedelta(days=5),
-    #             "current_period_start": now,
-    #         }
-    #     )
-    #     self.assertFalse(serializer.is_valid())
-    #     self.assertEqual(serializer.validated_data, {})
-    #     self.assertEqual(serializer.errors, {"billing": ["This field is required."]})
-
 
 class CreateSubscriptionSerializerTest(TestCase):
     def setUp(self):

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -71,7 +71,7 @@ class SubscriptionSerializerTest(TestCase):
         """The base subscription serializer must refer to its Plan relationship
         though its stripe id."""
         serializer = SubscriptionSerializer(self.subscription)
-        self.assertEqual(serializer.data['plan'], self.plan.id)
+        self.assertEqual(serializer.data["plan"], self.plan.id)
 
 
 class CreateSubscriptionSerializerTest(TestCase):
@@ -111,7 +111,7 @@ class CreateSubscriptionSerializerTest(TestCase):
         creation"""
         token = stripe_token_mock(card={})
         serializer = CreateSubscriptionSerializer(
-            data={"plan": 'dummy_plan_id', "stripe_token": token.id}
+            data={"plan": "dummy_plan_id", "stripe_token": token.id}
         )
         with self.assertRaises(ValidationError):
             self.assertFalse(serializer.is_valid(raise_exception=True))
@@ -169,9 +169,9 @@ class DeprecatedSubscriptionSerializerTest(TestCase):
         self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
@@ -233,9 +233,9 @@ class DeprecatedSubscriptionSerializerTest(TestCase):
 class DeprecatedCreateSubscriptionSerializerTest(TestCase):
     def setUp(self):
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
+from rest_framework.serializers import ValidationError
 
 from djstripe.contrib.rest_framework.serializers import (
     CreateSubscriptionSerializer,
@@ -117,10 +118,10 @@ class CreateSubscriptionSerializerTest(TestCase):
         creation"""
         token = stripe_token_mock(card={})
         serializer = CreateSubscriptionSerializer(
-            data={"plan": self.plan.pk, "stripe_token": token.id}
+            data={"plan": self.plan.id, "stripe_token": token.id}
         )
         self.assertTrue(serializer.is_valid())
-        self.assertEqual(serializer.validated_data["plan"], self.plan)
+        self.assertEqual(serializer.validated_data["plan"], self.plan.id)
         self.assertIn("stripe_token", serializer.validated_data)
         self.assertEqual(serializer.errors, {})
 

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -18,9 +18,9 @@ from rest_framework.serializers import ValidationError
 
 from djstripe.contrib.rest_framework.serializers import (
     CreateSubscriptionSerializer,
-    SubscriptionSerializer,
+    DeprecatedCreateSubscriptionSerializer,
     DeprecatedSubscriptionSerializer,
-    DeprecatedCreateSubscriptionSerializer
+    SubscriptionSerializer,
 )
 from djstripe.enums import SubscriptionStatus
 from djstripe.models import Plan, Subscription

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -108,10 +108,10 @@ class CreateSubscriptionSerializerTest(TestCase):
         creation"""
         token = stripe_token_mock(card={})
         serializer = CreateSubscriptionSerializer(
-            data={"plan": self.plan.id, "stripe_token": token.id}
+            data={"plan": self.plan.pk, "stripe_token": token.id}
         )
         self.assertTrue(serializer.is_valid())
-        self.assertEqual(serializer.validated_data["plan"], str(self.plan.id))
+        self.assertEqual(serializer.validated_data["plan"], self.plan)
         self.assertIn("stripe_token", serializer.validated_data)
         self.assertEqual(serializer.errors, {})
 
@@ -124,7 +124,7 @@ class CreateSubscriptionSerializerTest(TestCase):
         token = stripe_token_mock(card={})
         serializer = CreateSubscriptionSerializer(
             data={
-                "plan": self.plan.id,
+                "plan": self.plan.pk,
                 "stripe_token": token.id,
                 "charge_immediately": True,
                 "tax_percent": 13.00,

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -19,6 +19,8 @@ from rest_framework.serializers import ValidationError
 from djstripe.contrib.rest_framework.serializers import (
     CreateSubscriptionSerializer,
     SubscriptionSerializer,
+    DeprecatedSubscriptionSerializer,
+    DeprecatedCreateSubscriptionSerializer
 )
 from djstripe.enums import SubscriptionStatus
 from djstripe.models import Plan, Subscription
@@ -177,4 +179,123 @@ class CreateSubscriptionSerializerTest(TestCase):
         self.assertEqual(
             serializer.errors.get("plan"),
             [ErrorDetail(string="This field is required.", code="required")],
+        )
+
+
+########################################################################################
+# Tests of deprecated serializers (used in deprecated API view)
+########################################################################################
+class DeprecatedSubscriptionSerializerTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com"
+        )
+        self.customer = FAKE_CUSTOMER.create_for_user(self.user)
+
+        with patch(
+                "stripe.Product.retrieve",
+                return_value=deepcopy(FAKE_PRODUCT),
+                autospec=True,
+        ):
+            self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+
+    def test_valid_serializer(self):
+        now = timezone.now()
+        serializer = DeprecatedSubscriptionSerializer(
+            data={
+                "id": "sub_6lsC8pt7IcFpjA",
+                "collection_method": "charge_automatically",
+                "customer": self.customer.djstripe_id,
+                "plan": self.plan.djstripe_id,
+                "quantity": 2,
+                "start": now,
+                "status": SubscriptionStatus.active,
+                "current_period_end": now + timezone.timedelta(days=5),
+                "current_period_start": now,
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(
+            serializer.validated_data,
+            {
+                "id": "sub_6lsC8pt7IcFpjA",
+                "collection_method": "charge_automatically",
+                "customer": self.customer,
+                "plan": self.plan,
+                "quantity": 2,
+                "start": now,
+                "status": SubscriptionStatus.active,
+                "current_period_end": now + timezone.timedelta(days=5),
+                "current_period_start": now,
+            },
+        )
+        self.assertEqual(serializer.errors, {})
+
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    def test_invalid_serializer(self, product_retrieve_mock):
+        now = timezone.now()
+        serializer = DeprecatedSubscriptionSerializer(
+            data={
+                "id": "sub_6lsC8pt7IcFpjA",
+                "customer": self.customer.djstripe_id,
+                "plan": self.plan.djstripe_id,
+                "start": now,
+                "status": SubscriptionStatus.active,
+                "current_period_end": now + timezone.timedelta(days=5),
+                "current_period_start": now,
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.validated_data, {})
+        self.assertEqual(
+            serializer.errors, {"collection_method": ["This field is required."]}
+        )
+
+
+class DeprecatedCreateSubscriptionSerializerTest(TestCase):
+    def setUp(self):
+        with patch(
+                "stripe.Product.retrieve",
+                return_value=deepcopy(FAKE_PRODUCT),
+                autospec=True,
+        ):
+            self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+
+    @patch(
+        "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+    )
+    def test_valid_serializer(self, stripe_token_mock):
+        token = stripe_token_mock(card={})
+        serializer = DeprecatedCreateSubscriptionSerializer(
+            data={"plan": self.plan.id, "stripe_token": token.id}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["plan"], str(self.plan.id))
+        self.assertIn("stripe_token", serializer.validated_data)
+        self.assertEqual(serializer.errors, {})
+
+    @patch(
+        "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+    )
+    def test_valid_serializer_non_required_fields(self, stripe_token_mock):
+        """Test the CreateSubscriptionSerializer is_valid method."""
+        token = stripe_token_mock(card={})
+        serializer = DeprecatedCreateSubscriptionSerializer(
+            data={
+                "plan": self.plan.id,
+                "stripe_token": token.id,
+                "charge_immediately": True,
+                "tax_percent": 13.00,
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_invalid_serializer(self):
+        serializer = DeprecatedCreateSubscriptionSerializer(data={"plan": self.plan.id})
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.validated_data, {})
+        self.assertEqual(
+            serializer.errors, {"stripe_token": ["This field is required."]}
         )

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -43,7 +43,7 @@ class SubscriptionSerializerTest(TestCase):
         self.subcription_data = {
             "id": "sub_6lsC8pt7IcFpjA",
             "customer": self.customer,
-            "billing": "charge_automatically",
+            "collection_method": "charge_automatically",
             "plan": self.plan,
             "quantity": 2,
             "start": now,

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -61,6 +61,15 @@ class SubscriptionSerializerTest(TestCase):
         serializer = SubscriptionSerializer(self.subscription)
         self.assertIsNotNone(serializer.data)
 
+    @patch(
+        "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+    )
+    def test_valid_serializer_use_plan_id(self, stripe_token_mock):
+        """The base subscription serializer must refer to its Plan relationship
+        though its stripe id."""
+        serializer = SubscriptionSerializer(self.subscription)
+        self.assertEqual(serializer.data['plan'], self.plan.id)
+
     # This test is ambiguous as it is originally used for PUT/update methods. However,
     # creating a serializer only with data={} parameter is for creating instances,
     # hence checking the billing fields contradicts the other test below which uses the

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -121,7 +121,7 @@ class CreateSubscriptionSerializerTest(TestCase):
             data={"plan": self.plan.id, "stripe_token": token.id}
         )
         self.assertTrue(serializer.is_valid())
-        self.assertEqual(serializer.validated_data["plan"], self.plan.id)
+        self.assertEqual(serializer.validated_data["plan"], self.plan)
         self.assertIn("stripe_token", serializer.validated_data)
         self.assertEqual(serializer.errors, {})
 

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -113,7 +113,7 @@ class CreateSubscriptionSerializerTest(TestCase):
     @patch(
         "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
     )
-    def test_valid_serializer_wth_minimal_data(self, stripe_token_mock):
+    def test_valid_serializer_with_minimal_data(self, stripe_token_mock):
         """The serializer must be valid when provided with minimal data for instance
         creation"""
         token = stripe_token_mock(card={})

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -16,9 +16,9 @@ from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
 
 from djstripe.contrib.rest_framework.serializers import (
-    SubscriptionSerializer, CreateSubscriptionSerializer
+    CreateSubscriptionSerializer,
+    SubscriptionSerializer,
 )
-
 from djstripe.enums import SubscriptionStatus
 from djstripe.models import Plan, Subscription
 
@@ -33,9 +33,9 @@ class SubscriptionSerializerTest(TestCase):
         self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
@@ -94,9 +94,9 @@ class CreateSubscriptionSerializerTest(TestCase):
         self.customer = FAKE_CUSTOMER.create_for_user(self.user)
 
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             self.plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
 
@@ -138,8 +138,8 @@ class CreateSubscriptionSerializerTest(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.validated_data, {})
         self.assertEqual(
-            serializer.errors.get('stripe_token'),
-            [ErrorDetail(string='This field is required.', code='required')]
+            serializer.errors.get("stripe_token"),
+            [ErrorDetail(string="This field is required.", code="required")],
         )
 
     @patch(
@@ -152,6 +152,6 @@ class CreateSubscriptionSerializerTest(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.validated_data, {})
         self.assertEqual(
-            serializer.errors.get('plan'),
-            [ErrorDetail(string='This field is required.', code='required')]
+            serializer.errors.get("plan"),
+            [ErrorDetail(string="This field is required.", code="required")],
         )

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -147,7 +147,7 @@ class CreateSubscriptionSerializerTest(TestCase):
         token = stripe_token_mock(card={})
         serializer = CreateSubscriptionSerializer(
             data={
-                "plan": self.plan.pk,
+                "plan": self.plan.id,
                 "stripe_token": token.id,
                 "charge_immediately": True,
                 "tax_percent": 13.00,

--- a/tests/test_contrib/test_serializers.py
+++ b/tests/test_contrib/test_serializers.py
@@ -128,6 +128,19 @@ class CreateSubscriptionSerializerTest(TestCase):
     @patch(
         "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
     )
+    def test_valid_serializer_with_wrong_plan_id(self, stripe_token_mock):
+        """The serializer must be valid when provided with minimal data for instance
+        creation"""
+        token = stripe_token_mock(card={})
+        serializer = CreateSubscriptionSerializer(
+            data={"plan": 'dummy_plan_id', "stripe_token": token.id}
+        )
+        with self.assertRaises(ValidationError):
+            self.assertFalse(serializer.is_valid(raise_exception=True))
+
+    @patch(
+        "stripe.Token.create", return_value=PropertyMock(id="token_test"), autospec=True
+    )
     def test_valid_serializer_with_non_required_fields(self, stripe_token_mock):
         """The serializer must be valid when provided with data including non
          reuired field for instance creation"""

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -49,11 +49,12 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         data = {"plan": plan.djstripe_id, "stripe_token": "cake"}
         response = self.client.post(self.url_list, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
         self.assertEqual(1, Customer.objects.count())
         customer = Customer.objects.get()
         add_card_mock.assert_called_once_with(customer, "cake")
         subscribe_mock.assert_called_once_with(customer, "test0", True)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         # Do not test data content in views. Values will be string representation
         # of MagicMock of the values.
 

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -185,7 +185,9 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
     )
     @patch("djstripe.models.Subscription.cancel", autospec=True)
-    def test_cancel_subscription_with_delete(self, cancel_subscription_mock, retrieve_mock):
+    def test_cancel_subscription_with_delete(
+        self, cancel_subscription_mock, retrieve_mock
+    ):
         """Test a cancel through a DELETE method.
 
         Should cancel a Customer objects subscription.
@@ -337,7 +339,7 @@ class RestSubscriptionTest(APITestCase):
     @patch("djstripe.models.Customer.subscribe", autospec=True)
     @patch("djstripe.models.Customer.add_card", autospec=True)
     def test_create_subscription_charge_immediately(
-            self, add_card_mock, subscribe_mock
+        self, add_card_mock, subscribe_mock
     ):
         """Test a POST to the SubscriptionRestView.
 
@@ -379,9 +381,9 @@ class RestSubscriptionTest(APITestCase):
         Should return the correct data.
         """
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
@@ -412,9 +414,9 @@ class RestSubscriptionTest(APITestCase):
         fake_canceled_subscription = deepcopy(FAKE_SUBSCRIPTION)
 
         with patch(
-                "stripe.Product.retrieve",
-                return_value=deepcopy(FAKE_PRODUCT),
-                autospec=True,
+            "stripe.Product.retrieve",
+            return_value=deepcopy(FAKE_PRODUCT),
+            autospec=True,
         ):
             Subscription.sync_from_stripe_data(fake_canceled_subscription)
 

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -150,7 +150,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         url = reverse(
             "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}
         )
-        response = self.client.put(url, data={'status': SubscriptionStatus.unpaid})
+        response = self.client.put(url, data={"status": SubscriptionStatus.unpaid})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @patch(
@@ -166,7 +166,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         url = reverse(
             "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}
         )
-        response = self.client.put(url, data={'status': 'wrong subscription status'})
+        response = self.client.put(url, data={"status": "wrong subscription status"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch(

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -180,3 +180,47 @@ class SubscriptionListCreateAPIViewAnonymousTestCase(APITestCase):
         data = {"plan": "test0", "stripe_token": "cake"}
         response = self.client.post(self.url_list, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PlanListAPIViewAnonymousTestCase(APITestCase):
+    """
+    Test the anonymous access to the LIST endpoint for Plans.
+    """
+
+    def setUp(self):
+        self.url_list = reverse("rest_djstripe:plan-list")
+
+    def test_get_list_of_plans(self):
+        response = self.client.get(self.url_list)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_post_new_plans(self):
+        response = self.client.post(self.url_list, data={'nickname': 'John Doe'})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PlanDetailAPIViewAnonymousTestCase(APITestCase):
+    """
+    Test the anonymous access to the LIST endpoint for Plans.
+    """
+
+    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    def test_get_detail_of_plan(self, retrieve_mock):
+        plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    def test_update_new_plans(self, retrieve_mock):
+        plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
+        response = self.client.put(url, data={'nickname': 'John Doe'})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    def test_delete_new_plans(self, retrieve_mock):
+        plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
+        response = self.client.delete(url, data={'nickname': 'John Doe'})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -29,7 +29,7 @@ class RestSubscriptionTest(APITestCase):
     """
 
     def setUp(self):
-        self.url = reverse("rest_djstripe:subscription")
+        self.url_list = reverse("rest_djstripe:subscription-list")
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com", password="password"
         )

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -142,7 +142,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
     )
     @patch("djstripe.models.Subscription.cancel", autospec=True)
     def test_cancel_subscription(self, cancel_subscription_mock, retrieve_mock):
-        """Test a DELETE to the SubscriptionRestView.
+        """Test a cancel through a PUT method.
 
         Should cancel a Customer objects subscription.
         """

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -145,7 +145,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
 
         Should return the updated data.
         """
-        plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
         url = reverse(
             "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}
@@ -161,7 +161,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
 
         Should return a 400 for a failed updated.
         """
-        plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
         url = reverse(
             "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -296,3 +296,166 @@ class PlanDetailAPIViewAnonymousTestCase(APITestCase):
         url = reverse("rest_djstripe:plan-detail", kwargs={"id": plan.id})
         response = self.client.delete(url, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+########################################################################################
+# Tests of deprecated endpoint (see urls.py)
+########################################################################################
+class RestSubscriptionTest(APITestCase):
+    """
+    Test the REST api for subscriptions.
+    """
+
+    def setUp(self):
+        self.url = reverse("rest_djstripe:subscription")
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com", password="password"
+        )
+        self.assertTrue(self.client.login(username="pydanny", password="password"))
+        self.customer = FAKE_CUSTOMER.create_for_user(self.user)
+
+    @patch("djstripe.models.Customer.subscribe", autospec=True)
+    @patch("djstripe.models.Customer.add_card", autospec=True)
+    def test_create_subscription(self, add_card_mock, subscribe_mock):
+        """Test a POST to the SubscriptionRestView.
+
+        Should:
+            - Create a Customer object
+            - Add a card to the Customer object
+            - Subcribe the Customer to a plan
+        """
+        data = {"plan": "test0", "stripe_token": "cake"}
+        response = self.client.post(self.url, data)
+        self.assertEqual(1, Customer.objects.count())
+        customer = Customer.objects.get()
+        add_card_mock.assert_called_once_with(customer, "cake")
+        subscribe_mock.assert_called_once_with(customer, "test0", True)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data["charge_immediately"] = None
+        self.assertEqual(response.data, data)
+
+    @patch("djstripe.models.Customer.subscribe", autospec=True)
+    @patch("djstripe.models.Customer.add_card", autospec=True)
+    def test_create_subscription_charge_immediately(
+            self, add_card_mock, subscribe_mock
+    ):
+        """Test a POST to the SubscriptionRestView.
+
+        Should be able to accept an charge_immediately.
+        This will not send an invoice to the customer on subscribe.
+        """
+        data = {"plan": "test0", "stripe_token": "cake", "charge_immediately": False}
+        response = self.client.post(self.url, data)
+        self.assertEqual(1, Customer.objects.count())
+        customer = Customer.objects.get()
+        subscribe_mock.assert_called_once_with(customer, "test0", False)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data, data)
+
+    @patch("djstripe.models.Customer.subscribe", autospec=True)
+    @patch("djstripe.models.Customer.add_card", autospec=True)
+    def test_create_subscription_exception(self, add_card_mock, subscribe_mock):
+        """Test a POST to the SubscriptionRestView.
+
+        Should return a 400 when an Exception is raised.
+        """
+        subscribe_mock.side_effect = Exception
+        data = {"plan": "test0", "stripe_token": "cake"}
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_subscription_incorrect_data(self):
+        """Test a POST to the SubscriptionRestView.
+
+        Should return a 400 when a the serializer is invalid.
+        """
+        data = {"foo": "bar"}
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_subscription(self):
+        """Test a GET to the SubscriptionRestView.
+
+        Should return the correct data.
+        """
+        with patch(
+                "stripe.Product.retrieve",
+                return_value=deepcopy(FAKE_PRODUCT),
+                autospec=True,
+        ):
+            plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
+        subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["plan"], plan.djstripe_id)
+        self.assertEqual(response.data["status"], subscription.status)
+        self.assertEqual(
+            response.data["cancel_at_period_end"], subscription.cancel_at_period_end
+        )
+
+    @patch("djstripe.models.Subscription.cancel", autospec=True)
+    def test_cancel_subscription(self, cancel_subscription_mock):
+        """Test a DELETE to the SubscriptionRestView.
+
+        Should cancel a Customer objects subscription.
+        """
+
+        def _cancel_sub(*args, **kwargs):
+            subscription = Subscription.objects.first()
+            subscription.status = SubscriptionStatus.canceled
+            subscription.canceled_at = timezone.now()
+            subscription.ended_at = timezone.now()
+            subscription.save()
+            return subscription
+
+        fake_canceled_subscription = deepcopy(FAKE_SUBSCRIPTION)
+
+        with patch(
+                "stripe.Product.retrieve",
+                return_value=deepcopy(FAKE_PRODUCT),
+                autospec=True,
+        ):
+            Subscription.sync_from_stripe_data(fake_canceled_subscription)
+
+        cancel_subscription_mock.side_effect = _cancel_sub
+
+        self.assertEqual(1, Subscription.objects.count())
+        self.assertEqual(Subscription.objects.first().status, SubscriptionStatus.active)
+
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Cancelled means flagged as canceled, so it should still be there
+        self.assertEqual(1, Subscription.objects.count())
+        self.assertEqual(
+            Subscription.objects.first().status, SubscriptionStatus.canceled
+        )
+
+        cancel_subscription_mock.assert_called_once_with(
+            Subscription.objects.first(),
+            at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END,
+        )
+        self.assertTrue(self.user.is_authenticated)
+
+    def test_cancel_subscription_exception(self):
+        """Test a DELETE to the SubscriptionRestView.
+
+        Should return a 400 when an exception is raised.
+        """
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class RestSubscriptionNotLoggedInTest(APITestCase):
+    """
+    Test the exceptions thrown by the subscription rest views.
+    """
+
+    def setUp(self):
+        self.url = reverse("rest_djstripe:subscription")
+
+    def test_create_subscription_not_logged_in(self):
+        data = {"plan": "test0", "stripe_token": "cake"}
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -54,7 +54,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         self.assertEqual(1, Customer.objects.count())
         customer = Customer.objects.get()
         add_card_mock.assert_called_once_with(customer, "cake")
-        subscribe_mock.assert_called_once_with(customer, "test0", True)
+        subscribe_mock.assert_called_once_with(customer, plan, True)
         # Do not test data content in views. Values will be string representation
         # of MagicMock of the values.
 

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -51,7 +51,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
             - Subcribe the Customer to a plan
         """
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        data = {"plan": plan.djstripe_id, "stripe_token": "cake"}
+        data = {"plan": plan.id, "stripe_token": "cake"}
         response = self.client.post(self.url_list, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -79,7 +79,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         """
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         data = {
-            "plan": plan.djstripe_id,
+            "plan": plan.id,
             "stripe_token": "cake",
             "charge_immediately": False,
         }
@@ -127,11 +127,11 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
 
         url = reverse(
-            "rest_djstripe:subscription-detail", kwargs={"pk": subscription.pk}
+            "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["plan"], plan.djstripe_id)
+        self.assertEqual(response.data["plan"], plan.id)
         self.assertEqual(response.data["status"], subscription.status)
         self.assertEqual(
             response.data["cancel_at_period_end"], subscription.cancel_at_period_end
@@ -164,7 +164,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         self.assertEqual(Subscription.objects.first().status, SubscriptionStatus.active)
 
         url = reverse(
-            "rest_djstripe:subscription-detail", kwargs={"pk": subscription.pk}
+            "rest_djstripe:subscription-detail", kwargs={"id": subscription.id}
         )
         response = self.client.put(url, data={"status": SubscriptionStatus.canceled})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -231,7 +231,7 @@ class PlanDetailAPIViewAnonymousTestCase(APITestCase):
     )
     def test_get_detail_of_plan(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"id": plan.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -240,7 +240,7 @@ class PlanDetailAPIViewAnonymousTestCase(APITestCase):
     )
     def test_update_new_plans(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"id": plan.id})
         response = self.client.put(url, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -249,6 +249,6 @@ class PlanDetailAPIViewAnonymousTestCase(APITestCase):
     )
     def test_delete_new_plans(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"id": plan.id})
         response = self.client.delete(url, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/tests/test_contrib/test_views.py
+++ b/tests/test_contrib/test_views.py
@@ -35,8 +35,12 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
     # The return_value of .subscribe is mandatory because normal serialization fails
     # on Decimal and DateTime fields: a Mock instance is provided in place
     # because @patch and make the conversion from string impossible.
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
-    @patch("djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription())
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
+    @patch(
+        "djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription()
+    )
     @patch("djstripe.models.Customer.add_card", autospec=True)
     def test_create_subscription(self, add_card_mock, subscribe_mock, retrieve_mock):
         """Test a POST to the Subscription List endpoint.
@@ -48,7 +52,7 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         """
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         data = {"plan": plan.djstripe_id, "stripe_token": "cake"}
-        response = self.client.post(self.url_list, data, format='json')
+        response = self.client.post(self.url_list, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         self.assertEqual(1, Customer.objects.count())
@@ -58,11 +62,15 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         # Do not test data content in views. Values will be string representation
         # of MagicMock of the values.
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
-    @patch("djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription())
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
+    @patch(
+        "djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription()
+    )
     @patch("djstripe.models.Customer.add_card", autospec=True)
     def test_create_subscription_charge_immediately(
-            self, add_card_mock, subscribe_mock, retrieve_mock
+        self, add_card_mock, subscribe_mock, retrieve_mock
     ):
         """Test a POST to the Subscription List endpoint.
 
@@ -70,7 +78,11 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         This will not send an invoice to the customer on subscribe.
         """
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        data = {"plan": plan.djstripe_id, "stripe_token": "cake", "charge_immediately": False}
+        data = {
+            "plan": plan.djstripe_id,
+            "stripe_token": "cake",
+            "charge_immediately": False,
+        }
         response = self.client.post(self.url_list, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -80,7 +92,9 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         # Do not test data content in views. Values will be string representation
         # of MagicMock of the values.
 
-    @patch("djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription())
+    @patch(
+        "djstripe.models.Customer.subscribe", autospec=True, return_value=Subscription()
+    )
     @patch("djstripe.models.Customer.add_card", autospec=True)
     def test_create_subscription_exception(self, add_card_mock, subscribe_mock):
         """Test a POST to the SubscriptionRestView.
@@ -101,7 +115,9 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         response = self.client.post(self.url_list, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
     def test_get_subscription(self, retrieve_mock):
         """Test a GET to the SubscriptionRestView.
 
@@ -110,7 +126,9 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
         subscription = Subscription.sync_from_stripe_data(deepcopy(FAKE_SUBSCRIPTION))
 
-        url = reverse("rest_djstripe:subscription-detail", kwargs={'pk': subscription.pk})
+        url = reverse(
+            "rest_djstripe:subscription-detail", kwargs={"pk": subscription.pk}
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["plan"], plan.djstripe_id)
@@ -119,7 +137,9 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
             response.data["cancel_at_period_end"], subscription.cancel_at_period_end
         )
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
     @patch("djstripe.models.Subscription.cancel", autospec=True)
     def test_cancel_subscription(self, cancel_subscription_mock, retrieve_mock):
         """Test a DELETE to the SubscriptionRestView.
@@ -143,8 +163,10 @@ class SubscriptionListCreateAPIViewAuthenticatedTestCase(APITestCase):
         self.assertEqual(1, Subscription.objects.count())
         self.assertEqual(Subscription.objects.first().status, SubscriptionStatus.active)
 
-        url = reverse("rest_djstripe:subscription-detail", kwargs={'pk': subscription.pk})
-        response = self.client.put(url, data={'status': SubscriptionStatus.canceled})
+        url = reverse(
+            "rest_djstripe:subscription-detail", kwargs={"pk": subscription.pk}
+        )
+        response = self.client.put(url, data={"status": SubscriptionStatus.canceled})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Cancelled means flagged as canceled, so it should still be there
@@ -195,7 +217,7 @@ class PlanListAPIViewAnonymousTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_post_new_plans(self):
-        response = self.client.post(self.url_list, data={'nickname': 'John Doe'})
+        response = self.client.post(self.url_list, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
@@ -204,23 +226,29 @@ class PlanDetailAPIViewAnonymousTestCase(APITestCase):
     Test the anonymous access to the LIST endpoint for Plans.
     """
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
     def test_get_detail_of_plan(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
     def test_update_new_plans(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
-        response = self.client.put(url, data={'nickname': 'John Doe'})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
+        response = self.client.put(url, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    @patch("stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT))
+    @patch(
+        "stripe.Product.retrieve", autospec=True, return_value=deepcopy(FAKE_PRODUCT)
+    )
     def test_delete_new_plans(self, retrieve_mock):
         plan = Plan.sync_from_stripe_data(deepcopy(FAKE_PLAN))
-        url = reverse('rest_djstripe:plan-detail', kwargs={'pk': plan.pk})
-        response = self.client.delete(url, data={'nickname': 'John Doe'})
+        url = reverse("rest_djstripe:plan-detail", kwargs={"pk": plan.pk})
+        response = self.client.delete(url, data={"nickname": "John Doe"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Hi. dj-stripe is amazing, but I really need REST APIs in my service. It seems there weren't much maintained since a while, so I took the liberty of a small overhaul. 

The current APIs cover only Subscriptions and Plans. It is a first step. Given the complexity of the models, and their inter-relationships, I prefer to focus on small parts one at a time.

I've gained a bit of experience in the last years with DRF and I really thing readability is improved if we clarly separate LIST and DETAIL endpoints, as well as separating clearly the work done by each "layer": views, serailzers and models (that have not been modified at all). The idea is simply to expose REST APIs without modifying the models.

Tests have been quite difficult to pass, since the original intention was sometimes ambiguous IMHO. I did have to change a few things to be completely consistent accross serializers. But I think the results is now more consistent, and tests have been added and made more similar to each other in code shape.

I could add more, but I thought it would be better to submit the PR asap for review, discussion and criticism before going any further. I'd be happy to improve anything someonen can spot.