### PR TITLE
Upgrade default API version to 2020-08-27

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -9,7 +9,7 @@ from django.utils.module_loading import import_string
 
 from .checks import validate_stripe_api_version
 
-DEFAULT_STRIPE_API_VERSION = "2020-03-02"
+DEFAULT_STRIPE_API_VERSION = "2020-08-27"
 
 
 def get_callback_function(setting_name, default=None):


### PR DESCRIPTION
According to the documentation and 2.4.0 release notes, `2020-08-27` is the latest tested Stripe version.

However it was not updated in the `DEFAULT_STRIPE_API_VERSION` setting.