### PR TITLE
Removed customer list_filter from PaymentMethodAdmin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -395,8 +395,7 @@ class SourceAdmin(StripeModelAdmin):
 @admin.register(models.PaymentMethod)
 class PaymentMethodAdmin(StripeModelAdmin):
     list_display = ("customer", "billing_details")
-    list_filter = ("customer",)
-
+    
 
 @admin.register(models.Subscription)
 class SubscriptionAdmin(StripeModelAdmin):


### PR DESCRIPTION
For anyone with a non-trivial amount of customers this filter will quickly kill your admin.