### PR TITLE
Fix event data jsonfield

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -1,9 +1,37 @@
 """
 Django Administration interface definitions
 """
+import json
+
 from django.contrib import admin
+from django.contrib.admin.utils import display_for_field, display_for_value
+from jsonfield import JSONField
 
 from . import models
+
+
+def custom_display_for_JSONfield(value, field, empty_value_display):
+    """
+    Overriding display_for_field to correctly render JSONField READonly fields
+    in django-admin. Relevant when DJSTRIPE_USE_NATIVE_JSONFIELD is False
+    Note: This does not handle invalid JSON. That should be handled by the JSONField itself
+    """
+    # we manually JSON serialise in case field is from jsonfield module
+    if isinstance(field, JSONField) and value:
+        try:
+            return json.dumps(value)
+        except TypeError:
+            return display_for_value(value, empty_value_display)
+    return display_for_field(value, field, empty_value_display)
+
+
+def admin_display_for_field_override():
+    admin.utils.display_for_field = custom_display_for_JSONfield
+    admin.helpers.display_for_field = custom_display_for_JSONfield
+
+
+# execute override
+admin_display_for_field_override()
 
 
 class ReadOnlyMixin:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,9 +3,15 @@ dj-stripe Admin Tests.
 """
 from django.contrib import admin
 from django.test import TestCase
+from jsonfield import JSONField
+
+from djstripe.admin import custom_display_for_JSONfield
 
 
 class TestAdminSite(TestCase):
+    def setUp(self):
+        self.empty_value = "-empty-"
+
     def test_search_fields(self):
         """
         Search for errors like this:
@@ -22,4 +28,18 @@ class TestAdminSite(TestCase):
                     "Bad search field <{search_field}> for {model_name} model.".format(
                         search_field=search_field, model_name=model_name
                     ),
+                )
+
+    def test_json_display_for_field(self):
+        json_tests = [
+            ({"a": {"b": None}}, '{"a": {"b": null}}'),
+            (["a", False], '["a", false]'),
+            ("a", '"a"'),
+            ({("a", "b"): "c"}, "{('a', 'b'): 'c'}"),  # Invalid JSON.
+        ]
+        for value, display_value in json_tests:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    custom_display_for_JSONfield(value, JSONField(), self.empty_value),
+                    display_value,
                 )


### PR DESCRIPTION
This PR contains the following changes:

1. All fields of the type `JSONField` that were being displayed as `readonly_fields` were not getting **displayed** properly in Django-admin. Were getting displayed as `dict` and not `JSON` objects.
2. All fields of the type `JSONField` with permissions forcing them to be displayed as `readonly_fields` were not getting **displayed** properly in Django-admin. Were getting displayed as `dict` and not `JSON` objects.
3. The issue was `not in how the data was getting stored` in the DB, but in `how it was being displayed on the admin only`.
4. The issue was happening only when either the env var `USE_NATIVE_JSONFIELD` was False
5. Added a test to make sure `JSON` gets displayed properly by the admin. Note that the display doesn't handle if the json passed to it is invalid. That is the domain of the `JSONField` at the ORM level.

Fixes https://github.com/dj-stripe/dj-stripe/issues/1345