### PR TITLE
Mention required DJSTRIPE_FOREIGN_KEY_TO_FIELD in installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,7 @@ Add your Stripe keys and set the operating mode:
     STRIPE_TEST_SECRET_KEY = os.environ.get("STRIPE_TEST_SECRET_KEY", "<your secret key>")
     STRIPE_LIVE_MODE = False  # Change to True in production
     DJSTRIPE_WEBHOOK_SECRET = "whsec_xxx"  # Get it from the section in the Stripe dashboard where you added the webhook endpoint
+    DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
 
 Add some payment plans via the Stripe.com dashboard.
 


### PR DESCRIPTION
I installed dj-stripe for the first time and the setup failed because DJSTRIPE_FOREIGN_KEY_TO_FIELD was missing. When looking at the settings, I discovered that this setting is actually required to operate. The docs recommend the value of `"id"` so that's what I'm listing.