### PR TITLE
Regenerate test fixtures

### DIFF
--- a/tests/apps/example/management/commands/regenerate_test_fixtures.py
+++ b/tests/apps/example/management/commands/regenerate_test_fixtures.py
@@ -126,10 +126,16 @@ class Command(BaseCommand):
                 "id",
                 # not actually read-only
                 "billing_cycle_anchor",
-                # seem that this is replacing "billing"? (but they can't both be set)
-                "collection_method",
+                "billing",
                 "current_period_end",
                 "current_period_start",
+                # workaround for "the
+                # `invoice_customer_balance_settings[consume_applied_balance_on_void]`
+                # parameter is only supported in API version 2019-11-05 and below.
+                # See
+                # https://stripe.com/docs/api#versioning and
+                # https://stripe.com/docs/upgrades#2019-12-03 for more detail.
+                "invoice_customer_balance_settings",
                 "latest_invoice",
                 "start",
                 "start_date",

--- a/tests/fixtures/balance_transaction_txn_fake_ch_fakefakefakefakefake0001.json
+++ b/tests/fixtures/balance_transaction_txn_fake_ch_fakefakefakefakefake0001.json
@@ -18,6 +18,7 @@
         }
     ],
     "net": 1912,
+    "reporting_category": "charge",
     "source": "ch_fakefakefakefakefake0001",
     "status": "pending",
     "type": "charge"

--- a/tests/fixtures/bank_account_ba_fakefakefakefakefake0003.json
+++ b/tests/fixtures/bank_account_ba_fakefakefakefakefake0003.json
@@ -7,7 +7,7 @@
     "country": "US",
     "currency": "usd",
     "customer": "cus_example_with_bank_account",
-    "fingerprint": "6HQmlfTrD91HjjlV",
+    "fingerprint": "PzC4f6ki9HTDR1cc",
     "last4": "6789",
     "metadata": {
         "djstripe_test_fake_id": "ba_fakefakefakefakefake0003",

--- a/tests/fixtures/card_card_fakefakefakefakefake0001.json
+++ b/tests/fixtures/card_card_fakefakefakefakefake0001.json
@@ -15,7 +15,7 @@
     "cvc_check": null,
     "dynamic_last4": null,
     "exp_month": 6,
-    "exp_year": 2020,
+    "exp_year": 2021,
     "fingerprint": "88PuXw9tEmvYe69o",
     "funding": "credit",
     "last4": "4242",

--- a/tests/fixtures/card_card_fakefakefakefakefake0002.json
+++ b/tests/fixtures/card_card_fakefakefakefakefake0002.json
@@ -15,7 +15,7 @@
     "cvc_check": null,
     "dynamic_last4": null,
     "exp_month": 6,
-    "exp_year": 2020,
+    "exp_year": 2021,
     "fingerprint": "88PuXw9tEmvYe69o",
     "funding": "credit",
     "last4": "4242",

--- a/tests/fixtures/card_card_fakefakefakefakefake0005.json
+++ b/tests/fixtures/card_card_fakefakefakefakefake0005.json
@@ -15,7 +15,7 @@
     "cvc_check": null,
     "dynamic_last4": null,
     "exp_month": 6,
-    "exp_year": 2020,
+    "exp_year": 2021,
     "fingerprint": "88PuXw9tEmvYe69o",
     "funding": "credit",
     "last4": "4242",

--- a/tests/fixtures/charge_ch_fakefakefakefakefake0001.json
+++ b/tests/fixtures/charge_ch_fakefakefakefakefake0001.json
@@ -20,6 +20,7 @@
         "name": "alex-nesnes@hotmail.fr",
         "phone": null
     },
+    "calculated_statement_descriptor": "Stripe",
     "captured": true,
     "created": 1557995177,
     "currency": "usd",
@@ -42,7 +43,7 @@
         "network_status": "approved_by_network",
         "reason": null,
         "risk_level": "normal",
-        "risk_score": 42,
+        "risk_score": 2,
         "seller_message": "Payment complete.",
         "type": "authorized"
     },
@@ -59,7 +60,7 @@
             },
             "country": "US",
             "exp_month": 6,
-            "exp_year": 2020,
+            "exp_year": 2021,
             "fingerprint": "88PuXw9tEmvYe69o",
             "funding": "credit",
             "installments": null,
@@ -94,11 +95,13 @@
         "cvc_check": null,
         "dynamic_last4": null,
         "exp_month": 6,
-        "exp_year": 2020,
+        "exp_year": 2021,
         "fingerprint": "88PuXw9tEmvYe69o",
         "funding": "credit",
         "last4": "4242",
-        "metadata": {},
+        "metadata": {
+            "djstripe_test_fake_id": "card_fakefakefakefakefake0001"
+        },
         "name": "alex-nesnes@hotmail.fr",
         "tokenization_method": null
     },

--- a/tests/fixtures/customer_cus_4QWKsZuuTHcs7X.json
+++ b/tests/fixtures/customer_cus_4QWKsZuuTHcs7X.json
@@ -1,7 +1,6 @@
 {
     "id": "cus_4QWKsZuuTHcs7X",
     "object": "customer",
-    "account_balance": 0,
     "address": null,
     "balance": 0,
     "created": 1557995167,
@@ -12,7 +11,7 @@
         "amount": null,
         "card": {
             "exp_month": 6,
-            "exp_year": 2020,
+            "exp_year": 2021,
             "last4": "4242",
             "country": "US",
             "brand": "Visa",
@@ -54,7 +53,7 @@
     "description": "John Doe",
     "discount": null,
     "email": "john.doe@example.com",
-    "invoice_prefix": "B23380FA",
+    "invoice_prefix": "90175264",
     "invoice_settings": {
         "custom_fields": null,
         "default_payment_method": null,
@@ -63,6 +62,7 @@
     "livemode": false,
     "metadata": {},
     "name": null,
+    "next_invoice_sequence": 1,
     "phone": null,
     "preferred_locales": [],
     "shipping": null,
@@ -75,7 +75,7 @@
                 "amount": null,
                 "card": {
                     "exp_month": 6,
-                    "exp_year": 2020,
+                    "exp_year": 2021,
                     "last4": "4242",
                     "country": "US",
                     "brand": "Visa",
@@ -120,7 +120,5 @@
     },
     "subscriptions": {},
     "tax_exempt": "none",
-    "tax_ids": {},
-    "tax_info": null,
-    "tax_info_verification": null
+    "tax_ids": {}
 }

--- a/tests/fixtures/customer_cus_4UbFSo9tl62jqj.json
+++ b/tests/fixtures/customer_cus_4UbFSo9tl62jqj.json
@@ -1,7 +1,6 @@
 {
     "id": "cus_4UbFSo9tl62jqj",
     "object": "customer",
-    "account_balance": 0,
     "address": null,
     "balance": 0,
     "created": 1557995167,
@@ -23,7 +22,7 @@
         "cvc_check": null,
         "dynamic_last4": null,
         "exp_month": 6,
-        "exp_year": 2020,
+        "exp_year": 2021,
         "fingerprint": "88PuXw9tEmvYe69o",
         "funding": "credit",
         "last4": "4242",
@@ -37,7 +36,7 @@
     "description": "John Snow",
     "discount": null,
     "email": "john.snow@thewall.com",
-    "invoice_prefix": "D842E5A6",
+    "invoice_prefix": "D7B0B3B6",
     "invoice_settings": {
         "custom_fields": null,
         "default_payment_method": null,
@@ -46,6 +45,7 @@
     "livemode": false,
     "metadata": {},
     "name": null,
+    "next_invoice_sequence": 3,
     "phone": null,
     "preferred_locales": [],
     "shipping": null,
@@ -69,7 +69,7 @@
                 "cvc_check": null,
                 "dynamic_last4": null,
                 "exp_month": 6,
-                "exp_year": 2020,
+                "exp_year": 2021,
                 "fingerprint": "88PuXw9tEmvYe69o",
                 "funding": "credit",
                 "last4": "4242",
@@ -91,7 +91,6 @@
                 "id": "sub_fakefakefakefakefake0004",
                 "object": "subscription",
                 "application_fee_percent": null,
-                "billing": "charge_automatically",
                 "billing_cycle_anchor": 1558230771,
                 "billing_thresholds": null,
                 "cancel_at": null,
@@ -108,9 +107,6 @@
                 "default_tax_rates": [],
                 "discount": null,
                 "ended_at": null,
-                "invoice_customer_balance_settings": {
-                    "consume_applied_balance_on_void": true
-                },
                 "items": {
                     "object": "list",
                     "data": [
@@ -141,6 +137,31 @@
                                 "transform_usage": null,
                                 "trial_period_days": null,
                                 "usage_type": "licensed"
+                            },
+                            "price": {
+                                "id": "gold21323",
+                                "object": "price",
+                                "active": true,
+                                "billing_scheme": "per_unit",
+                                "created": 1593225979,
+                                "currency": "usd",
+                                "livemode": false,
+                                "lookup_key": null,
+                                "metadata": {},
+                                "nickname": "New plan name",
+                                "product": "prod_fake1",
+                                "recurring": {
+                                    "aggregate_usage": null,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": null,
+                                    "usage_type": "licensed"
+                                },
+                                "tiers_mode": null,
+                                "transform_quantity": null,
+                                "type": "recurring",
+                                "unit_amount": 2000,
+                                "unit_amount_decimal": "2000"
                             },
                             "quantity": 1,
                             "subscription": "sub_fakefakefakefakefake0004",
@@ -174,6 +195,31 @@
                                 "trial_period_days": 12,
                                 "usage_type": "licensed"
                             },
+                            "price": {
+                                "id": "silver41294",
+                                "object": "price",
+                                "active": true,
+                                "billing_scheme": "per_unit",
+                                "created": 1593225979,
+                                "currency": "usd",
+                                "livemode": false,
+                                "lookup_key": null,
+                                "metadata": {},
+                                "nickname": "New plan name",
+                                "product": "prod_fake1",
+                                "recurring": {
+                                    "aggregate_usage": null,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": 12,
+                                    "usage_type": "licensed"
+                                },
+                                "tiers_mode": null,
+                                "transform_quantity": null,
+                                "type": "recurring",
+                                "unit_amount": 4000,
+                                "unit_amount_decimal": "4000"
+                            },
                             "quantity": 1,
                             "subscription": "sub_fakefakefakefakefake0004",
                             "tax_rates": []
@@ -183,21 +229,23 @@
                     "total_count": 2,
                     "url": "/v1/subscription_items?subscription=sub_fakefakefakefakefake0004"
                 },
-                "latest_invoice": "in_1EhAAlCOCguPTL2BHKM8PujL",
+                "latest_invoice": "in_1GyU3kCOCguPTL2BO0EVwuzj",
                 "livemode": false,
                 "metadata": {
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0004"
                 },
                 "next_pending_invoice_item_invoice": null,
+                "pause_collection": null,
                 "pending_invoice_item_interval": null,
                 "pending_setup_intent": null,
+                "pending_update": null,
                 "plan": null,
                 "quantity": null,
                 "schedule": null,
-                "start": 1558230771,
                 "start_date": 1559476706,
                 "status": "active",
                 "tax_percent": null,
+                "transfer_data": null,
                 "trial_end": null,
                 "trial_start": null
             },
@@ -205,7 +253,6 @@
                 "id": "sub_fakefakefakefakefake0003",
                 "object": "subscription",
                 "application_fee_percent": null,
-                "billing": "charge_automatically",
                 "billing_cycle_anchor": 1558230769,
                 "billing_thresholds": null,
                 "cancel_at": null,
@@ -222,9 +269,6 @@
                 "default_tax_rates": [],
                 "discount": null,
                 "ended_at": null,
-                "invoice_customer_balance_settings": {
-                    "consume_applied_balance_on_void": true
-                },
                 "items": {
                     "object": "list",
                     "data": [
@@ -256,6 +300,31 @@
                                 "trial_period_days": null,
                                 "usage_type": "licensed"
                             },
+                            "price": {
+                                "id": "gold21323",
+                                "object": "price",
+                                "active": true,
+                                "billing_scheme": "per_unit",
+                                "created": 1593225979,
+                                "currency": "usd",
+                                "livemode": false,
+                                "lookup_key": null,
+                                "metadata": {},
+                                "nickname": "New plan name",
+                                "product": "prod_fake1",
+                                "recurring": {
+                                    "aggregate_usage": null,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": null,
+                                    "usage_type": "licensed"
+                                },
+                                "tiers_mode": null,
+                                "transform_quantity": null,
+                                "type": "recurring",
+                                "unit_amount": 2000,
+                                "unit_amount_decimal": "2000"
+                            },
                             "quantity": 1,
                             "subscription": "sub_fakefakefakefakefake0003",
                             "tax_rates": []
@@ -265,14 +334,16 @@
                     "total_count": 1,
                     "url": "/v1/subscription_items?subscription=sub_fakefakefakefakefake0003"
                 },
-                "latest_invoice": "in_1EhAAjCOCguPTL2BRExZmp4c",
+                "latest_invoice": "in_1GyU3iCOCguPTL2BDgqo4dj7",
                 "livemode": false,
                 "metadata": {
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0003"
                 },
                 "next_pending_invoice_item_invoice": null,
+                "pause_collection": null,
                 "pending_invoice_item_interval": null,
                 "pending_setup_intent": null,
+                "pending_update": null,
                 "plan": {
                     "id": "gold21323",
                     "object": "plan",
@@ -297,10 +368,10 @@
                 },
                 "quantity": 1,
                 "schedule": null,
-                "start": 1558230769,
                 "start_date": 1559476704,
                 "status": "active",
                 "tax_percent": null,
+                "transfer_data": null,
                 "trial_end": null,
                 "trial_start": null
             }
@@ -310,7 +381,5 @@
         "url": "/v1/customers/cus_4UbFSo9tl62jqj/subscriptions"
     },
     "tax_exempt": "none",
-    "tax_ids": {},
-    "tax_info": null,
-    "tax_info_verification": null
+    "tax_ids": {}
 }

--- a/tests/fixtures/customer_cus_6lsBvm5rJ0zyHc.json
+++ b/tests/fixtures/customer_cus_6lsBvm5rJ0zyHc.json
@@ -1,7 +1,6 @@
 {
     "id": "cus_6lsBvm5rJ0zyHc",
     "object": "customer",
-    "account_balance": 0,
     "address": null,
     "balance": 0,
     "created": 1557995166,
@@ -23,7 +22,7 @@
         "cvc_check": null,
         "dynamic_last4": null,
         "exp_month": 6,
-        "exp_year": 2020,
+        "exp_year": 2021,
         "fingerprint": "88PuXw9tEmvYe69o",
         "funding": "credit",
         "last4": "4242",
@@ -37,7 +36,7 @@
     "description": "Michael Smith",
     "discount": null,
     "email": "michael.smith@example.com",
-    "invoice_prefix": "7759B3BE",
+    "invoice_prefix": "E5B23224",
     "invoice_settings": {
         "custom_fields": null,
         "default_payment_method": null,
@@ -46,6 +45,7 @@
     "livemode": false,
     "metadata": {},
     "name": null,
+    "next_invoice_sequence": 3,
     "phone": null,
     "preferred_locales": [],
     "shipping": null,
@@ -69,7 +69,7 @@
                 "cvc_check": null,
                 "dynamic_last4": null,
                 "exp_month": 6,
-                "exp_year": 2020,
+                "exp_year": 2021,
                 "fingerprint": "88PuXw9tEmvYe69o",
                 "funding": "credit",
                 "last4": "4242",
@@ -96,7 +96,7 @@
                 "cvc_check": null,
                 "dynamic_last4": null,
                 "exp_month": 6,
-                "exp_year": 2020,
+                "exp_year": 2021,
                 "fingerprint": "88PuXw9tEmvYe69o",
                 "funding": "credit",
                 "last4": "4242",
@@ -118,7 +118,6 @@
                 "id": "sub_fakefakefakefakefake0002",
                 "object": "subscription",
                 "application_fee_percent": null,
-                "billing": "charge_automatically",
                 "billing_cycle_anchor": 1558230766,
                 "billing_thresholds": null,
                 "cancel_at": null,
@@ -135,9 +134,6 @@
                 "default_tax_rates": [],
                 "discount": null,
                 "ended_at": null,
-                "invoice_customer_balance_settings": {
-                    "consume_applied_balance_on_void": true
-                },
                 "items": {
                     "object": "list",
                     "data": [
@@ -169,6 +165,31 @@
                                 "trial_period_days": 12,
                                 "usage_type": "licensed"
                             },
+                            "price": {
+                                "id": "silver41294",
+                                "object": "price",
+                                "active": true,
+                                "billing_scheme": "per_unit",
+                                "created": 1593225979,
+                                "currency": "usd",
+                                "livemode": false,
+                                "lookup_key": null,
+                                "metadata": {},
+                                "nickname": "New plan name",
+                                "product": "prod_fake1",
+                                "recurring": {
+                                    "aggregate_usage": null,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": 12,
+                                    "usage_type": "licensed"
+                                },
+                                "tiers_mode": null,
+                                "transform_quantity": null,
+                                "type": "recurring",
+                                "unit_amount": 4000,
+                                "unit_amount_decimal": "4000"
+                            },
                             "quantity": 1,
                             "subscription": "sub_fakefakefakefakefake0002",
                             "tax_rates": [
@@ -176,7 +197,7 @@
                                     "id": "txr_fakefakefakefakefake0001",
                                     "object": "tax_rate",
                                     "active": true,
-                                    "created": 1570944265,
+                                    "created": 1593225980,
                                     "description": null,
                                     "display_name": "VAT",
                                     "inclusive": true,
@@ -200,8 +221,10 @@
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0002"
                 },
                 "next_pending_invoice_item_invoice": null,
+                "pause_collection": null,
                 "pending_invoice_item_interval": null,
                 "pending_setup_intent": null,
+                "pending_update": null,
                 "plan": {
                     "id": "silver41294",
                     "object": "plan",
@@ -226,10 +249,10 @@
                 },
                 "quantity": 1,
                 "schedule": null,
-                "start": 1558230766,
                 "start_date": 1559476702,
                 "status": "active",
                 "tax_percent": null,
+                "transfer_data": null,
                 "trial_end": null,
                 "trial_start": null
             },
@@ -237,7 +260,6 @@
                 "id": "sub_fakefakefakefakefake0001",
                 "object": "subscription",
                 "application_fee_percent": null,
-                "billing": "charge_automatically",
                 "billing_cycle_anchor": 1558230764,
                 "billing_thresholds": null,
                 "cancel_at": null,
@@ -256,7 +278,7 @@
                         "id": "txr_fakefakefakefakefake0001",
                         "object": "tax_rate",
                         "active": true,
-                        "created": 1570921289,
+                        "created": 1593225980,
                         "description": null,
                         "display_name": "VAT",
                         "inclusive": true,
@@ -270,9 +292,6 @@
                 ],
                 "discount": null,
                 "ended_at": null,
-                "invoice_customer_balance_settings": {
-                    "consume_applied_balance_on_void": true
-                },
                 "items": {
                     "object": "list",
                     "data": [
@@ -304,6 +323,31 @@
                                 "trial_period_days": null,
                                 "usage_type": "licensed"
                             },
+                            "price": {
+                                "id": "gold21323",
+                                "object": "price",
+                                "active": true,
+                                "billing_scheme": "per_unit",
+                                "created": 1593225979,
+                                "currency": "usd",
+                                "livemode": false,
+                                "lookup_key": null,
+                                "metadata": {},
+                                "nickname": "New plan name",
+                                "product": "prod_fake1",
+                                "recurring": {
+                                    "aggregate_usage": null,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": null,
+                                    "usage_type": "licensed"
+                                },
+                                "tiers_mode": null,
+                                "transform_quantity": null,
+                                "type": "recurring",
+                                "unit_amount": 2000,
+                                "unit_amount_decimal": "2000"
+                            },
                             "quantity": 1,
                             "subscription": "sub_fakefakefakefakefake0001",
                             "tax_rates": []
@@ -319,8 +363,10 @@
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0001"
                 },
                 "next_pending_invoice_item_invoice": null,
+                "pause_collection": null,
                 "pending_invoice_item_interval": null,
                 "pending_setup_intent": null,
+                "pending_update": null,
                 "plan": {
                     "id": "gold21323",
                     "object": "plan",
@@ -345,10 +391,10 @@
                 },
                 "quantity": 1,
                 "schedule": null,
-                "start": 1558230764,
                 "start_date": 1559476700,
                 "status": "active",
                 "tax_percent": null,
+                "transfer_data": null,
                 "trial_end": null,
                 "trial_start": null
             }
@@ -358,7 +404,5 @@
         "url": "/v1/customers/cus_6lsBvm5rJ0zyHc/subscriptions"
     },
     "tax_exempt": "none",
-    "tax_ids": {},
-    "tax_info": null,
-    "tax_info_verification": null
+    "tax_ids": {}
 }

--- a/tests/fixtures/customer_cus_example_with_bank_account.json
+++ b/tests/fixtures/customer_cus_example_with_bank_account.json
@@ -1,7 +1,6 @@
 {
     "id": "cus_example_with_bank_account",
     "object": "customer",
-    "account_balance": 0,
     "address": null,
     "balance": 0,
     "created": 1566463428,
@@ -15,7 +14,7 @@
         "country": "US",
         "currency": "usd",
         "customer": "cus_example_with_bank_account",
-        "fingerprint": "6HQmlfTrD91HjjlV",
+        "fingerprint": "PzC4f6ki9HTDR1cc",
         "last4": "6789",
         "metadata": {
             "djstripe_test_fake_id": "ba_fakefakefakefakefake0003",
@@ -28,7 +27,7 @@
     "description": null,
     "discount": null,
     "email": "jane.austen@example.com",
-    "invoice_prefix": "5E93BD77",
+    "invoice_prefix": "905A7617",
     "invoice_settings": {
         "custom_fields": null,
         "default_payment_method": null,
@@ -37,6 +36,7 @@
     "livemode": false,
     "metadata": {},
     "name": "Jane Austen",
+    "next_invoice_sequence": 1,
     "phone": null,
     "preferred_locales": [],
     "shipping": null,
@@ -52,7 +52,7 @@
                 "country": "US",
                 "currency": "usd",
                 "customer": "cus_example_with_bank_account",
-                "fingerprint": "6HQmlfTrD91HjjlV",
+                "fingerprint": "PzC4f6ki9HTDR1cc",
                 "last4": "6789",
                 "metadata": {
                     "djstripe_test_fake_id": "ba_fakefakefakefakefake0003",
@@ -68,7 +68,5 @@
     },
     "subscriptions": {},
     "tax_exempt": "none",
-    "tax_ids": {},
-    "tax_info": null,
-    "tax_info_verification": null
+    "tax_ids": {}
 }

--- a/tests/fixtures/invoice_in_fakefakefakefakefake0001.json
+++ b/tests/fixtures/invoice_in_fakefakefakefakefake0001.json
@@ -10,7 +10,6 @@
     "attempt_count": 1,
     "attempted": true,
     "auto_advance": false,
-    "billing": "charge_automatically",
     "billing_reason": "subscription_create",
     "charge": "ch_fakefakefakefakefake0001",
     "collection_method": "charge_automatically",
@@ -32,7 +31,7 @@
             "id": "txr_fakefakefakefakefake0001",
             "object": "tax_rate",
             "active": true,
-            "created": 1570921289,
+            "created": 1593225980,
             "description": null,
             "display_name": "VAT",
             "inclusive": true,
@@ -55,7 +54,7 @@
         "object": "list",
         "data": [
             {
-                "id": "sli_3445f2b5e035b0",
+                "id": "il_1GyU3dCOCguPTL2Bow2th8zP",
                 "object": "line_item",
                 "amount": 2000,
                 "currency": "usd",
@@ -66,8 +65,8 @@
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0001"
                 },
                 "period": {
-                    "end": 1562137289,
-                    "start": 1559545289
+                    "end": 1595817981,
+                    "start": 1593225981
                 },
                 "plan": {
                     "id": "gold21323",
@@ -91,10 +90,35 @@
                     "trial_period_days": null,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "gold21323",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": null,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 2000,
+                    "unit_amount_decimal": "2000"
+                },
                 "proration": false,
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0001",
-                "subscription_item": "si_FBXFzo2zBOeeMy",
+                "subscription_item": "si_HXZCDv9ixoUB5u",
                 "tax_amounts": [
                     {
                         "amount": 261,
@@ -115,7 +139,7 @@
         "djstripe_test_fake_id": "in_fakefakefakefakefake0001"
     },
     "next_payment_attempt": null,
-    "number": "7759B3BE-0001",
+    "number": "E5B23224-0001",
     "paid": true,
     "payment_intent": "pi_fakefakefakefakefake0001",
     "period_end": 1557995176,
@@ -127,9 +151,9 @@
     "statement_descriptor": null,
     "status": "paid",
     "status_transitions": {
-        "finalized_at": 1559545289,
+        "finalized_at": 1593225981,
         "marked_uncollectible_at": null,
-        "paid_at": 1559545289,
+        "paid_at": 1593225983,
         "voided_at": null
     },
     "subscription": "sub_fakefakefakefakefake0001",
@@ -144,5 +168,6 @@
             "tax_rate": "txr_fakefakefakefakefake0001"
         }
     ],
+    "transfer_data": null,
     "webhooks_delivered_at": 1557995178
 }

--- a/tests/fixtures/invoice_in_fakefakefakefakefake0004.json
+++ b/tests/fixtures/invoice_in_fakefakefakefakefake0004.json
@@ -10,9 +10,8 @@
     "attempt_count": 1,
     "attempted": true,
     "auto_advance": false,
-    "billing": "charge_automatically",
     "billing_reason": "subscription_create",
-    "charge": "ch_1FSyryCOCguPTL2BT40P4uy7",
+    "charge": "ch_1GyU3gCOCguPTL2BnyYlJe2x",
     "collection_method": "charge_automatically",
     "created": 1570941590,
     "currency": "usd",
@@ -39,7 +38,7 @@
         "object": "list",
         "data": [
             {
-                "id": "sli_3141ba20e7baea",
+                "id": "il_1GyU3gCOCguPTL2B69cIweEY",
                 "object": "line_item",
                 "amount": 4000,
                 "currency": "usd",
@@ -50,8 +49,8 @@
                     "djstripe_test_fake_id": "sub_fakefakefakefakefake0002"
                 },
                 "period": {
-                    "end": 1573619990,
-                    "start": 1570941590
+                    "end": 1595817984,
+                    "start": 1593225984
                 },
                 "plan": {
                     "id": "silver41294",
@@ -75,10 +74,35 @@
                     "trial_period_days": 12,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "silver41294",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": 12,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 4000,
+                    "unit_amount_decimal": "4000"
+                },
                 "proration": false,
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0002",
-                "subscription_item": "si_FywlrQT40WNc91",
+                "subscription_item": "si_HXZCuxDh3W7EQm",
                 "tax_amounts": [
                     {
                         "amount": 522,
@@ -91,7 +115,7 @@
                         "id": "txr_fakefakefakefakefake0001",
                         "object": "tax_rate",
                         "active": true,
-                        "created": 1570944265,
+                        "created": 1593225980,
                         "description": null,
                         "display_name": "VAT",
                         "inclusive": true,
@@ -115,9 +139,9 @@
         "djstripe_test_fake_id": "in_fakefakefakefakefake0004"
     },
     "next_payment_attempt": null,
-    "number": "4CABBFC9-0002",
+    "number": "E5B23224-0002",
     "paid": true,
-    "payment_intent": "pi_1FSyryCOCguPTL2B9g38x9AD",
+    "payment_intent": "pi_1GyU3gCOCguPTL2BVH2OIzjf",
     "period_end": 1570941590,
     "period_start": 1570941590,
     "post_payment_credit_notes_amount": 0,
@@ -127,9 +151,9 @@
     "statement_descriptor": null,
     "status": "paid",
     "status_transitions": {
-        "finalized_at": 1570941590,
+        "finalized_at": 1593225984,
         "marked_uncollectible_at": null,
-        "paid_at": 1570941591,
+        "paid_at": 1593225985,
         "voided_at": null
     },
     "subscription": "sub_fakefakefakefakefake0002",
@@ -144,5 +168,6 @@
             "tax_rate": "txr_fakefakefakefakefake0001"
         }
     ],
+    "transfer_data": null,
     "webhooks_delivered_at": 1570941591
 }

--- a/tests/fixtures/payment_intent_pi_fakefakefakefakefake0001.json
+++ b/tests/fixtures/payment_intent_pi_fakefakefakefakefake0001.json
@@ -34,6 +34,7 @@
                     "name": "alex-nesnes@hotmail.fr",
                     "phone": null
                 },
+                "calculated_statement_descriptor": "Stripe",
                 "captured": true,
                 "created": 1562801159,
                 "currency": "usd",
@@ -56,7 +57,7 @@
                     "network_status": "approved_by_network",
                     "reason": null,
                     "risk_level": "normal",
-                    "risk_score": 60,
+                    "risk_score": 2,
                     "seller_message": "Payment complete.",
                     "type": "authorized"
                 },
@@ -72,9 +73,9 @@
                             "cvc_check": null
                         },
                         "country": "US",
-                        "exp_month": 7,
-                        "exp_year": 2020,
-                        "fingerprint": "XBb4pv4IRQeImoJN",
+                        "exp_month": 6,
+                        "exp_year": 2021,
+                        "fingerprint": "88PuXw9tEmvYe69o",
                         "funding": "credit",
                         "installments": null,
                         "last4": "4242",
@@ -107,12 +108,14 @@
                     "customer": "cus_6lsBvm5rJ0zyHc",
                     "cvc_check": null,
                     "dynamic_last4": null,
-                    "exp_month": 7,
-                    "exp_year": 2020,
-                    "fingerprint": "XBb4pv4IRQeImoJN",
+                    "exp_month": 6,
+                    "exp_year": 2021,
+                    "fingerprint": "88PuXw9tEmvYe69o",
                     "funding": "credit",
                     "last4": "4242",
-                    "metadata": {},
+                    "metadata": {
+                        "djstripe_test_fake_id": "card_fakefakefakefakefake0001"
+                    },
                     "name": "alex-nesnes@hotmail.fr",
                     "tokenization_method": null
                 },
@@ -128,7 +131,7 @@
         "total_count": 1,
         "url": "/v1/charges?payment_intent=pi_fakefakefakefakefake0001"
     },
-    "client_secret": "pi_fakefakefakefakefake0001_secret_ThITPIod1Ij6loKD5KOhEYqMA",
+    "client_secret": "pi_fakefakefakefakefake0001_secret_fu8Bf1uEyWIbQwB7f4xCQ7iTX",
     "confirmation_method": "automatic",
     "created": 1562801159,
     "currency": "usd",
@@ -146,6 +149,7 @@
     "payment_method_options": {
         "card": {
             "installments": null,
+            "network": null,
             "request_three_d_secure": "automatic"
         }
     },

--- a/tests/fixtures/payment_method_card_fakefakefakefakefake0001.json
+++ b/tests/fixtures/payment_method_card_fakefakefakefakefake0001.json
@@ -23,11 +23,17 @@
         },
         "country": "US",
         "exp_month": 6,
-        "exp_year": 2020,
+        "exp_year": 2021,
         "fingerprint": "88PuXw9tEmvYe69o",
         "funding": "credit",
         "generated_from": null,
         "last4": "4242",
+        "networks": {
+            "available": [
+                "visa"
+            ],
+            "preferred": null
+        },
         "three_d_secure_usage": {
             "supported": true
         },

--- a/tests/fixtures/payment_method_pm_fakefakefakefake0001.json
+++ b/tests/fixtures/payment_method_pm_fakefakefakefake0001.json
@@ -22,12 +22,18 @@
             "cvc_check": null
         },
         "country": "US",
-        "exp_month": 8,
-        "exp_year": 2020,
-        "fingerprint": "WJTDnAWuKKdbSagG",
+        "exp_month": 6,
+        "exp_year": 2021,
+        "fingerprint": "88PuXw9tEmvYe69o",
         "funding": "credit",
         "generated_from": null,
         "last4": "4242",
+        "networks": {
+            "available": [
+                "visa"
+            ],
+            "preferred": null
+        },
         "three_d_secure_usage": {
             "supported": true
         },

--- a/tests/fixtures/product_prod_fake1.json
+++ b/tests/fixtures/product_prod_fake1.json
@@ -3,19 +3,14 @@
     "object": "product",
     "active": true,
     "attributes": [],
-    "caption": null,
     "created": 1557995174,
-    "deactivate_on": [],
     "description": null,
     "images": [],
     "livemode": false,
     "metadata": {},
     "name": "Fake Product",
-    "package_dimensions": null,
-    "shippable": null,
     "statement_descriptor": null,
     "type": "service",
     "unit_label": null,
-    "updated": 1557995176,
-    "url": null
+    "updated": 1557995176
 }

--- a/tests/fixtures/source_src_fakefakefakefakefake0001.json
+++ b/tests/fixtures/source_src_fakefakefakefakefake0001.json
@@ -4,7 +4,7 @@
     "amount": null,
     "card": {
         "exp_month": 6,
-        "exp_year": 2020,
+        "exp_year": 2021,
         "last4": "4242",
         "country": "US",
         "brand": "Visa",

--- a/tests/fixtures/subscription_sub_fakefakefakefakefake0001.json
+++ b/tests/fixtures/subscription_sub_fakefakefakefakefake0001.json
@@ -2,7 +2,6 @@
     "id": "sub_fakefakefakefakefake0001",
     "object": "subscription",
     "application_fee_percent": null,
-    "billing": "charge_automatically",
     "billing_cycle_anchor": 1557995176,
     "billing_thresholds": null,
     "cancel_at": null,
@@ -21,7 +20,7 @@
             "id": "txr_fakefakefakefakefake0001",
             "object": "tax_rate",
             "active": true,
-            "created": 1570921289,
+            "created": 1593225980,
             "description": null,
             "display_name": "VAT",
             "inclusive": true,
@@ -35,9 +34,6 @@
     ],
     "discount": null,
     "ended_at": null,
-    "invoice_customer_balance_settings": {
-        "consume_applied_balance_on_void": true
-    },
     "items": {
         "object": "list",
         "data": [
@@ -69,6 +65,31 @@
                     "trial_period_days": null,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "gold21323",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": null,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 2000,
+                    "unit_amount_decimal": "2000"
+                },
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0001",
                 "tax_rates": []
@@ -84,8 +105,10 @@
         "djstripe_test_fake_id": "sub_fakefakefakefakefake0001"
     },
     "next_pending_invoice_item_invoice": null,
+    "pause_collection": null,
     "pending_invoice_item_interval": null,
     "pending_setup_intent": null,
+    "pending_update": null,
     "plan": {
         "id": "gold21323",
         "object": "plan",
@@ -110,10 +133,10 @@
     },
     "quantity": 1,
     "schedule": null,
-    "start": 1557995176,
     "start_date": 1559476700,
     "status": "active",
     "tax_percent": null,
+    "transfer_data": null,
     "trial_end": null,
     "trial_start": null
 }

--- a/tests/fixtures/subscription_sub_fakefakefakefakefake0002.json
+++ b/tests/fixtures/subscription_sub_fakefakefakefakefake0002.json
@@ -2,7 +2,6 @@
     "id": "sub_fakefakefakefakefake0002",
     "object": "subscription",
     "application_fee_percent": null,
-    "billing": "charge_automatically",
     "billing_cycle_anchor": 1557995178,
     "billing_thresholds": null,
     "cancel_at": null,
@@ -19,9 +18,6 @@
     "default_tax_rates": [],
     "discount": null,
     "ended_at": null,
-    "invoice_customer_balance_settings": {
-        "consume_applied_balance_on_void": true
-    },
     "items": {
         "object": "list",
         "data": [
@@ -53,6 +49,31 @@
                     "trial_period_days": 12,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "silver41294",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": 12,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 4000,
+                    "unit_amount_decimal": "4000"
+                },
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0002",
                 "tax_rates": [
@@ -60,7 +81,7 @@
                         "id": "txr_fakefakefakefakefake0001",
                         "object": "tax_rate",
                         "active": true,
-                        "created": 1570944265,
+                        "created": 1593225980,
                         "description": null,
                         "display_name": "VAT",
                         "inclusive": true,
@@ -84,8 +105,10 @@
         "djstripe_test_fake_id": "sub_fakefakefakefakefake0002"
     },
     "next_pending_invoice_item_invoice": null,
+    "pause_collection": null,
     "pending_invoice_item_interval": null,
     "pending_setup_intent": null,
+    "pending_update": null,
     "plan": {
         "id": "silver41294",
         "object": "plan",
@@ -110,10 +133,10 @@
     },
     "quantity": 1,
     "schedule": null,
-    "start": 1557995178,
     "start_date": 1559476702,
     "status": "active",
     "tax_percent": null,
+    "transfer_data": null,
     "trial_end": null,
     "trial_start": null
 }

--- a/tests/fixtures/subscription_sub_fakefakefakefakefake0003.json
+++ b/tests/fixtures/subscription_sub_fakefakefakefakefake0003.json
@@ -2,7 +2,6 @@
     "id": "sub_fakefakefakefakefake0003",
     "object": "subscription",
     "application_fee_percent": null,
-    "billing": "charge_automatically",
     "billing_cycle_anchor": 1557995180,
     "billing_thresholds": null,
     "cancel_at": null,
@@ -19,9 +18,6 @@
     "default_tax_rates": [],
     "discount": null,
     "ended_at": null,
-    "invoice_customer_balance_settings": {
-        "consume_applied_balance_on_void": true
-    },
     "items": {
         "object": "list",
         "data": [
@@ -53,6 +49,31 @@
                     "trial_period_days": null,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "gold21323",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": null,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 2000,
+                    "unit_amount_decimal": "2000"
+                },
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0003",
                 "tax_rates": []
@@ -62,14 +83,16 @@
         "total_count": 1,
         "url": "/v1/subscription_items?subscription=sub_fakefakefakefakefake0003"
     },
-    "latest_invoice": "in_1EhAAjCOCguPTL2BRExZmp4c",
+    "latest_invoice": "in_1GyU3iCOCguPTL2BDgqo4dj7",
     "livemode": false,
     "metadata": {
         "djstripe_test_fake_id": "sub_fakefakefakefakefake0003"
     },
     "next_pending_invoice_item_invoice": null,
+    "pause_collection": null,
     "pending_invoice_item_interval": null,
     "pending_setup_intent": null,
+    "pending_update": null,
     "plan": {
         "id": "gold21323",
         "object": "plan",
@@ -94,10 +117,10 @@
     },
     "quantity": 1,
     "schedule": null,
-    "start": 1557995180,
     "start_date": 1559476704,
     "status": "active",
     "tax_percent": null,
+    "transfer_data": null,
     "trial_end": null,
     "trial_start": null
 }

--- a/tests/fixtures/subscription_sub_fakefakefakefakefake0004.json
+++ b/tests/fixtures/subscription_sub_fakefakefakefakefake0004.json
@@ -2,7 +2,6 @@
     "id": "sub_fakefakefakefakefake0004",
     "object": "subscription",
     "application_fee_percent": null,
-    "billing": "charge_automatically",
     "billing_cycle_anchor": 1557995182,
     "billing_thresholds": null,
     "cancel_at": null,
@@ -19,9 +18,6 @@
     "default_tax_rates": [],
     "discount": null,
     "ended_at": null,
-    "invoice_customer_balance_settings": {
-        "consume_applied_balance_on_void": true
-    },
     "items": {
         "object": "list",
         "data": [
@@ -52,6 +48,31 @@
                     "transform_usage": null,
                     "trial_period_days": null,
                     "usage_type": "licensed"
+                },
+                "price": {
+                    "id": "gold21323",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": null,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 2000,
+                    "unit_amount_decimal": "2000"
                 },
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0004",
@@ -85,6 +106,31 @@
                     "trial_period_days": 12,
                     "usage_type": "licensed"
                 },
+                "price": {
+                    "id": "silver41294",
+                    "object": "price",
+                    "active": true,
+                    "billing_scheme": "per_unit",
+                    "created": 1593225979,
+                    "currency": "usd",
+                    "livemode": false,
+                    "lookup_key": null,
+                    "metadata": {},
+                    "nickname": "New plan name",
+                    "product": "prod_fake1",
+                    "recurring": {
+                        "aggregate_usage": null,
+                        "interval": "month",
+                        "interval_count": 1,
+                        "trial_period_days": 12,
+                        "usage_type": "licensed"
+                    },
+                    "tiers_mode": null,
+                    "transform_quantity": null,
+                    "type": "recurring",
+                    "unit_amount": 4000,
+                    "unit_amount_decimal": "4000"
+                },
                 "quantity": 1,
                 "subscription": "sub_fakefakefakefakefake0004",
                 "tax_rates": []
@@ -94,21 +140,23 @@
         "total_count": 2,
         "url": "/v1/subscription_items?subscription=sub_fakefakefakefakefake0004"
     },
-    "latest_invoice": "in_1EhAAlCOCguPTL2BHKM8PujL",
+    "latest_invoice": "in_1GyU3kCOCguPTL2BO0EVwuzj",
     "livemode": false,
     "metadata": {
         "djstripe_test_fake_id": "sub_fakefakefakefakefake0004"
     },
     "next_pending_invoice_item_invoice": null,
+    "pause_collection": null,
     "pending_invoice_item_interval": null,
     "pending_setup_intent": null,
+    "pending_update": null,
     "plan": null,
     "quantity": null,
     "schedule": null,
-    "start": 1557995182,
     "start_date": 1559476706,
     "status": "active",
     "tax_percent": null,
+    "transfer_data": null,
     "trial_end": null,
     "trial_start": null
 }

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -852,7 +852,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         # but this doesn't match what I'm seeing from Stripe
         # I'm not sure if it's possible to predict the whole item id now,
         # sli seems to not reference anything
-        item_id_prefix = "{invoice_id}-sli_".format(invoice_id=invoice.id)
+        item_id_prefix = "{invoice_id}-il_".format(invoice_id=invoice.id)
         self.assertTrue(items[0].id.startswith(item_id_prefix))
         self.assertEqual(items[0].subscription.id, FAKE_SUBSCRIPTION["id"])
 


### PR DESCRIPTION
Updating for API version 2020-03-02 - adds subscription.price etc, removes some deprecated fields.  Churn of things like invoice ids isn't ideal but not a huge deal.

as per https://dj-stripe.readthedocs.io/en/stable/project/test_fixtures.html?highlight=regenerate_test_fixtures#regenerating-the-test-fixtures

One test tweak needed since Invoice line items id prefix seems to have  changed (was `sli_`*, now `li_`*).