### PR TITLE
Fix testing issues

### DIFF
--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -245,17 +245,13 @@ class LegacySourceMixin:
 
         # try to retrieve by account attribute if retrieval by customer fails.
         if self.account:
-            account = self.account.api_retrieve(
-                api_key=api_key, stripe_account=stripe_account
+            return stripe.Account.retrieve_external_account(
+                self.account.id,
+                self.id,
+                expand=self.expand_fields,
+                stripe_account=stripe_account,
+                api_key=api_key,
             )
-
-            # TODO Handle the case the Stripe Connected Account has no External Accounts populated
-            # if "external_accounts" not in account:
-            #     pass
-
-            # This will retrieve the external_accounts using the bank_account ID where the account resides,
-            # so we don't have to pass `stripe_account`.
-            return account.external_accounts.retrieve(self.id)
 
 
 class BankAccount(LegacySourceMixin, StripeModel):

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -35,6 +35,7 @@ from . import (
     FAKE_BALANCE_TRANSACTION,
     FAKE_CARD,
     FAKE_CARD_AS_PAYMENT_METHOD,
+    FAKE_CARD_III,
     FAKE_CHARGE,
     FAKE_CHARGE_II,
     FAKE_COUPON,
@@ -158,7 +159,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_bank_account_event(
@@ -187,7 +188,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_bank_account_event(
@@ -216,7 +217,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_bank_account_event(
@@ -258,7 +259,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_card_event(
@@ -285,7 +286,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_card_event(
@@ -314,7 +315,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_card_event(
@@ -353,7 +354,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_bank_account_event(
@@ -382,7 +383,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_bank_account_event(
@@ -411,7 +412,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_bank_account_event(
@@ -453,7 +454,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_card_event(
@@ -480,7 +481,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_card_event(
@@ -509,7 +510,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_card_event(
@@ -550,7 +551,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_STANDARD_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_standard_account_updated_event(
@@ -586,7 +587,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_EXPRESS_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_updated_event(
@@ -622,7 +623,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_CUSTOM_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=True,
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_updated_event(
@@ -746,8 +747,16 @@ class TestCustomerEvents(EventTestCase):
             customer.currency, fake_stripe_event["data"]["object"]["currency"]
         )
 
+    @patch(
+        "stripe.Customer.retrieve_source",
+        side_effect=[deepcopy(FAKE_CARD), deepcopy(FAKE_CARD_III)],
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
     @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
-    def test_customer_deleted(self, customer_retrieve_mock):
+    def test_customer_deleted(
+        self, customer_retrieve_source_mock, customer_retrieve_mock
+    ):
+
         FAKE_CUSTOMER.create_for_user(self.user)
         event = self._create_event(FAKE_EVENT_CUSTOMER_CREATED)
         event.invoke_webhook_handlers()
@@ -792,7 +801,14 @@ class TestCustomerEvents(EventTestCase):
 
     @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
     @patch("stripe.Event.retrieve", autospec=True)
-    def test_customer_card_created(self, event_retrieve_mock, customer_retrieve_mock):
+    @patch(
+        "stripe.Customer.retrieve_source",
+        return_value=deepcopy(FAKE_CARD),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test_customer_card_created(
+        self, customer_retrieve_source_mock, event_retrieve_mock, customer_retrieve_mock
+    ):
         fake_stripe_event = deepcopy(FAKE_EVENT_CUSTOMER_SOURCE_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
 


### PR DESCRIPTION
This PR contains the following changes:

1) Retrieving `Stripe Connected Account's BankAccount` and/or `Card` objects in 1 request instead of the older way of first fetching the Connected Account and then fetching its Payout Sources.

1) Updated Corresponding tests

1) Fixes the issues with failing tests in https://github.com/dj-stripe/dj-stripe/pull/1359 as well.