### PR TITLE
Replaced Account.retrieve mock with a mock to directly retrieve the External Account

### DIFF
--- a/tests/test_bank_account.py
+++ b/tests/test_bank_account.py
@@ -57,12 +57,12 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     def test_api_retrieve_by_customer_equals_retrieval_by_account(
-        self, account_retrieve_mock, customer_retrieve_mock
+        self, account_retrieve_external_account_mock, customer_retrieve_mock
     ):
         # deepcopy the BankAccount object
         FAKE_BANK_ACCOUNT_DICT = deepcopy(FAKE_BANK_ACCOUNT_IV)

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -56,8 +56,8 @@ class CardTest(AssertStripeFksMixin, TestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -68,7 +68,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
     def test_api_retrieve_by_customer_equals_retrieval_by_account(
         self,
         customer_retrieve_source_mock,
-        account_retrieve_mock,
+        account_retrieve_external_account_mock,
         customer_retrieve_mock,
     ):
         # deepcopy the CardDict object

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -33,9 +33,11 @@ from djstripe.models.payment_methods import BankAccount
 from . import (
     FAKE_ACCOUNT,
     FAKE_BALANCE_TRANSACTION,
+    FAKE_BANK_ACCOUNT_IV,
     FAKE_CARD,
     FAKE_CARD_AS_PAYMENT_METHOD,
     FAKE_CARD_III,
+    FAKE_CARD_IV,
     FAKE_CHARGE,
     FAKE_CHARGE_II,
     FAKE_COUPON,
@@ -157,13 +159,13 @@ class TestAccountEvents(EventTestCase):
 
     # account.external_account.* events are fired for Custom and Express Accounts
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -186,13 +188,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -215,13 +217,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -257,13 +259,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED)
 
@@ -284,13 +286,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED
@@ -313,13 +315,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED
@@ -352,13 +354,13 @@ class TestAccountEvents(EventTestCase):
         self.assertEqual(card.id, fake_stripe_create_event["data"]["object"]["id"])
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -381,13 +383,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -410,13 +412,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_bank_account_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_BANK_ACCOUNT_CREATED
@@ -452,13 +454,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED)
 
@@ -479,13 +481,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED
@@ -508,13 +510,13 @@ class TestAccountEvents(EventTestCase):
         )
 
     @patch(
-        "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_EXPRESS_ACCOUNT),
+        "stripe.Account.retrieve_external_account",
+        return_value=deepcopy(FAKE_CARD_IV),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_card_event(
-        self, event_retrieve_mock, account_retrieve_mock
+        self, event_retrieve_mock, account_retrieve_external_account_mock
     ):
         fake_stripe_create_event = deepcopy(
             FAKE_EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CARD_CREATED


### PR DESCRIPTION
Fixes failing tests of https://github.com/dj-stripe/dj-stripe/pull/1361