### PR TITLE
Fix sync model recursion loop

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -647,7 +647,8 @@ class StripeModel(models.Model):
 
         if "customer" in data and data["customer"]:
             return target_cls._get_or_create_from_stripe_object(
-                data, "customer", current_ids=current_ids)[0]
+                data, "customer", current_ids=current_ids
+            )[0]
 
     @classmethod
     def _stripe_object_to_default_tax_rates(cls, target_cls, data):

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -429,7 +429,7 @@ class StripeModel(models.Model):
         """
         return "object" in data and data["object"] == cls.stripe_class.OBJECT_NAME
 
-    def _attach_objects_hook(self, cls, data):
+    def _attach_objects_hook(self, cls, data, current_ids=None):
         """
         Gets called by this object's create and sync methods just before save.
         Use this to populate fields before the model is saved.
@@ -437,6 +437,8 @@ class StripeModel(models.Model):
         :param cls: The target class for the instantiated object.
         :param data: The data dictionary received from the Stripe API.
         :type data: dict
+        :param current_ids: stripe ids of objects that are currently being processed
+        :type current_ids: set
         """
 
         pass
@@ -507,7 +509,7 @@ class StripeModel(models.Model):
                 stripe_account=stripe_account,
             )
         )
-        instance._attach_objects_hook(cls, data)
+        instance._attach_objects_hook(cls, data, current_ids=current_ids)
 
         if save:
             instance.save(force_insert=True)
@@ -631,7 +633,7 @@ class StripeModel(models.Model):
             return cls.stripe_objects.get(id=id_), False
 
     @classmethod
-    def _stripe_object_to_customer(cls, target_cls, data):
+    def _stripe_object_to_customer(cls, target_cls, data, current_ids=None):
         """
         Search the given manager for the Customer matching this object's
         ``customer`` field.
@@ -639,10 +641,13 @@ class StripeModel(models.Model):
         :type target_cls: Customer
         :param data: stripe object
         :type data: dict
+        :param current_ids: stripe ids of objects that are currently being processed
+        :type current_ids: set
         """
 
         if "customer" in data and data["customer"]:
-            return target_cls._get_or_create_from_stripe_object(data, "customer")[0]
+            return target_cls._get_or_create_from_stripe_object(
+                data, "customer", current_ids=current_ids)[0]
 
     @classmethod
     def _stripe_object_to_default_tax_rates(cls, target_cls, data):
@@ -854,7 +859,7 @@ class StripeModel(models.Model):
             record_data = cls._stripe_object_to_record(data)
             for attr, value in record_data.items():
                 setattr(instance, attr, value)
-            instance._attach_objects_hook(cls, data)
+            instance._attach_objects_hook(cls, data, current_ids=current_ids)
             instance.save()
             instance._attach_objects_post_save_hook(cls, data)
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -781,8 +781,8 @@ class UpcomingInvoice(BaseInvoice):
     def get_stripe_dashboard_url(self):
         return ""
 
-    def _attach_objects_hook(self, cls, data):
-        super()._attach_objects_hook(cls, data)
+    def _attach_objects_hook(self, cls, data, current_ids=None):
+        super()._attach_objects_hook(cls, data, current_ids=current_ids)
         self._invoiceitems = cls._stripe_object_to_invoice_items(
             target_cls=InvoiceItem, data=data, invoice=self
         )

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -308,7 +308,7 @@ class Charge(StripeModel):
             self.fraud_details and list(self.fraud_details.values())[0] == "fraudulent"
         )
 
-    def _attach_objects_hook(self, cls, data):
+    def _attach_objects_hook(self, cls, data, current_ids=None):
         from .payment_methods import DjstripePaymentMethod
 
         # Set the account on this object.
@@ -1292,7 +1292,7 @@ class Customer(StripeModel):
         if save:
             self.save()
 
-    def _attach_objects_hook(self, cls, data):
+    def _attach_objects_hook(self, cls, data, current_ids=None):
         # When we save a customer to Stripe, we add a reference to its Django PK
         # in the `django_account` key. If we find that, we re-attach that PK.
         subscriber_key = djstripe_settings.SUBSCRIBER_CUSTOMER_KEY
@@ -1420,7 +1420,7 @@ class Event(StripeModel):
     def str_parts(self):
         return ["type={type}".format(type=self.type)] + super().str_parts()
 
-    def _attach_objects_hook(self, cls, data):
+    def _attach_objects_hook(self, cls, data, current_ids=None):
         if self.api_version is None:
             # as of api version 2017-02-14, the account.application.deauthorized
             # event sends None as api_version.

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -473,8 +473,9 @@ class Source(StripeModel):
         data["source_data"] = data[data["type"]]
         return data
 
-    def _attach_objects_hook(self, cls, data):
-        customer = cls._stripe_object_to_customer(target_cls=Customer, data=data)
+    def _attach_objects_hook(self, cls, data, current_ids=None):
+        customer = cls._stripe_object_to_customer(
+            target_cls=Customer, data=data, current_ids=current_ids)
         if customer:
             self.customer = customer
         else:
@@ -542,8 +543,11 @@ class PaymentMethod(StripeModel):
 
     stripe_class = stripe.PaymentMethod
 
-    def _attach_objects_hook(self, cls, data):
-        customer = cls._stripe_object_to_customer(target_cls=Customer, data=data)
+    def _attach_objects_hook(self, cls, data, current_ids=None):
+        customer = None
+        if current_ids is None or data.get("customer") not in current_ids:
+            customer = cls._stripe_object_to_customer(target_cls=Customer, data=data, current_ids=current_ids)
+
         if customer:
             self.customer = customer
         else:

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -546,7 +546,8 @@ class PaymentMethod(StripeModel):
     def _attach_objects_hook(self, cls, data, current_ids=None):
         customer = None
         if current_ids is None or data.get("customer") not in current_ids:
-            customer = cls._stripe_object_to_customer(target_cls=Customer, data=data, current_ids=current_ids)
+            customer = cls._stripe_object_to_customer(
+                target_cls=Customer, data=data, current_ids=current_ids)
 
         if customer:
             self.customer = customer

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -475,7 +475,8 @@ class Source(StripeModel):
 
     def _attach_objects_hook(self, cls, data, current_ids=None):
         customer = cls._stripe_object_to_customer(
-            target_cls=Customer, data=data, current_ids=current_ids)
+            target_cls=Customer, data=data, current_ids=current_ids
+        )
         if customer:
             self.customer = customer
         else:
@@ -547,7 +548,8 @@ class PaymentMethod(StripeModel):
         customer = None
         if current_ids is None or data.get("customer") not in current_ids:
             customer = cls._stripe_object_to_customer(
-                target_cls=Customer, data=data, current_ids=current_ids)
+                target_cls=Customer, data=data, current_ids=current_ids
+            )
 
         if customer:
             self.customer = customer

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -316,19 +316,22 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         )
 
     @patch("stripe.Customer.retrieve", autospec=True)
-    @patch("stripe.PaymentMethod.retrieve", return_value=deepcopy(FAKE_PAYMENT_METHOD_I))
+    @patch(
+        "stripe.PaymentMethod.retrieve", return_value=deepcopy(FAKE_PAYMENT_METHOD_I)
+    )
     def test_customer_sync_default_payment_method_string(
         self, attach_mock, customer_retrieve_mock
     ):
         Customer.objects.all().delete()
         PaymentMethod.objects.all().delete()
         customer_fake = deepcopy(FAKE_CUSTOMER)
-        customer_fake["invoice_settings"]["default_payment_method"] = FAKE_PAYMENT_METHOD_I["id"]
+        customer_fake["invoice_settings"]["default_payment_method"] = (
+            FAKE_PAYMENT_METHOD_I["id"])
         customer_retrieve_mock.return_value = customer_fake
 
         customer = Customer.sync_from_stripe_data(customer_fake)
         self.assertEqual(customer.default_payment_method.id,
-            customer_fake["invoice_settings"]["default_payment_method"])
+                         customer_fake["invoice_settings"]["default_payment_method"])
         self.assertEqual(customer.payment_methods.count(), 1)
 
         self.assert_fks(

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -325,13 +325,16 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         Customer.objects.all().delete()
         PaymentMethod.objects.all().delete()
         customer_fake = deepcopy(FAKE_CUSTOMER)
-        customer_fake["invoice_settings"]["default_payment_method"] = (
-            FAKE_PAYMENT_METHOD_I["id"])
+        customer_fake["invoice_settings"][
+            "default_payment_method"
+        ] = FAKE_PAYMENT_METHOD_I["id"]
         customer_retrieve_mock.return_value = customer_fake
 
         customer = Customer.sync_from_stripe_data(customer_fake)
-        self.assertEqual(customer.default_payment_method.id,
-                         customer_fake["invoice_settings"]["default_payment_method"])
+        self.assertEqual(
+            customer.default_payment_method.id,
+            customer_fake["invoice_settings"]["default_payment_method"],
+        )
         self.assertEqual(customer.payment_methods.count(), 1)
 
         self.assert_fks(


### PR DESCRIPTION
Syncing customers with default_payment_method not null led to infinite recursion loops.
Here is a simple fix, based on the existing `current_ids` list.

Cheers