### PR TITLE
set default_auto_field at the app level to avoid unnecessary migrations

### DIFF
--- a/djstripe/__init__.py
+++ b/djstripe/__init__.py
@@ -16,6 +16,7 @@ class DjstripeAppConfig(AppConfig):
     """
 
     name = "djstripe"
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         import stripe


### PR DESCRIPTION
This should address https://github.com/dj-stripe/dj-stripe/issues/1344, by overriding the default at the app level as [per the release notes](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys). I ran `makemigrations` on a local project and confirmed the `alter field id` migrations were no longer created.

However, even then `makemigrations` still generated a migration off of master, to "Remove field djstripe_owner_account from countryspec". I'm a bit unclear how migrations and releases are meant to work on this project. Should I also submit this PR to a branch forked off the latest 2.4 release?

@jleclanche 
