### PR TITLE
Some test fixes

### DIFF
--- a/tests/apps/example/apps.py
+++ b/tests/apps/example/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ExampleConfig(AppConfig):
-    name = "example"

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -10,6 +10,11 @@ from djstripe.models import Account, Customer, StripeModel
 from djstripe.settings import STRIPE_SECRET_KEY
 
 
+class TestStripeModel(StripeModel):
+    # exists to avoid "Abstract models cannot be instantiated." error
+    pass
+
+
 class StripeModelExceptionsTest(TestCase):
     def test_no_object_value(self):
         # Instantiate a stripeobject model class
@@ -41,7 +46,7 @@ def test__api_delete(
     mock_api_retrieve, stripe_account, api_key, expected_api_key, extra_kwargs
 ):
     """Test that API delete properly uses the passed in parameters."""
-    test_model = StripeModel()
+    test_model = TestStripeModel()
     test_model._api_delete(
         api_key=api_key, stripe_account=stripe_account, **extra_kwargs
     )
@@ -67,7 +72,7 @@ def test_api_retrieve(
     mock_stripe_class, stripe_account, api_key, expected_api_key, expand_fields
 ):
     """Test that API delete properly uses the passed in parameters."""
-    test_model = StripeModel()
+    test_model = TestStripeModel()
     mock_id = "id_fakefakefakefake01"
     test_model.id = mock_id
     test_model.expand_fields = expand_fields
@@ -110,7 +115,7 @@ def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
     # Make first return the mock account.
     mock_account_reverse_manager.first.return_value = mock_account
 
-    test_model = StripeModel()
+    test_model = TestStripeModel()
     mock_id = "id_fakefakefakefake01"
     test_model.id = mock_id
     # Set mock reverse manager on the model.


### PR DESCRIPTION
The first commit fixes [this problem](https://github.com/dj-stripe/dj-stripe/issues/1348#issuecomment-834283471) (I don't have a complete story why, but I suspect something about the duplicate `apps` on the path and weird [pytest import stuff](https://stackoverflow.com/questions/41748464/pytest-cannot-import-module-while-python-can).

The second commit fixes some other errors, seemingly related to [this change](https://github.com/django/django/commit/c7e7f176c13b1070c689feb5255c07b524933e12) in django 3.2. I considered trying to fix it with mocks, but this seemed easier and maybe more future-proof? :man_shrugging: 

There is still one test failure on my env (see below) but the level of wizardy in mocking was beyond the time I had available to figure it out. I suspect is somehow related to swapping out the `TestStripeModel` class, but messed around for a bit and couldn't figure out a way to make it work.

```
E           AssertionError: expected call not found.
E           Expected: retrieve(id='id_fakefakefakefake01', api_key='sk_fakefakefakefake01', stripe_account=<MagicMock name='mock.first().id' id='140196009740656'>, expand=[])
E           Actual: retrieve(id='id_fakefakefakefake01', api_key='sk_fakefakefakefake01', expand=[], stripe_account=None)
```

