### PR TITLE
Subscription.cancel_at field added

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1391,6 +1391,11 @@ class Subscription(StripeModel):
             "invoices."
         ),
     )
+    cancel_at = StripeDateTimeField(
+        null=True,
+        blank=True,
+        help_text="A date in the future at which the subscription will automatically get canceled."
+    )
     cancel_at_period_end = models.BooleanField(
         default=False,
         help_text="If the subscription has been canceled with the ``at_period_end`` "

--- a/tests/fixtures/subscription_sub_fakefakefakefakefake0001.json
+++ b/tests/fixtures/subscription_sub_fakefakefakefakefake0001.json
@@ -5,7 +5,7 @@
     "billing": "charge_automatically",
     "billing_cycle_anchor": 1557995176,
     "billing_thresholds": null,
-    "cancel_at": null,
+    "cancel_at": 1624553655,
     "cancel_at_period_end": false,
     "canceled_at": null,
     "collection_method": "charge_automatically",

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -70,6 +70,7 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
         self.assert_fks(
             subscription, expected_blank_fks=self.default_expected_blank_fks
         )
+        self.assertEqual(datetime_to_unix(subscription.cancel_at), 1624553655)
 
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II), autospec=True)
     @patch(


### PR DESCRIPTION
It seems like #1087 was never fully implemented, and I needed Subscription.cancel_at for a project.