### PR TITLE
Fix defalut value error for TextField

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -81,7 +81,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -308,7 +308,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -429,7 +429,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -476,7 +476,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "failure_message",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         help_text="Message to user further explaining reason for charge failure if available.",
                         null=True,
                     ),
@@ -643,7 +643,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -760,7 +760,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -813,7 +813,7 @@ class Migration(migrations.Migration):
                         null=True,
                     ),
                 ),
-                ("email", models.TextField(null=True)),
+                ("email", djstripe.fields.TextField(null=True)),
                 (
                     "shipping",
                     djstripe.fields.JSONField(
@@ -871,7 +871,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -959,7 +959,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -988,7 +988,7 @@ class Migration(migrations.Migration):
                         null=True,
                     ),
                 ),
-                ("idempotency_key", models.TextField(blank=True, null=True)),
+                ("idempotency_key", djstripe.fields.TextField(blank=True, null=True)),
                 (
                     "type",
                     models.CharField(
@@ -1035,7 +1035,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1117,7 +1117,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1425,7 +1425,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1463,7 +1463,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "failure_message",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Message to user further explaining reason for payout failure if available.",
                         null=True,
@@ -1550,7 +1550,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1659,7 +1659,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "name",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Name of the plan, to be displayed on invoices and in the web interface.",
                         null=True,
@@ -1714,7 +1714,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1850,7 +1850,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -1953,7 +1953,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -2113,7 +2113,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -2302,7 +2302,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -2407,7 +2407,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "failure_message",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Message to user further explaining reason for transfer failure if available.",
                         null=True,
@@ -2452,7 +2452,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("headers", djstripe.fields.JSONField()),
-                ("body", models.TextField(blank=True)),
+                ("body", djstripe.fields.TextField(blank=True)),
                 (
                     "valid",
                     models.BooleanField(
@@ -2470,7 +2470,7 @@ class Migration(migrations.Migration):
                 ("exception", models.CharField(blank=True, max_length=128)),
                 (
                     "traceback",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Traceback if an exception was thrown during processing",
                     ),
@@ -2564,7 +2564,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -2825,7 +2825,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -2833,15 +2833,15 @@ class Migration(migrations.Migration):
                 ("djstripe_updated", models.DateTimeField(auto_now=True)),
                 (
                     "address_city",
-                    models.TextField(help_text="Billing address city.", null=True),
+                    djstripe.fields.TextField(help_text="Billing address city.", null=True),
                 ),
                 (
                     "address_country",
-                    models.TextField(help_text="Billing address country.", null=True),
+                    djstripe.fields.TextField(help_text="Billing address country.", null=True),
                 ),
                 (
                     "address_line1",
-                    models.TextField(help_text="Billing address (Line 1).", null=True),
+                    djstripe.fields.TextField(help_text="Billing address (Line 1).", null=True),
                 ),
                 (
                     "address_line1_check",
@@ -2854,15 +2854,15 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "address_line2",
-                    models.TextField(help_text="Billing address (Line 2).", null=True),
+                    djstripe.fields.TextField(help_text="Billing address (Line 2).", null=True),
                 ),
                 (
                     "address_state",
-                    models.TextField(help_text="Billing address state.", null=True),
+                    djstripe.fields.TextField(help_text="Billing address state.", null=True),
                 ),
                 (
                     "address_zip",
-                    models.TextField(help_text="Billing address zip code.", null=True),
+                    djstripe.fields.TextField(help_text="Billing address zip code.", null=True),
                 ),
                 (
                     "address_zip_check",
@@ -2910,7 +2910,7 @@ class Migration(migrations.Migration):
                 ("exp_year", models.IntegerField(help_text="Card expiration year.")),
                 (
                     "fingerprint",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Uniquely identifies this particular card number.",
                         null=True,
@@ -2930,7 +2930,7 @@ class Migration(migrations.Migration):
                         help_text="Last four digits of Card number.", max_length=4
                     ),
                 ),
-                ("name", models.TextField(help_text="Cardholder name.", null=True)),
+                ("name", djstripe.fields.TextField(help_text="Cardholder name.", null=True)),
                 (
                     "tokenization_method",
                     djstripe.fields.StripeEnumField(
@@ -3052,7 +3052,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="coupon",
             name="name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Name of the coupon displayed to customers on for instance invoices or receipts.",
@@ -3279,7 +3279,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3375,7 +3375,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3403,7 +3403,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "sql",
-                    models.TextField(help_text="SQL for the query.", max_length=5000),
+                    djstripe.fields.TextField(help_text="SQL for the query.", max_length=5000),
                 ),
                 (
                     "status",
@@ -3415,7 +3415,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "title",
-                    models.TextField(help_text="Title of the query.", max_length=5000),
+                    djstripe.fields.TextField(help_text="Title of the query.", max_length=5000),
                 ),
                 (
                     "file",
@@ -3471,7 +3471,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3545,7 +3545,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3628,7 +3628,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3693,7 +3693,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -3969,7 +3969,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="bankaccount",
             name="account_holder_name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The name of the person or business that owns the bank account.",
@@ -3979,7 +3979,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_city",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="City/District/Suburb/Town/Village.",
@@ -3989,7 +3989,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_country",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Billing address country.",
@@ -3999,7 +3999,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_line1",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Street address/PO Box/Company name.",
@@ -4020,7 +4020,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_line2",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Apartment/Suite/Unit/Building.",
@@ -4030,7 +4030,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_state",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="State/County/Province/Region.",
@@ -4040,7 +4040,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="address_zip",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True, default="", help_text="ZIP or postal code.", max_length=5000
             ),
         ),
@@ -4099,7 +4099,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="card",
             name="name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True, default="", help_text="Cardholder name.", max_length=5000
             ),
         ),
@@ -4128,7 +4128,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="charge",
             name="failure_message",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Message to user further explaining reason for charge failure if available.",
@@ -4138,7 +4138,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="charge",
             name="receipt_email",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The email address that the receipt for this charge was sent to.",
@@ -4197,12 +4197,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="customer",
             name="email",
-            field=models.TextField(blank=True, default="", max_length=5000),
+            field=djstripe.fields.TextField(blank=True, default="", max_length=5000),
         ),
         migrations.AlterField(
             model_name="event",
             name="idempotency_key",
-            field=models.TextField(blank=True, default=""),
+            field=djstripe.fields.TextField(blank=True, default=""),
         ),
         migrations.AlterField(
             model_name="event",
@@ -4217,7 +4217,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="invoice",
             name="hosted_invoice_url",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The URL for the hosted invoice page, which allows customers to view and pay an invoice. If the invoice has not been frozen yet, this will be null.",
@@ -4227,7 +4227,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="invoice",
             name="invoice_pdf",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The link to download the PDF for the invoice. If the invoice has not been frozen yet, this will be null.",
@@ -4268,7 +4268,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="payout",
             name="failure_message",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="Message to user further explaining reason for payout failure if available.",
@@ -4309,7 +4309,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="plan",
             name="nickname",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="A brief description of the plan, hidden from customers.",
@@ -4319,7 +4319,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="product",
             name="caption",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="A short one-line description of the product, meant to be displayableto the customer. Only applicable to products of `type=good`.",
@@ -4406,7 +4406,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="product",
             name="name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 help_text="The product's name, meant to be displayable to the customer. Applicable to both `service` and `good` types.",
                 max_length=5000,
             ),
@@ -4615,7 +4615,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -4715,7 +4715,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -4740,7 +4740,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "client_secret",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.",
                         max_length=5000,
@@ -4907,7 +4907,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "client_secret",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         help_text="The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key.",
                         max_length=5000,
                     ),
@@ -4928,7 +4928,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         default="",
                         help_text="An arbitrary string attached to the object. Often useful for displaying to users.",
@@ -5117,7 +5117,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="customer",
             name="name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The customer's full name or business name.",
@@ -5127,7 +5127,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="customer",
             name="phone",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="The customer's phone number.",
@@ -5225,7 +5225,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="charge",
             name="receipt_url",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 default="",
                 help_text="This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the latest state of the charge, including any refunds. If the charge is for an Invoice, the receipt will be stylized as an Invoice receipt.",
@@ -5269,7 +5269,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -5286,7 +5286,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "cancel_url",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The URL the customer will be directed to if theydecide to cancel payment and return to your website.",
                         max_length=5000,
@@ -5294,7 +5294,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "client_reference_id",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="A unique string to reference the Checkout Session.This can be a customer ID, a cart ID, or similar, andcan be used to reconcile the session with your internal systems.",
                         max_length=5000,
@@ -5341,7 +5341,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "success_url",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The URL the customer will be directed to after the payment or subscriptioncreation is successful.",
                         max_length=5000,

--- a/djstripe/migrations/0005_2_2.py
+++ b/djstripe/migrations/0005_2_2.py
@@ -92,7 +92,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="invoice",
             name="account_name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="The public name of the business associated with this invoice, most often the business creating the invoice.",
                 max_length=5000,
@@ -121,7 +121,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="invoice",
             name="customer_email",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="The customer’s email. Until the invoice is finalized, this field will equal customer.email. Once the invoice is finalized, this field will no longer be updated.",
                 max_length=5000,
@@ -130,7 +130,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="invoice",
             name="customer_name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="The customer’s name. Until the invoice is finalized, this field will equal customer.name. Once the invoice is finalized, this field will no longer be updated.",
                 max_length=5000,
@@ -139,7 +139,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="invoice",
             name="customer_phone",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="The customer’s phone number. Until the invoice is finalized, this field will equal customer.phone. Once the invoice is finalized, this field will no longer be updated.",
                 max_length=5000,
@@ -180,7 +180,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="invoice",
             name="footer",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="Footer displayed on the invoice.",
                 max_length=5000,
@@ -429,7 +429,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -446,7 +446,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "account_name",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The public name of the business associated with this invoice, most often the business creating the invoice.",
                         max_length=5000,
@@ -551,7 +551,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "customer_email",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The customer’s email. Until the invoice is finalized, this field will equal customer.email. Once the invoice is finalized, this field will no longer be updated.",
                         max_length=5000,
@@ -559,7 +559,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "customer_name",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The customer’s name. Until the invoice is finalized, this field will equal customer.name. Once the invoice is finalized, this field will no longer be updated.",
                         max_length=5000,
@@ -567,7 +567,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "customer_phone",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="The customer’s phone number. Until the invoice is finalized, this field will equal customer.phone. Once the invoice is finalized, this field will no longer be updated.",
                         max_length=5000,
@@ -607,7 +607,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "footer",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         help_text="Footer displayed on the invoice.",
                         max_length=5000,
@@ -623,7 +623,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "hosted_invoice_url",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         default="",
                         help_text="The URL for the hosted invoice page, which allows customers to view and pay an invoice. If the invoice has not been frozen yet, this will be null.",
@@ -632,7 +632,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "invoice_pdf",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True,
                         default="",
                         help_text="The link to download the PDF for the invoice. If the invoice has not been frozen yet, this will be null.",
@@ -874,7 +874,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),

--- a/djstripe/migrations/0007_2_4.py
+++ b/djstripe/migrations/0007_2_4.py
@@ -494,7 +494,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="bankaccount",
             name="account_holder_name",
-            field=models.TextField(
+            field=djstripe.fields.TextField(
                 blank=True,
                 help_text="The name of the person or business that owns the bank account.",
                 max_length=5000,
@@ -537,7 +537,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
@@ -849,7 +849,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "description",
-                    models.TextField(
+                    djstripe.fields.TextField(
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -12,7 +12,7 @@ from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.error import InvalidRequestError
 
 from .. import settings as djstripe_settings
-from ..fields import JSONField, StripeDateTimeField, StripeForeignKey, StripeIdField
+from ..fields import JSONField, StripeDateTimeField, StripeForeignKey, StripeIdField, TextField
 from ..managers import StripeModelManager
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class StripeModel(StripeBaseModel):
         "It can be useful for storing additional information about an object in "
         "a structured format.",
     )
-    description = models.TextField(
+    description = TextField(
         null=True, blank=True, help_text="A description of this object."
     )
 
@@ -324,7 +324,7 @@ class StripeModel(StripeBaseModel):
                     field_data = manipulated_data.get(field.name)
 
                 if (
-                    isinstance(field, (models.CharField, models.TextField))
+                    isinstance(field, (models.CharField, TextField))
                     and field_data is None
                 ):
                     # TODO - this applies to StripeEnumField as well, since it

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -21,6 +21,7 @@ from ..fields import (
     StripeIdField,
     StripePercentField,
     StripeQuantumCurrencyAmountField,
+    TextField,
 )
 from ..managers import SubscriptionManager
 from ..utils import QuerySetMock, get_friendly_currency_amount
@@ -111,7 +112,7 @@ class Coupon(StripeModel):
         help_text="Maximum number of times this coupon can be redeemed, in total, "
         "before it is no longer valid.",
     )
-    name = models.TextField(
+    name = TextField(
         max_length=5000,
         default="",
         blank=True,
@@ -198,7 +199,7 @@ class BaseInvoice(StripeModel):
         help_text="The country of the business associated with this invoice, "
         "most often the business creating the invoice.",
     )
-    account_name = models.TextField(
+    account_name = TextField(
         max_length=5000,
         blank=True,
         help_text="The public name of the business associated with this invoice, "
@@ -300,21 +301,21 @@ class BaseInvoice(StripeModel):
         "field will equal customer.address. Once the invoice is finalized, this field "
         "will no longer be updated.",
     )
-    customer_email = models.TextField(
+    customer_email = TextField(
         max_length=5000,
         blank=True,
         help_text="The customer’s email. Until the invoice is finalized, this field "
         "will equal customer.email. Once the invoice is finalized, this field will no "
         "longer be updated.",
     )
-    customer_name = models.TextField(
+    customer_name = TextField(
         max_length=5000,
         blank=True,
         help_text="The customer’s name. Until the invoice is finalized, this field "
         "will equal customer.name. Once the invoice is finalized, this field will no "
         "longer be updated.",
     )
-    customer_phone = models.TextField(
+    customer_phone = TextField(
         max_length=5000,
         blank=True,
         help_text="The customer’s phone number. Until the invoice is finalized, "
@@ -368,10 +369,10 @@ class BaseInvoice(StripeModel):
         help_text="Ending customer balance (in cents) after attempting to pay invoice. "
         "If the invoice has not been attempted yet, this will be null.",
     )
-    footer = models.TextField(
+    footer = TextField(
         max_length=5000, blank=True, help_text="Footer displayed on the invoice."
     )
-    hosted_invoice_url = models.TextField(
+    hosted_invoice_url = TextField(
         max_length=799,
         default="",
         blank=True,
@@ -379,7 +380,7 @@ class BaseInvoice(StripeModel):
         "and pay an invoice. If the invoice has not been frozen yet, "
         "this will be null.",
     )
-    invoice_pdf = models.TextField(
+    invoice_pdf = TextField(
         max_length=799,
         default="",
         blank=True,
@@ -1093,7 +1094,7 @@ class Plan(StripeModel):
             "between each subscription billing."
         ),
     )
-    nickname = models.TextField(
+    nickname = TextField(
         max_length=5000,
         default="",
         blank=True,

--- a/djstripe/models/checkout.py
+++ b/djstripe/models/checkout.py
@@ -2,7 +2,7 @@ import stripe
 from django.db import models
 
 from .. import enums
-from ..fields import JSONField, StripeEnumField, StripeForeignKey
+from ..fields import JSONField, StripeEnumField, StripeForeignKey, TextField
 from .base import StripeModel
 
 
@@ -22,7 +22,7 @@ class Session(StripeModel):
             "collected the customer’s billing address."
         ),
     )
-    cancel_url = models.TextField(
+    cancel_url = TextField(
         max_length=5000,
         blank=True,
         help_text=(
@@ -30,7 +30,7 @@ class Session(StripeModel):
             "decide to cancel payment and return to your website."
         ),
     )
-    client_reference_id = models.TextField(
+    client_reference_id = TextField(
         max_length=5000,
         blank=True,
         help_text=(
@@ -93,7 +93,7 @@ class Session(StripeModel):
         on_delete=models.SET_NULL,
         help_text=("Subscription created if one or more plans were provided."),
     )
-    success_url = models.TextField(
+    success_url = TextField(
         max_length=5000,
         blank=True,
         help_text=(

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -25,6 +25,7 @@ from ..fields import (
     StripeForeignKey,
     StripeIdField,
     StripeQuantumCurrencyAmountField,
+    TextField
 )
 from ..managers import ChargeManager
 from ..signals import WEBHOOK_SIGNALS
@@ -183,7 +184,7 @@ class Charge(StripeModel):
         blank=True,
         help_text="Error code explaining reason for charge failure if available.",
     )
-    failure_message = models.TextField(
+    failure_message = TextField(
         max_length=5000,
         default="",
         blank=True,
@@ -240,7 +241,7 @@ class Charge(StripeModel):
         null=True,
         blank=True,
     )
-    receipt_email = models.TextField(
+    receipt_email = TextField(
         max_length=800,  # yup, 800.
         default="",
         blank=True,
@@ -253,7 +254,7 @@ class Charge(StripeModel):
         help_text="The transaction number that appears "
         "on email receipts sent for this charge.",
     )
-    receipt_url = models.TextField(
+    receipt_url = TextField(
         max_length=5000,
         default="",
         blank=True,
@@ -449,7 +450,7 @@ class Product(StripeModel):
     stripe_dashboard_item_name = "products"
 
     # Fields applicable to both `good` and `service`
-    name = models.TextField(
+    name = TextField(
         max_length=5000,
         help_text=(
             "The product's name, meant to be displayable to the customer. "
@@ -481,7 +482,7 @@ class Product(StripeModel):
             '(e.g., `["color", "size"]`). Only applicable to products of `type=good`.'
         ),
     )
-    caption = models.TextField(
+    caption = TextField(
         default="",
         blank=True,
         max_length=5000,
@@ -608,7 +609,7 @@ class Customer(StripeModel):
         "the date that the discount will end.",
     )
     # </discount>
-    email = models.TextField(max_length=5000, default="", blank=True)
+    email = TextField(max_length=5000, default="", blank=True)
     invoice_prefix = models.CharField(
         default="",
         blank=True,
@@ -631,13 +632,13 @@ class Customer(StripeModel):
         help_text="default payment method used for subscriptions and invoices "
         "for the customer.",
     )
-    name = models.TextField(
+    name = TextField(
         max_length=5000,
         default="",
         blank=True,
         help_text="The customer's full name or business name.",
     )
-    phone = models.TextField(
+    phone = TextField(
         max_length=5000,
         default="",
         blank=True,
@@ -1346,7 +1347,7 @@ class Event(StripeModel):
         default="",
         blank=True,
     )
-    idempotency_key = models.TextField(default="", blank=True)
+    idempotency_key = TextField(default="", blank=True)
     type = models.CharField(max_length=250, help_text="Stripe's event description code")
 
     def str_parts(self):
@@ -1506,7 +1507,7 @@ class PaymentIntent(StripeModel):
         enum=enums.CaptureMethod,
         help_text="Capture method of this PaymentIntent, one of automatic or manual.",
     )
-    client_secret = models.TextField(
+    client_secret = TextField(
         max_length=5000,
         help_text=(
             "The client secret of this PaymentIntent. "
@@ -1526,7 +1527,7 @@ class PaymentIntent(StripeModel):
         on_delete=models.CASCADE,
         help_text="Customer this PaymentIntent is for if one exists.",
     )
-    description = models.TextField(
+    description = TextField(
         max_length=1000,
         default="",
         blank=True,
@@ -1708,7 +1709,7 @@ class SetupIntent(StripeModel):
             "requested_by_customer, or duplicate"
         ),
     )
-    client_secret = models.TextField(
+    client_secret = TextField(
         max_length=5000,
         blank=True,
         help_text=(
@@ -1837,7 +1838,7 @@ class Payout(StripeModel):
             "See https://stripe.com/docs/api/python#transfer_failures."
         ),
     )
-    failure_message = models.TextField(
+    failure_message = TextField(
         default="",
         blank=True,
         help_text=(

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -13,6 +13,7 @@ from ..fields import (
     StripeDecimalCurrencyAmountField,
     StripeEnumField,
     StripeForeignKey,
+    TextField,
 )
 from .base import StripeModel, logger
 from .core import Customer
@@ -185,7 +186,7 @@ class BankAccount(LegacySourceMixin, StripeModel):
         help_text="The account the charge was made on behalf of. Null here indicates "
         "that this value was never set.",
     )
-    account_holder_name = models.TextField(
+    account_holder_name = TextField(
         max_length=5000,
         blank=True,
         help_text="The name of the person or business that owns the bank account.",
@@ -252,16 +253,16 @@ class Card(LegacySourceMixin, StripeModel):
 
     stripe_class = stripe.Card
 
-    address_city = models.TextField(
+    address_city = TextField(
         max_length=5000,
         blank=True,
         default="",
         help_text="City/District/Suburb/Town/Village.",
     )
-    address_country = models.TextField(
+    address_country = TextField(
         max_length=5000, blank=True, default="", help_text="Billing address country."
     )
-    address_line1 = models.TextField(
+    address_line1 = TextField(
         max_length=5000,
         blank=True,
         default="",
@@ -273,19 +274,19 @@ class Card(LegacySourceMixin, StripeModel):
         default="",
         help_text="If `address_line1` was provided, results of the check.",
     )
-    address_line2 = models.TextField(
+    address_line2 = TextField(
         max_length=5000,
         blank=True,
         default="",
         help_text="Apartment/Suite/Unit/Building.",
     )
-    address_state = models.TextField(
+    address_state = TextField(
         max_length=5000,
         blank=True,
         default="",
         help_text="State/County/Province/Region.",
     )
-    address_zip = models.TextField(
+    address_zip = TextField(
         max_length=5000, blank=True, default="", help_text="ZIP or postal code."
     )
     address_zip_check = StripeEnumField(
@@ -329,7 +330,7 @@ class Card(LegacySourceMixin, StripeModel):
         enum=enums.CardFundingType, help_text="Card funding type."
     )
     last4 = models.CharField(max_length=4, help_text="Last four digits of Card number.")
-    name = models.TextField(
+    name = TextField(
         max_length=5000, default="", blank=True, help_text="Cardholder name."
     )
     tokenization_method = StripeEnumField(

--- a/djstripe/models/sigma.py
+++ b/djstripe/models/sigma.py
@@ -2,7 +2,13 @@ import stripe
 from django.db import models
 
 from .. import enums
-from ..fields import JSONField, StripeDateTimeField, StripeEnumField, StripeForeignKey
+from ..fields import (
+    JSONField,
+    StripeDateTimeField,
+    StripeEnumField,
+    StripeForeignKey,
+    TextField,
+)
 from .base import StripeModel
 
 
@@ -34,8 +40,8 @@ class ScheduledQueryRun(StripeModel):
         help_text="Time at which the result expires and is no longer available "
         "for download."
     )
-    sql = models.TextField(max_length=5000, help_text="SQL for the query.")
+    sql = TextField(max_length=5000, help_text="SQL for the query.")
     status = StripeEnumField(
         enum=enums.ScheduledQueryRunStatus, help_text="The query's execution status."
     )
-    title = models.TextField(max_length=5000, help_text="Title of the query.")
+    title = TextField(max_length=5000, help_text="Title of the query.")

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -9,7 +9,7 @@ from django.utils.functional import cached_property
 
 from .. import settings as djstripe_settings
 from ..context_managers import stripe_temporary_api_version
-from ..fields import JSONField, StripeForeignKey
+from ..fields import JSONField, StripeForeignKey, TextField
 from ..signals import webhook_processing_error
 from .base import logger
 from .core import Event
@@ -36,7 +36,7 @@ class WebhookEventTrigger(models.Model):
         help_text="IP address of the request client."
     )
     headers = JSONField()
-    body = models.TextField(blank=True)
+    body = TextField(blank=True)
     valid = models.BooleanField(
         default=False,
         help_text="Whether or not the webhook event has passed validation",
@@ -46,7 +46,7 @@ class WebhookEventTrigger(models.Model):
         help_text="Whether or not the webhook event has been successfully processed",
     )
     exception = models.CharField(max_length=128, blank=True)
-    traceback = models.TextField(
+    traceback = TextField(
         blank=True, help_text="Traceback if an exception was thrown during processing"
     )
     event = StripeForeignKey(

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -64,6 +64,7 @@ get_idempotency_key = get_callback_function(
 )
 
 USE_NATIVE_JSONFIELD = getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", False)
+USE_NATIVE_TEXTFIELD = getattr(settings, "DJSTRIPE_USE_NATIVE_TEXTFIELD", True)
 
 PRORATION_POLICY = getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)
 CANCELLATION_AT_PERIOD_END = not getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)

--- a/tests/test_textfield.py
+++ b/tests/test_textfield.py
@@ -1,0 +1,46 @@
+"""
+Tests for TextField
+
+Due to their nature messing with subclassing, these tests must be run last.
+"""
+import sys
+from importlib import reload
+from unittest import skipUnless
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from djstripe import fields as fields
+from djstripe import settings as djstripe_settings
+
+from django.db.models import TextField as DjangoTextField, CharField as DjangoCharField
+
+
+@override_settings(DJSTRIPE_USE_NATIVE_TEXTFIELD=False)
+class TestCustomizedTextField(TestCase):
+    def setUp(self):
+        reload(djstripe_settings)
+        reload(fields)
+
+    def test_charfield_inheritance(self):
+        field = fields.TextField(default="")
+        self.assertFalse(isinstance(field, DjangoTextField))
+        self.assertTrue(isinstance(field, DjangoCharField))
+        self.assertEqual(field.max_length, 500)
+
+    def test_textfield_inheritance(self):
+        field = fields.TextField()
+        self.assertTrue(isinstance(field, DjangoTextField))
+        self.assertFalse(isinstance(field, DjangoCharField))
+        self.assertIsNone(field.max_length)
+
+
+@override_settings(DJSTRIPE_USE_NATIVE_TEXTFIELD=True)
+class TestNativeTextField(TestCase):
+    def setUp(self):
+        reload(djstripe_settings)
+        reload(fields)
+
+    def test_textfield_inheritance(self):
+        self.assertEqual(fields.TextField, DjangoTextField)
+        self.assertFalse(issubclass(fields.TextField, DjangoCharField))


### PR DESCRIPTION
Fix #1255 #1340
Due to MySQL 8 doesn't support default value for BLOB, TEXT, GEOMETRY or JSON column, here we have to use `CharField` instead of `TextField` if default value was set.
This was controlled by settings `DJSTRIPE_USE_NATIVE_TEXTFIELD`.
Ideally the `max_length` should be 5000, but some tables would exceed the maximum size of fields, so I just set 500 as `max_length`.