### PR TITLE
Properly default the return value of get_list_kwargs when syncing models

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -120,11 +120,16 @@ class Command(BaseCommand):
         :param model:
         :return: Sequence[dict]
         """
-        all_list_kwargs = (
-            [{"expand": [f"data.{k}" for k in model.expand_fields]}]
-            if model.expand_fields
-            else []
-        )
+
+        if model.expand_fields:
+            all_list_kwargs = [
+                {"expand": [f"data.{k}" for k in model.expand_fields]}
+            ]
+        else:
+            # Default to an empty dictionary so that models without fields to expand
+            # are listed
+            all_list_kwargs = [{}]
+
         if model is models.PaymentMethod:
             # special case
             all_list_kwargs.extend(

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         This allows us to sync models that require parameters to api_list
 
         :param model:
-        :return: Sequence[dict]
+        :return: Sequence[Dict[str, List[str]]]
         """
 
         if model.expand_fields:


### PR DESCRIPTION
Previously because this was an empty list nothing would be synced. I don't really know how to test this change, it didn't cause existing tests to fail and I don't see any tests for commands.