### PR TITLE
Fixed the failing stripe model test test_api_retrieve_reverse_foreign_key_lookup

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -632,7 +632,7 @@ class BaseInvoice(StripeModel):
         )
 
     def retry(self):
-        """ Retry payment on this invoice if it isn't paid or uncollectible."""
+        """Retry payment on this invoice if it isn't paid or uncollectible."""
 
         if (
             self.status != enums.InvoiceStatus.paid
@@ -1158,7 +1158,7 @@ class Plan(StripeModel):
 
     @classmethod
     def get_or_create(cls, **kwargs):
-        """ Get or create a Plan."""
+        """Get or create a Plan."""
 
         try:
             return Plan.objects.get(id=kwargs["id"]), False

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1035,7 +1035,7 @@ class Customer(StripeModel):
         self.save()
 
     def _get_valid_subscriptions(self):
-        """ Get a list of this customer's valid subscriptions."""
+        """Get a list of this customer's valid subscriptions."""
 
         return [
             subscription
@@ -1142,7 +1142,7 @@ class Customer(StripeModel):
             return False  # There was nothing to invoice
 
     def retry_unpaid_invoices(self):
-        """ Attempt to retry collecting payment on the customer's unpaid invoices."""
+        """Attempt to retry collecting payment on the customer's unpaid invoices."""
 
         self._sync_invoices()
         for invoice in self.invoices.filter(auto_advance=True).exclude(status="paid"):
@@ -1153,7 +1153,7 @@ class Customer(StripeModel):
                     raise
 
     def has_valid_source(self):
-        """ Check whether the customer has a valid payment source."""
+        """Check whether the customer has a valid payment source."""
         return self.default_source is not None
 
     def add_coupon(self, coupon, idempotency_key=None):
@@ -1400,17 +1400,17 @@ class Event(StripeModel):
 
     @cached_property
     def parts(self):
-        """ Gets the event category/verb as a list of parts. """
+        """Gets the event category/verb as a list of parts."""
         return str(self.type).split(".")
 
     @cached_property
     def category(self):
-        """ Gets the event category string (e.g. 'customer'). """
+        """Gets the event category string (e.g. 'customer')."""
         return self.parts[0]
 
     @cached_property
     def verb(self):
-        """ Gets the event past-tense verb string (e.g. 'updated'). """
+        """Gets the event past-tense verb string (e.g. 'updated')."""
         return ".".join(self.parts[1:])
 
     @property
@@ -2012,7 +2012,7 @@ class Price(StripeModel):
 
     @classmethod
     def get_or_create(cls, **kwargs):
-        """ Get or create a Price."""
+        """Get or create a Price."""
 
         try:
             return Price.objects.get(id=kwargs["id"]), False

--- a/tests/apps/testapp/models.py
+++ b/tests/apps/testapp/models.py
@@ -3,13 +3,13 @@ from django.db.models.fields import CharField, EmailField
 
 
 class Organization(Model):
-    """ Model used to test the new custom model setting."""
+    """Model used to test the new custom model setting."""
 
     email = EmailField()
 
 
 class StaticEmailOrganization(Model):
-    """ Model used to test the new custom model setting."""
+    """Model used to test the new custom model setting."""
 
     name = CharField(max_length=200, unique=True)
 
@@ -19,6 +19,6 @@ class StaticEmailOrganization(Model):
 
 
 class NoEmailOrganization(Model):
-    """ Model used to test the new custom model setting."""
+    """Model used to test the new custom model setting."""
 
     name = CharField(max_length=200, unique=True)

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -86,62 +86,6 @@ def test_api_retrieve(
     )
 
 
-# # ! Approach # 1
-# @patch.object(target=StripeModel, attribute="_meta", autospec=True)
-# @patch.object(target=StripeModel, attribute="stripe_class")
-# def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
-#     """Test that the reverse foreign key lookup finds the correct fields."""
-#     # Set up some mock fields that shouldn't be used for reverse lookups
-#     mock_field_1 = MagicMock()
-#     mock_field_1.is_relation = False
-#     mock_field_2 = MagicMock()
-#     mock_field_2.is_relation = True
-#     mock_field_2.one_to_many = False
-#     # Set up a mock reverse foreign key field
-#     mock_reverse_foreign_key = MagicMock()
-#     mock_reverse_foreign_key.is_relation = True
-#     mock_reverse_foreign_key.one_to_many = True
-#     mock_reverse_foreign_key.related_model = Account
-#     mock_reverse_foreign_key.get_accessor_name.return_value="foo_account_reverse_attr"
-#     # Set the mocked _meta.get_fields to return some mock fields, including the mock
-#     # reverse foreign key above.
-#     mock__meta.get_fields.return_value = (
-#         mock_field_1,
-#         mock_field_2,
-#         mock_reverse_foreign_key,
-#     )
-#     # Set up a mock account for the reverse foreign key query to return.
-#     mock_account = MagicMock()
-#     mock_account_reverse_manager = MagicMock()
-#     # Make first return the mock account.
-#     mock_account_reverse_manager.first.return_value = mock_account
-
-#     test_model = TestStripeModel()
-#     mock_id = "id_fakefakefakefake01"
-#     test_model.id = mock_id
-#     # Set mock reverse manager on the model.
-#     test_model.foo_account_reverse_attr = mock_account_reverse_manager
-
-#     # Set the _meta attrbute to the mocked meta
-#     # Abstract Parent Class' _meta attribute is not inherited by non-abstract child
-#     # classes.
-#     # Non-abstract Child classes inherit their Parent's Meta and use that to create
-#     # a new _meta attr.
-#     test_model._meta = mock__meta
-
-#     # Call the function with API key set because we mocked _meta
-#     mock_api_key = "sk_fakefakefakefake01"
-#     test_model.api_retrieve(api_key=mock_api_key)
-
-#     # Expect the retrieve to be done with the reverse look up of the Account ID.
-#     mock_stripe_class.retrieve.assert_called_once_with(
-#         id=mock_id, api_key=mock_api_key, stripe_account=mock_account.id, expand=[]
-#     )
-#     mock_reverse_foreign_key.get_accessor_name.assert_called_once_with()
-#     mock_account_reverse_manager.first.assert_called_once_with()
-
-
-# ! Approach # 2
 @patch.object(target=StripeModel, attribute="stripe_class")
 def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class):
     """Test that the reverse foreign key lookup finds the correct fields."""

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -86,9 +86,64 @@ def test_api_retrieve(
     )
 
 
-@patch.object(target=StripeModel, attribute="_meta", autospec=True)
+# # ! Approach # 1
+# @patch.object(target=StripeModel, attribute="_meta", autospec=True)
+# @patch.object(target=StripeModel, attribute="stripe_class")
+# def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
+#     """Test that the reverse foreign key lookup finds the correct fields."""
+#     # Set up some mock fields that shouldn't be used for reverse lookups
+#     mock_field_1 = MagicMock()
+#     mock_field_1.is_relation = False
+#     mock_field_2 = MagicMock()
+#     mock_field_2.is_relation = True
+#     mock_field_2.one_to_many = False
+#     # Set up a mock reverse foreign key field
+#     mock_reverse_foreign_key = MagicMock()
+#     mock_reverse_foreign_key.is_relation = True
+#     mock_reverse_foreign_key.one_to_many = True
+#     mock_reverse_foreign_key.related_model = Account
+#     mock_reverse_foreign_key.get_accessor_name.return_value="foo_account_reverse_attr"
+#     # Set the mocked _meta.get_fields to return some mock fields, including the mock
+#     # reverse foreign key above.
+#     mock__meta.get_fields.return_value = (
+#         mock_field_1,
+#         mock_field_2,
+#         mock_reverse_foreign_key,
+#     )
+#     # Set up a mock account for the reverse foreign key query to return.
+#     mock_account = MagicMock()
+#     mock_account_reverse_manager = MagicMock()
+#     # Make first return the mock account.
+#     mock_account_reverse_manager.first.return_value = mock_account
+
+#     test_model = TestStripeModel()
+#     mock_id = "id_fakefakefakefake01"
+#     test_model.id = mock_id
+#     # Set mock reverse manager on the model.
+#     test_model.foo_account_reverse_attr = mock_account_reverse_manager
+
+#     # Set the _meta attrbute to the mocked meta
+#     # Abstract Parent Class' _meta attribute is not inherited by non-abstract child
+#     # classes.
+#     # Non-abstract Child classes inherit their Parent's Meta and use that to create
+#     # a new _meta attr.
+#     test_model._meta = mock__meta
+
+#     # Call the function with API key set because we mocked _meta
+#     mock_api_key = "sk_fakefakefakefake01"
+#     test_model.api_retrieve(api_key=mock_api_key)
+
+#     # Expect the retrieve to be done with the reverse look up of the Account ID.
+#     mock_stripe_class.retrieve.assert_called_once_with(
+#         id=mock_id, api_key=mock_api_key, stripe_account=mock_account.id, expand=[]
+#     )
+#     mock_reverse_foreign_key.get_accessor_name.assert_called_once_with()
+#     mock_account_reverse_manager.first.assert_called_once_with()
+
+
+# ! Approach # 2
 @patch.object(target=StripeModel, attribute="stripe_class")
-def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
+def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class):
     """Test that the reverse foreign key lookup finds the correct fields."""
     # Set up some mock fields that shouldn't be used for reverse lookups
     mock_field_1 = MagicMock()
@@ -102,13 +157,7 @@ def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
     mock_reverse_foreign_key.one_to_many = True
     mock_reverse_foreign_key.related_model = Account
     mock_reverse_foreign_key.get_accessor_name.return_value = "foo_account_reverse_attr"
-    # Set the mocked _meta.get_fields to return some mock fields, including the mock
-    # reverse foreign key above.
-    mock__meta.get_fields.return_value = (
-        mock_field_1,
-        mock_field_2,
-        mock_reverse_foreign_key,
-    )
+
     # Set up a mock account for the reverse foreign key query to return.
     mock_account = MagicMock()
     mock_account_reverse_manager = MagicMock()
@@ -120,6 +169,15 @@ def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class, mock__meta):
     test_model.id = mock_id
     # Set mock reverse manager on the model.
     test_model.foo_account_reverse_attr = mock_account_reverse_manager
+
+    # Set the mocked _meta.get_fields to return some mock fields, including the mock
+    # reverse foreign key above.
+    test_model._meta = MagicMock()
+    test_model._meta.get_fields.return_value = (
+        mock_field_1,
+        mock_field_2,
+        mock_reverse_foreign_key,
+    )
 
     # Call the function with API key set because we mocked _meta
     mock_api_key = "sk_fakefakefakefake01"


### PR DESCRIPTION
The test `test_api_retrieve_reverse_foreign_key_lookup` was failing due to how Django constructs the `_meta` attribute of non-abstract child classes of Abstract Parent classes.

Non-Abstract Child classes do not inherit `_meta` of Abstract parents as it seems was the aim and why I think the Abstract Parent `StripeModel` was being monkeypatched. Non-Abstract Child classes, however, inheir the `Meta` attribute of their Abstract Parents and use that to add an `Options` container as their `_meta` [attribute](https://github.com/django/django/blob/66491f08fe86629fa25977bb3dddda06959f65e7/django/db/models/base.py#L122).

```
meta = attr_meta or getattr(new_class, 'Meta', None)
new_class.add_to_class('_meta', Options(meta, app_label))
```

I have updated the code and added 2 approaches. 

1) Approach # 1 --> Dynamically set the `_meta` of the non-abstract child class `TestStripeModel` --> `Harder to understand due to how _meta of non-abstract child classes is constructed. Commented out.`
2) Approach # 2 --> Directly Mock `_meta.get_fields()` of  the non-abstract child class `TestStripeModel`.  --> `My Preferred approach due to easy to follow code. Uncommented`

PS: Running `black` and `flake8` resulted in 3 other files getting reformatted.