### PR TITLE
Fix djstripe_sync_models for classes with arguments already

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -140,7 +140,7 @@ class Command(BaseCommand):
                     for subscription in models.Subscription.api_list()
                 )
             )
-        else:
+        elif not all_list_kwargs:
             all_list_kwargs.append({})
 
         return all_list_kwargs


### PR DESCRIPTION
Syncing Price objects is done twice because

`all_list_kwargs = [{"expand": "data.tiers"}, {}]`

Fixes #1311