### PR TITLE
Fix build on readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-pip>=10.0.1
+pip>=19.0
 setuptools>=39.2.0
 wheel>=0.31.1
 six>=1.11.0
@@ -12,3 +12,6 @@ sphinx>=1.7.4
 sphinx_rtd_theme>=0.1.9
 sphinx-autobuild>=0.6.0
 sphinxcontrib-django
+
+# install djstripe package on readthedocs
+.


### PR DESCRIPTION
Build was failing because our readthedocs settings assumed setup.py exists.

eg https://readthedocs.org/projects/dj-stripe/builds/11281794/

```
/home/docs/checkouts/readthedocs.org/user_builds/dj-stripe/envs/master/bin/python /home/docs/checkouts/readthedocs.org/user_builds/dj-stripe/checkouts/master/setup.py install --force 
 /home/docs/checkouts/readthedocs.org/user_builds/dj-stripe/envs/master/bin/python: can't open file '/home/docs/checkouts/readthedocs.org/user_builds/dj-stripe/checkouts/master/setup.py': [Errno 2] No such file or directory 
```

Fixed by disabling this (unticking "Install Project" in advanced settings), and adding . to the docs/requirements.txt instead.

FYI @kavdev @jleclanche 