### PR TITLE
Minor fixes

### DIFF
--- a/djstripe/fields.py
+++ b/djstripe/fields.py
@@ -41,8 +41,7 @@ class StripeForeignKey(models.ForeignKey):
         # https://stackoverflow.com/a/14390402/227443
         if isinstance(self.remote_field.model, str):
             return self._get_default()
-        else:
-            return super().get_default()
+        return super().get_default()
 
 
 class PaymentMethodForeignKey(models.ForeignKey):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,7 +15,7 @@ USE_TZ = True
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
-ALLOWED_HOSTS = json.loads(os.environ.get("DJSTRIPE_TEST_ALLOWED_HOSTS_JSON", "[]"))
+ALLOWED_HOSTS = json.loads(os.environ.get("DJSTRIPE_TEST_ALLOWED_HOSTS_JSON", '["*"]'))
 
 if test_db_vendor == "postgres":
     DATABASES = {


### PR DESCRIPTION
This PR contains the following minor fixes:

1. Updated `ALLOWED_HOSTS` default value to accept requests from all `domains`. The original default would not have allowed a not `null Host` header. That would be a problem for those developing directly on a `docker` container and not directly on their `localhost`

1. Removed unnecessary `else` clause in `fields.get_default(self)`.