### PR TITLE
Updated ci.yml file to also run when PRs are raised on master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Update Github actions in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI tests
 
-on: [push]
+on:
+  push:
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
 
 jobs:
   tests:


### PR DESCRIPTION
Updated `ci.yml` to also run whenever a PR is raised on `master` branch. This will avoid issues with tests running and failing later on. Will simplify the contribution process.