### PR TITLE
Add restframework to the test app so DRF web UI works

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.sites",
     "django.contrib.staticfiles",
+    "rest_framework",
     "jsonfield",
     "djstripe",
     "tests",


### PR DESCRIPTION
eg /testapp/rest_djstripe/subscription/

Resolves `TemplateDoesNotExist at /testapp/rest_djstripe/subscription/`