### PR TITLE
Multiplan subscription are not synced when removing subscription items

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -737,14 +737,18 @@ class StripeModel(models.Model):
 
         items = data.get("items")
         if not items:
+            subscription.items.delete()
             return []
 
+        pks = []
         subscriptionitems = []
         for item_data in items.auto_paging_iter():
             item, _ = target_cls._get_or_create_from_stripe_object(
                 item_data, refetch=False
             )
+            pks.append(item.pk)
             subscriptionitems.append(item)
+        subscription.items.exclude(pk__in=pks).delete()
 
         return subscriptionitems
 


### PR DESCRIPTION
Subscription sync always fails (see failing test case added) when we are removing some of the existing plan/prices attached to the subscription. 

Indeed, until now subscription are only creating/updating items, never deleting.

This PR aims to enable the deletion of removed items from a subscription update.

Cheers,
Pierre