### PR TITLE
Patch Account.get_default_account for restricted API keys.

### DIFF
--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -124,6 +124,11 @@ class Account(StripeModel):
 
     @classmethod
     def get_default_account(cls):
+        # As of API version 2020-03-02, there is no permission that can allow
+        # restricted keys to call GET /v1/account
+        if djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_"):
+            return None
+
         account_data = cls.stripe_class.retrieve(
             api_key=djstripe_settings.STRIPE_SECRET_KEY
         )


### PR DESCRIPTION
When dj-stripe is used with restricted API keys, any attempt to load the
current account will fail.

The Stripe error message looks like:

    Request req_***: The provided key
    'rk_live_AB****************************123' does not have the
    required permissions for this endpoint on account 'acct_ABC***'.
    This is a restricted API key, but the required permissions are not
    available for use by restricted keys.

Stripe doesn't offer any permission that would allow granting the
ability to call GET /v1/account

So instead just return None in Account.get_default_account if invoked
with a restricted API key.