### PR TITLE
Add blank=True to the description field of PaymentIntent

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1496,6 +1496,7 @@ class PaymentIntent(StripeModel):
     description = models.TextField(
         max_length=1000,
         default="",
+        blank=True,
         help_text=(
             "An arbitrary string attached to the object. "
             "Often useful for displaying to users."


### PR DESCRIPTION
Thank you for the awesome project, very helpful.

I faced an unexpected behavior.
Is_valid method of the ModelForm class that takes PaymentIntent as a model class returned false and its error message was saying "Description field is required."

It looked an unexpected behavior because the default property of the field is set as ''.
Therefore I added "blank=True".

Thank you for your time.