### PR TITLE
Refactored djstripe.settings module by exposing djstripe_settings object as an interface for all djstripe settings

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -10,7 +10,7 @@ from django.utils.dateparse import date_re
 @checks.register("djstripe")
 def check_stripe_api_key(app_configs=None, **kwargs):
     """Check the user has configured API live/test keys correctly."""
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
 
@@ -48,7 +48,7 @@ def validate_stripe_api_version(version):
 @checks.register("djstripe")
 def check_stripe_api_version(app_configs=None, **kwargs):
     """Check the user has configured API version correctly."""
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
     default_version = djstripe_settings.DEFAULT_STRIPE_API_VERSION
@@ -79,7 +79,7 @@ def check_native_jsonfield_postgres_engine(app_configs=None, **kwargs):
     Check that the DJSTRIPE_USE_NATIVE_JSONFIELD isn't set unless Postgres is in use.
     Only used on Django < 3.1.
     """
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
     error_msg = (
@@ -176,7 +176,7 @@ def check_webhook_secret(app_configs=None, **kwargs):
     """
     Check that DJSTRIPE_WEBHOOK_SECRET looks correct
     """
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
 
@@ -198,7 +198,7 @@ def check_webhook_validation(app_configs=None, **kwargs):
     """
     Check that DJSTRIPE_WEBHOOK_VALIDATION is valid
     """
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
 
@@ -247,7 +247,7 @@ def check_subscriber_key_length(app_configs=None, **kwargs):
 
     Docs: https://stripe.com/docs/api#metadata
     """
-    from . import settings as djstripe_settings
+    from .settings import djstripe_settings
 
     messages = []
 

--- a/djstripe/context_managers.py
+++ b/djstripe/context_managers.py
@@ -3,6 +3,8 @@ dj-stripe Context Managers
 """
 from contextlib import contextmanager
 
+from .settings import djstripe_settings
+
 
 @contextmanager
 def stripe_temporary_api_version(version, validate=True):
@@ -12,13 +14,12 @@ def stripe_temporary_api_version(version, validate=True):
 
     The original value is restored as soon as context exits.
     """
-    from .settings import get_stripe_api_version, set_stripe_api_version
 
-    old_version = get_stripe_api_version()
+    old_version = djstripe_settings.get_stripe_api_version()
 
     try:
-        set_stripe_api_version(version, validate=validate)
+        djstripe_settings.set_stripe_api_version(version, validate=validate)
         yield
     finally:
         # Validation is bypassed since we're restoring a previous value.
-        set_stripe_api_version(old_version, validate=False)
+        djstripe_settings.set_stripe_api_version(old_version, validate=False)

--- a/djstripe/fields.py
+++ b/djstripe/fields.py
@@ -7,17 +7,20 @@ from django.conf import SettingsReference, settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from .settings import USE_NATIVE_JSONFIELD
+from .settings import djstripe_settings
 from .utils import convert_tstamp
 
-if USE_NATIVE_JSONFIELD:
-    try:
-        # Django 3.1
-        from django.db.models import JSONField as BaseJSONField
-    except ImportError:
-        from django.contrib.postgres.fields import JSONField as BaseJSONField
-else:
-    from jsonfield import JSONField as BaseJSONField
+
+def import_jsonfield():
+    if djstripe_settings.USE_NATIVE_JSONFIELD:
+        try:
+            # Django 3.1
+            from django.db.models import JSONField as BaseJSONField
+        except ImportError:
+            from django.contrib.postgres.fields import JSONField as BaseJSONField
+    else:
+        from jsonfield import JSONField as BaseJSONField
+    return BaseJSONField
 
 
 class StripeForeignKey(models.ForeignKey):
@@ -163,7 +166,7 @@ class StripeDateTimeField(models.DateTimeField):
             return convert_tstamp(val)
 
 
-class JSONField(BaseJSONField):
+class JSONField(import_jsonfield()):
     """A field used to define a JSONField value according to djstripe logic."""
 
     pass

--- a/djstripe/management/commands/djstripe_init_customers.py
+++ b/djstripe/management/commands/djstripe_init_customers.py
@@ -4,7 +4,7 @@ init_customers command.
 from django.core.management.base import BaseCommand
 
 from ...models import Customer
-from ...settings import get_subscriber_model
+from ...settings import djstripe_settings
 
 
 class Command(BaseCommand):
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         """
         Create Customer objects for Subscribers without Customer objects associated.
         """
-        for subscriber in get_subscriber_model().objects.filter(
+        for subscriber in djstripe_settings.get_subscriber_model().objects.filter(
             djstripe_customers=None
         ):
             # use get_or_create in case of race conditions on large subscriber bases

--- a/djstripe/management/commands/djstripe_process_events.py
+++ b/djstripe/management/commands/djstripe_process_events.py
@@ -1,8 +1,8 @@
 from django.core.management.base import BaseCommand
 
 from ... import models
-from ... import settings as djstripe_settings
 from ...mixins import VerbosityAwareOutputMixin
+from ...settings import djstripe_settings
 
 
 class Command(VerbosityAwareOutputMixin, BaseCommand):

--- a/djstripe/management/commands/djstripe_sync_customers.py
+++ b/djstripe/management/commands/djstripe_sync_customers.py
@@ -3,7 +3,7 @@ sync_customer command.
 """
 from django.core.management.base import BaseCommand
 
-from ...settings import get_subscriber_model
+from ...settings import djstripe_settings
 from ...sync import sync_subscriber
 
 
@@ -14,7 +14,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Call sync_subscriber on Subscribers without customers associated to them."""
-        qs = get_subscriber_model().objects.filter(djstripe_customers__isnull=True)
+        qs = djstripe_settings.get_subscriber_model().objects.filter(
+            djstripe_customers__isnull=True
+        )
         count = 0
         total = qs.count()
         for subscriber in qs:

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -3,8 +3,9 @@ from typing import List
 from django.apps import apps
 from django.core.management.base import BaseCommand, CommandError
 
-from ... import enums, models, settings
+from ... import enums, models
 from ...models.base import StripeBaseModel
+from ...settings import djstripe_settings
 
 
 class Command(BaseCommand):
@@ -55,7 +56,7 @@ class Command(BaseCommand):
         if model is models.UpcomingInvoice:
             return False, "Upcoming Invoices are virtual only"
 
-        if not settings.STRIPE_LIVE_MODE:
+        if not djstripe_settings.STRIPE_LIVE_MODE:
             if model is models.ScheduledQueryRun:
                 return False, "only available in live mode"
 
@@ -78,7 +79,7 @@ class Command(BaseCommand):
                 if model is models.Account:
                     # special case, since own account isn't returned by Account.api_list
                     stripe_obj = models.Account.stripe_class.retrieve(
-                        api_key=settings.STRIPE_SECRET_KEY
+                        api_key=djstripe_settings.STRIPE_SECRET_KEY
                     )
                     count += 1
                     djstripe_obj = model.sync_from_stripe_data(stripe_obj)
@@ -164,7 +165,7 @@ class Command(BaseCommand):
             # fetch all Card and BankAccount objects associated with the instance
             items = models.Account.stripe_class.list_external_accounts(
                 id,
-                api_key=settings.STRIPE_SECRET_KEY,
+                api_key=djstripe_settings.STRIPE_SECRET_KEY,
             )
             bank_count = 0
             card_count = 0

--- a/djstripe/mixins.py
+++ b/djstripe/mixins.py
@@ -4,8 +4,8 @@ dj-stripe mixins
 import sys
 import traceback
 
-from . import settings as djstripe_settings
 from .models import Customer, Plan
+from .settings import djstripe_settings
 
 
 class PaymentsContextMixin:

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -2,9 +2,9 @@ import stripe
 from django.db import models, transaction
 
 from .. import enums
-from .. import settings as djstripe_settings
 from ..enums import APIKeyType
 from ..fields import JSONField, StripeCurrencyCodeField, StripeEnumField
+from ..settings import djstripe_settings
 from .api import APIKey
 from .base import StripeModel
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -11,9 +11,9 @@ from django.utils.encoding import smart_str
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.error import InvalidRequestError
 
-from .. import settings as djstripe_settings
 from ..fields import JSONField, StripeDateTimeField, StripeForeignKey, StripeIdField
 from ..managers import StripeModelManager
+from ..settings import djstripe_settings
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class StripeModel(StripeBaseModel):
         Call the stripe API's retrieve operation for this model.
 
         :param api_key: The api key to use for this request. \
-            Defaults to settings.STRIPE_SECRET_KEY.
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
         :type api_key: string
         :param stripe_account: The optional connected account \
             for which this request is being made.
@@ -173,7 +173,7 @@ class StripeModel(StripeBaseModel):
         Call the stripe API's retrieve operation for this model.
 
         :param api_key: The api key to use for this request. \
-            Defaults to settings.STRIPE_SECRET_KEY.
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
         :type api_key: string
         :param stripe_account: The optional connected account \
             for which this request is being made.

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext_lazy as _
 from stripe.error import InvalidRequestError
 
 from .. import enums
-from .. import settings as djstripe_settings
 from ..fields import (
     JSONField,
     PaymentMethodForeignKey,
@@ -23,6 +22,7 @@ from ..fields import (
     StripeQuantumCurrencyAmountField,
 )
 from ..managers import SubscriptionManager
+from ..settings import djstripe_settings
 from ..utils import QuerySetMock, get_friendly_currency_amount
 from .base import StripeModel
 

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -12,7 +12,7 @@ from ..fields import (
     StripeQuantumCurrencyAmountField,
 )
 from ..managers import TransferManager
-from ..settings import get_default_api_key
+from ..settings import djstripe_settings
 from .base import StripeBaseModel, StripeModel
 
 
@@ -145,7 +145,7 @@ class CountrySpec(StripeBaseModel):
 
     def api_retrieve(self, api_key: str = None, stripe_account=None):
         if api_key is None:
-            api_key = get_default_api_key(livemode=None)
+            api_key = djstripe_settings.get_default_api_key(livemode=None)
 
         return self.stripe_class.retrieve(
             id=self.id,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -11,9 +11,7 @@ from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from stripe.error import InvalidRequestError
 
-from .. import enums
-from .. import settings as djstripe_settings
-from .. import webhooks
+from .. import enums, webhooks
 from ..exceptions import MultipleSubscriptionException
 from ..fields import (
     JSONField,
@@ -27,6 +25,7 @@ from ..fields import (
     StripeQuantumCurrencyAmountField,
 )
 from ..managers import ChargeManager
+from ..settings import djstripe_settings
 from ..signals import WEBHOOK_SIGNALS
 from ..utils import get_friendly_currency_amount
 from .base import IdempotencyKey, StripeModel, logger

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -5,7 +5,6 @@ from django.db import models, transaction
 from stripe.error import InvalidRequestError
 
 from .. import enums
-from .. import settings as djstripe_settings
 from ..exceptions import StripeObjectManipulationException
 from ..fields import (
     JSONField,
@@ -14,6 +13,7 @@ from ..fields import (
     StripeEnumField,
     StripeForeignKey,
 )
+from ..settings import djstripe_settings
 from .account import Account
 from .base import StripeModel, logger
 from .core import Customer

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -7,9 +7,9 @@ from django.db import models
 from django.utils.datastructures import CaseInsensitiveMapping
 from django.utils.functional import cached_property
 
-from .. import settings as djstripe_settings
 from ..context_managers import stripe_temporary_api_version
 from ..fields import JSONField, StripeForeignKey
+from ..settings import djstripe_settings
 from ..signals import webhook_processing_error
 from .base import logger
 from .core import Event

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -9,224 +9,276 @@ from django.utils.module_loading import import_string
 
 from .checks import validate_stripe_api_version
 
-DEFAULT_STRIPE_API_VERSION = "2020-08-27"
 
+class DjstripeSettings:
 
-def get_callback_function(setting_name, default=None):
-    """
-    Resolve a callback function based on a setting name.
+    DEFAULT_STRIPE_API_VERSION = "2020-08-27"
 
-    If the setting value isn't set, default is returned.  If the setting value
-    is already a callable function, that value is used - If the setting value
-    is a string, an attempt is made to import it.  Anything else will result in
-    a failed import causing ImportError to be raised.
-
-    :param setting_name: The name of the setting to resolve a callback from.
-    :type setting_name: string (``str``/``unicode``)
-    :param default: The default to return if setting isn't populated.
-    :type default: ``bool``
-    :returns: The resolved callback function (if any).
-    :type: ``callable``
-    """
-    func = getattr(settings, setting_name, None)
-    if not func:
-        return default
-
-    if callable(func):
-        return func
-
-    if isinstance(func, str):
-        func = import_string(func)
-
-    if not callable(func):
-        raise ImproperlyConfigured("{name} must be callable.".format(name=setting_name))
-
-    return func
-
-
-subscriber_request_callback = get_callback_function(
-    "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK", default=(lambda request: request.user)
-)
-
-
-def _get_idempotency_key(object_type, action, livemode):
-    from .models import IdempotencyKey
-
-    action = "{}:{}".format(object_type, action)
-    idempotency_key, _created = IdempotencyKey.objects.get_or_create(
-        action=action, livemode=livemode
+    ZERO_DECIMAL_CURRENCIES = set(
+        [
+            "bif",
+            "clp",
+            "djf",
+            "gnf",
+            "jpy",
+            "kmf",
+            "krw",
+            "mga",
+            "pyg",
+            "rwf",
+            "vnd",
+            "vuv",
+            "xaf",
+            "xof",
+            "xpf",
+        ]
     )
-    return str(idempotency_key.uuid)
 
+    def __init__(self):
+        # Set STRIPE_API_HOST if you want to use a different Stripe API server
+        # Example: https://github.com/stripe/stripe-mock
+        if hasattr(settings, "STRIPE_API_HOST"):
+            stripe.api_base = getattr(settings, "STRIPE_API_HOST")
 
-get_idempotency_key = get_callback_function(
-    "DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK", _get_idempotency_key
-)
+    # generic setter and deleter methods to ensure object patching works
+    def __setattr__(self, name, value):
+        self.__dict__["name"] = value
 
-USE_NATIVE_JSONFIELD = getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", False)
+    def __delattr__(self, name):
+        del self.__dict__["name"]
 
-PRORATION_POLICY = getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)
-CANCELLATION_AT_PERIOD_END = not getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)
+    @property
+    def SUBSCRIPTION_REDIRECT(self):
+        return getattr(settings, "DJSTRIPE_SUBSCRIPTION_REDIRECT", "")
 
-DJSTRIPE_WEBHOOK_URL = getattr(settings, "DJSTRIPE_WEBHOOK_URL", r"^webhook/$")
+    @property
+    def SUBSCRIPTION_REQUIRED_EXCEPTION_URLS(self):
+        return getattr(settings, "DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS", ())
 
-WEBHOOK_TOLERANCE = getattr(
-    settings, "DJSTRIPE_WEBHOOK_TOLERANCE", stripe.Webhook.DEFAULT_TOLERANCE
-)
-WEBHOOK_VALIDATION = getattr(
-    settings, "DJSTRIPE_WEBHOOK_VALIDATION", "verify_signature"
-)
-WEBHOOK_SECRET = getattr(settings, "DJSTRIPE_WEBHOOK_SECRET", "")
+    @property
+    def subscriber_request_callback(self):
+        return self.get_callback_function(
+            "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK",
+            default=(lambda request: request.user),
+        )
 
-# Webhook event callbacks allow an application to take control of what happens
-# when an event from Stripe is received.  One suggestion is to put the event
-# onto a task queue (such as celery) for asynchronous processing.
-WEBHOOK_EVENT_CALLBACK = get_callback_function("DJSTRIPE_WEBHOOK_EVENT_CALLBACK")
+    @property
+    def get_idempotency_key(self):
+        return self.get_callback_function(
+            "DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK", self._get_idempotency_key
+        )
 
-SUBSCRIBER_CUSTOMER_KEY = getattr(
-    settings, "DJSTRIPE_SUBSCRIBER_CUSTOMER_KEY", "djstripe_subscriber"
-)
+    @property
+    def USE_NATIVE_JSONFIELD(self):
+        return getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", False)
 
-TEST_API_KEY = getattr(settings, "STRIPE_TEST_SECRET_KEY", "")
-LIVE_API_KEY = getattr(settings, "STRIPE_LIVE_SECRET_KEY", "")
+    @property
+    def PRORATION_POLICY(self):
+        return getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)
 
-# Determines whether we are in live mode or test mode
-STRIPE_LIVE_MODE = getattr(settings, "STRIPE_LIVE_MODE", False)
+    @property
+    def CANCELLATION_AT_PERIOD_END(self):
+        return not getattr(settings, "DJSTRIPE_PRORATION_POLICY", False)
 
-# Default secret key
-if hasattr(settings, "STRIPE_SECRET_KEY"):
-    STRIPE_SECRET_KEY = settings.STRIPE_SECRET_KEY
-else:
-    STRIPE_SECRET_KEY = LIVE_API_KEY if STRIPE_LIVE_MODE else TEST_API_KEY
+    @property
+    def DJSTRIPE_WEBHOOK_URL(self):
+        return getattr(settings, "DJSTRIPE_WEBHOOK_URL", r"^webhook/$")
 
-# Default public key
-if hasattr(settings, "STRIPE_PUBLIC_KEY"):
-    STRIPE_PUBLIC_KEY = settings.STRIPE_PUBLIC_KEY
-elif STRIPE_LIVE_MODE:
-    STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_LIVE_PUBLIC_KEY", "")
-else:
-    STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_TEST_PUBLIC_KEY", "")
+    @property
+    def WEBHOOK_TOLERANCE(self):
+        return getattr(
+            settings, "DJSTRIPE_WEBHOOK_TOLERANCE", stripe.Webhook.DEFAULT_TOLERANCE
+        )
 
+    @property
+    def WEBHOOK_VALIDATION(self):
+        return getattr(settings, "DJSTRIPE_WEBHOOK_VALIDATION", "verify_signature")
 
-# Set STRIPE_API_HOST if you want to use a different Stripe API server
-# Example: https://github.com/stripe/stripe-mock
-if hasattr(settings, "STRIPE_API_HOST"):
-    stripe.api_base = settings.STRIPE_API_HOST
+    @property
+    def WEBHOOK_SECRET(self):
+        return getattr(settings, "DJSTRIPE_WEBHOOK_SECRET", "")
 
+    # Webhook event callbacks allow an application to take control of what happens
+    # when an event from Stripe is received.  One suggestion is to put the event
+    # onto a task queue (such as celery) for asynchronous processing.
+    @property
+    def WEBHOOK_EVENT_CALLBACK(self):
+        return self.get_callback_function("DJSTRIPE_WEBHOOK_EVENT_CALLBACK")
 
-def get_default_api_key(livemode):
-    """
-    Returns the default API key for a value of `livemode`.
-    """
-    if livemode is None:
-        # Livemode is unknown. Use the default secret key.
+    @property
+    def SUBSCRIBER_CUSTOMER_KEY(self):
+        return getattr(
+            settings, "DJSTRIPE_SUBSCRIBER_CUSTOMER_KEY", "djstripe_subscriber"
+        )
+
+    @property
+    def TEST_API_KEY(self):
+        return getattr(settings, "STRIPE_TEST_SECRET_KEY", "")
+
+    @property
+    def LIVE_API_KEY(self):
+        return getattr(settings, "STRIPE_LIVE_SECRET_KEY", "")
+
+    # Determines whether we are in live mode or test mode
+    @property
+    def STRIPE_LIVE_MODE(self):
+        return getattr(settings, "STRIPE_LIVE_MODE", False)
+
+    @property
+    def STRIPE_SECRET_KEY(self):
+        # Default secret key
+        if hasattr(settings, "STRIPE_SECRET_KEY"):
+            STRIPE_SECRET_KEY = settings.STRIPE_SECRET_KEY
+        else:
+            STRIPE_SECRET_KEY = (
+                self.LIVE_API_KEY if self.STRIPE_LIVE_MODE else self.TEST_API_KEY
+            )
         return STRIPE_SECRET_KEY
-    elif livemode:
-        # Livemode is true, use the live secret key
-        return LIVE_API_KEY or STRIPE_SECRET_KEY
-    else:
-        # Livemode is false, use the test secret key
-        return TEST_API_KEY or STRIPE_SECRET_KEY
 
+    @property
+    def STRIPE_PUBLIC_KEY(self):
 
-SUBSCRIPTION_REDIRECT = getattr(settings, "DJSTRIPE_SUBSCRIPTION_REDIRECT", "")
+        # Default public key
+        if hasattr(settings, "STRIPE_PUBLIC_KEY"):
+            STRIPE_PUBLIC_KEY = settings.STRIPE_PUBLIC_KEY
+        elif self.STRIPE_LIVE_MODE:
+            STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_LIVE_PUBLIC_KEY", "")
+        else:
+            STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_TEST_PUBLIC_KEY", "")
+        return STRIPE_PUBLIC_KEY
 
-SUBSCRIPTION_REQUIRED_EXCEPTION_URLS = getattr(
-    settings, "DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS", ()
-)
+    def get_callback_function(self, setting_name, default=None):
+        """
+        Resolve a callback function based on a setting name.
 
+        If the setting value isn't set, default is returned.  If the setting value
+        is already a callable function, that value is used - If the setting value
+        is a string, an attempt is made to import it.  Anything else will result in
+        a failed import causing ImportError to be raised.
 
-ZERO_DECIMAL_CURRENCIES = set(
-    [
-        "bif",
-        "clp",
-        "djf",
-        "gnf",
-        "jpy",
-        "kmf",
-        "krw",
-        "mga",
-        "pyg",
-        "rwf",
-        "vnd",
-        "vuv",
-        "xaf",
-        "xof",
-        "xpf",
-    ]
-)
-
-
-def get_subscriber_model_string():
-    """Get the configured subscriber model as a module path string."""
-    return getattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL", settings.AUTH_USER_MODEL)
-
-
-def get_subscriber_model():
-    """
-    Attempt to pull settings.DJSTRIPE_SUBSCRIBER_MODEL.
-
-    Users have the option of specifying a custom subscriber model via the
-    DJSTRIPE_SUBSCRIBER_MODEL setting.
-
-    This methods falls back to AUTH_USER_MODEL if DJSTRIPE_SUBSCRIBER_MODEL is not set.
-
-    Returns the subscriber model that is active in this project.
-    """
-    model_name = get_subscriber_model_string()
-
-    # Attempt a Django 1.7 app lookup
-    try:
-        subscriber_model = django_apps.get_model(model_name)
-    except ValueError:
-        raise ImproperlyConfigured(
-            "DJSTRIPE_SUBSCRIBER_MODEL must be of the form 'app_label.model_name'."
-        )
-    except LookupError:
-        raise ImproperlyConfigured(
-            "DJSTRIPE_SUBSCRIBER_MODEL refers to model '{model}' "
-            "that has not been installed.".format(model=model_name)
-        )
-
-    if (
-        "email" not in [field_.name for field_ in subscriber_model._meta.get_fields()]
-    ) and not hasattr(subscriber_model, "email"):
-        raise ImproperlyConfigured(
-            "DJSTRIPE_SUBSCRIBER_MODEL must have an email attribute."
-        )
-
-    if model_name != settings.AUTH_USER_MODEL:
-        # Custom user model detected. Make sure the callback is configured.
-        func = get_callback_function("DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK")
+        :param setting_name: The name of the setting to resolve a callback from.
+        :type setting_name: string (``str``/``unicode``)
+        :param default: The default to return if setting isn't populated.
+        :type default: ``bool``
+        :returns: The resolved callback function (if any).
+        :type: ``callable``
+        """
+        func = getattr(settings, setting_name, None)
         if not func:
+            return default
+
+        if callable(func):
+            return func
+
+        if isinstance(func, str):
+            func = import_string(func)
+
+        if not callable(func):
             raise ImproperlyConfigured(
-                "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be implemented "
-                "if a DJSTRIPE_SUBSCRIBER_MODEL is defined."
+                "{name} must be callable.".format(name=setting_name)
             )
 
-    return subscriber_model
+        return func
+
+    def _get_idempotency_key(self, object_type, action, livemode):
+        from .models import IdempotencyKey
+
+        action = "{}:{}".format(object_type, action)
+        idempotency_key, _created = IdempotencyKey.objects.get_or_create(
+            action=action, livemode=livemode
+        )
+        return str(idempotency_key.uuid)
+
+    def get_default_api_key(self, livemode):
+        """
+        Returns the default API key for a value of `livemode`.
+        """
+        if livemode is None:
+            # Livemode is unknown. Use the default secret key.
+            return self.STRIPE_SECRET_KEY
+        elif livemode:
+            # Livemode is true, use the live secret key
+            return self.LIVE_API_KEY or self.STRIPE_SECRET_KEY
+        else:
+            # Livemode is false, use the test secret key
+            return self.TEST_API_KEY or self.STRIPE_SECRET_KEY
+
+    def get_subscriber_model_string(self):
+        """Get the configured subscriber model as a module path string."""
+        return getattr(settings, "DJSTRIPE_SUBSCRIBER_MODEL", settings.AUTH_USER_MODEL)
+
+    def get_subscriber_model(self):
+        """
+        Attempt to pull settings.DJSTRIPE_SUBSCRIBER_MODEL.
+
+        Users have the option of specifying a custom subscriber model via the
+        DJSTRIPE_SUBSCRIBER_MODEL setting.
+
+        This methods falls back to AUTH_USER_MODEL if DJSTRIPE_SUBSCRIBER_MODEL is not set.
+
+        Returns the subscriber model that is active in this project.
+        """
+        model_name = self.get_subscriber_model_string()
+
+        # Attempt a Django 1.7 app lookup
+        try:
+            subscriber_model = django_apps.get_model(model_name)
+        except ValueError:
+            raise ImproperlyConfigured(
+                "DJSTRIPE_SUBSCRIBER_MODEL must be of the form 'app_label.model_name'."
+            )
+        except LookupError:
+            raise ImproperlyConfigured(
+                "DJSTRIPE_SUBSCRIBER_MODEL refers to model '{model}' "
+                "that has not been installed.".format(model=model_name)
+            )
+
+        if (
+            "email"
+            not in [field_.name for field_ in subscriber_model._meta.get_fields()]
+        ) and not hasattr(subscriber_model, "email"):
+            raise ImproperlyConfigured(
+                "DJSTRIPE_SUBSCRIBER_MODEL must have an email attribute."
+            )
+
+        if model_name != settings.AUTH_USER_MODEL:
+            # Custom user model detected. Make sure the callback is configured.
+            func = self.get_callback_function(
+                "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK"
+            )
+            if not func:
+                raise ImproperlyConfigured(
+                    "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be implemented "
+                    "if a DJSTRIPE_SUBSCRIBER_MODEL is defined."
+                )
+
+        return subscriber_model
+
+    # TODO convert to STRIPE_API_VERSION property
+    def get_stripe_api_version(self):
+        """Get the desired API version to use for Stripe requests."""
+        version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
+        return version or self.DEFAULT_STRIPE_API_VERSION
+
+    # TODO convert to setter for STRIPE_API_VERSION property
+    def set_stripe_api_version(self, version=None, validate=True):
+        """
+        Set the desired API version to use for Stripe requests.
+
+        :param version: The version to set for the Stripe API.
+        :type version: ``str``
+        :param validate: If True validate the value for the specified version).
+        :type validate: ``bool``
+        """
+        version = version or self.get_stripe_api_version()
+
+        if validate:
+            valid = validate_stripe_api_version(version)
+            if not valid:
+                raise ValueError("Bad stripe API version: {}".format(version))
+
+        stripe.api_version = version
 
 
-def get_stripe_api_version():
-    """Get the desired API version to use for Stripe requests."""
-    version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
-    return version or DEFAULT_STRIPE_API_VERSION
-
-
-def set_stripe_api_version(version=None, validate=True):
-    """
-    Set the desired API version to use for Stripe requests.
-
-    :param version: The version to set for the Stripe API.
-    :type version: ``str``
-    :param validate: If True validate the value for the specified version).
-    :type validate: ``bool``
-    """
-    version = version or get_stripe_api_version()
-
-    if validate:
-        valid = validate_stripe_api_version(version)
-        if not valid:
-            raise ValueError("Bad stripe API version: {}".format(version))
-
-    stripe.api_version = version
+# initialise the settings object
+djstripe_settings = DjstripeSettings()

--- a/djstripe/urls.py
+++ b/djstripe/urls.py
@@ -9,8 +9,8 @@ Wire this into the root URLConf this way::
 """
 from django.urls import re_path
 
-from . import settings as app_settings
 from . import views
+from .settings import djstripe_settings as app_settings
 
 app_name = "djstripe"
 

--- a/docs/api_versions.md
+++ b/docs/api_versions.md
@@ -45,8 +45,8 @@ sent to you by Stripe with your API version, we re-fetch the data with
 dj-stripe's API version), this is because the API schema needs to match
 dj-stripe's Django model schema.
 
-This is defined by `djstripe.settings.DEFAULT_STRIPE_API_VERSION` and
-`can be overridden <setting_stripe_api_version>`, though see the warning
+This is defined by `djstripe.settings.djstripe_settings.DEFAULT_STRIPE_API_VERSION` and
+can be overridden by the function, `djstripe.settings.djstripe_settings.set_stripe_api_version`, though see the warning
 about doing this.
 
 ## dj-stripe's tested version (as mentioned in README)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,7 +51,7 @@ switch an older installation to "id", the easiest way is to wipe the djstripe db
 sync again from scratch. This is obviously not ideal, and we will design a proper
 migration path before 3.0.
 
-## DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK (=djstripe.settings.\_get_idempotency_key)
+## DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK (=djstripe.settings.djstripe_settings.\_get_idempotency_key)
 
 A function which will return an idempotency key for a particular object_type and action
 pair. By default, this is set to a function which will create a

--- a/tests/apps/example/management/commands/regenerate_test_fixtures.py
+++ b/tests/apps/example/management/commands/regenerate_test_fixtures.py
@@ -8,8 +8,8 @@ from django.core.management import BaseCommand
 from stripe.error import InvalidRequestError
 
 import djstripe.models
-import djstripe.settings
 import tests
+from djstripe.settings import djstripe_settings
 
 """
 Key used to store fake ids in the real stripe object's metadata dict
@@ -682,7 +682,7 @@ class Command(BaseCommand):
             stripe.PaymentMethod.attach(
                 obj["id"],
                 customer=customer_id,
-                api_key=djstripe.settings.STRIPE_SECRET_KEY,
+                api_key=djstripe_settings.STRIPE_SECRET_KEY,
             )
 
             for k in writable_fields:

--- a/tests/apps/example/views.py
+++ b/tests/apps/example/views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.views.generic import DetailView, FormView
 
 import djstripe.models
-import djstripe.settings
+from djstripe.settings import djstripe_settings
 
 from . import forms
 
@@ -45,7 +45,7 @@ class PurchaseSubscriptionView(FormView):
                 "(or use the dj-stripe webhooks)"
             )
 
-        ctx["STRIPE_PUBLIC_KEY"] = djstripe.settings.STRIPE_PUBLIC_KEY
+        ctx["STRIPE_PUBLIC_KEY"] = djstripe_settings.STRIPE_PUBLIC_KEY
 
         return ctx
 
@@ -61,7 +61,7 @@ class PurchaseSubscriptionView(FormView):
             user = User.objects.create(username=email, email=email)
 
         # Create the stripe Customer, by default subscriber Model is User,
-        # this can be overridden with settings.DJSTRIPE_SUBSCRIBER_MODEL
+        # this can be overridden with djstripe_settings.DJSTRIPE_SUBSCRIBER_MODEL
         customer, created = djstripe.models.Customer.get_or_create(subscriber=user)
 
         # Add the source as the customer's default card
@@ -116,12 +116,12 @@ def create_payment_intent(request):
                     currency="usd",
                     confirmation_method="manual",
                     confirm=True,
-                    api_key=djstripe.settings.STRIPE_SECRET_KEY,
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
                 )
             elif "payment_intent_id" in data:
                 intent = stripe.PaymentIntent.confirm(
                     data["payment_intent_id"],
-                    api_key=djstripe.settings.STRIPE_SECRET_KEY,
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
                 )
         except stripe.error.CardError as e:
             # Display error on client
@@ -156,5 +156,5 @@ def create_payment_intent(request):
         )
 
     else:
-        ctx = {"STRIPE_PUBLIC_KEY": djstripe.settings.STRIPE_PUBLIC_KEY}
+        ctx = {"STRIPE_PUBLIC_KEY": djstripe_settings.STRIPE_PUBLIC_KEY}
         return TemplateResponse(request, "payment_intent.html", ctx)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,16 +2,14 @@
 dj-stripe Account Tests.
 """
 from copy import deepcopy
-from importlib import reload
 from unittest.mock import patch
 
 import pytest
 from django.test.testcases import TestCase
 from django.test.utils import override_settings
 
-from djstripe import settings as djstripe_settings
 from djstripe.models import Account
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_ACCOUNT,
@@ -34,7 +32,9 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
         account = Account.get_default_account()
 
-        account_retrieve_mock.assert_called_once_with(api_key=STRIPE_SECRET_KEY)
+        account_retrieve_mock.assert_called_once_with(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )
 
         self.assertGreater(len(account.business_profile), 0)
         self.assertGreater(len(account.settings), 0)
@@ -69,7 +69,9 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
         account = Account.get_default_account()
 
-        account_retrieve_mock.assert_called_once_with(api_key=STRIPE_SECRET_KEY)
+        account_retrieve_mock.assert_called_once_with(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )
 
         self.assert_fks(
             account,
@@ -123,16 +125,12 @@ class TestAccountRestrictedKeys(TestCase):
         """
         Test that we do not attempt to retrieve account ID with restricted keys.
         """
-        reload(djstripe_settings)
         assert djstripe_settings.STRIPE_SECRET_KEY == "rk_test_blah"
 
         account = Account.get_default_account()
 
         assert account is None
         account_retrieve_mock.assert_not_called()
-
-    def tearDown(self):
-        reload(djstripe_settings)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,11 +1,9 @@
-from importlib import reload
-
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
 from djstripe import models
-from djstripe import settings as djstripe_settings
+from djstripe.settings import djstripe_settings
 
 
 class TestCheckApiKeySettings(TestCase):
@@ -15,7 +13,6 @@ class TestCheckApiKeySettings(TestCase):
         STRIPE_LIVE_MODE=True,
     )
     def test_global_api_keys_live_mode(self):
-        reload(djstripe_settings)
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, True)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_live_foo")
         self.assertEqual(djstripe_settings.LIVE_API_KEY, "sk_live_foo")
@@ -27,7 +24,6 @@ class TestCheckApiKeySettings(TestCase):
         STRIPE_LIVE_MODE=False,
     )
     def test_global_api_keys_test_mode(self):
-        reload(djstripe_settings)
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, False)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_test_foo")
         self.assertEqual(djstripe_settings.TEST_API_KEY, "sk_test_foo")
@@ -43,7 +39,6 @@ class TestCheckApiKeySettings(TestCase):
     def test_api_key_live_mode(self):
         del settings.STRIPE_SECRET_KEY, settings.STRIPE_TEST_SECRET_KEY
         del settings.STRIPE_PUBLIC_KEY, settings.STRIPE_TEST_PUBLIC_KEY
-        reload(djstripe_settings)
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, True)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_live_foo")
         self.assertEqual(djstripe_settings.STRIPE_PUBLIC_KEY, "pk_live_foo")
@@ -60,12 +55,8 @@ class TestCheckApiKeySettings(TestCase):
     def test_secret_key_test_mode(self):
         del settings.STRIPE_SECRET_KEY
         del settings.STRIPE_PUBLIC_KEY
-        reload(djstripe_settings)
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, False)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_test_foo")
         self.assertEqual(djstripe_settings.STRIPE_PUBLIC_KEY, "pk_test_foo")
         self.assertEqual(djstripe_settings.TEST_API_KEY, "sk_test_foo")
         self.assertEqual(models.Account(livemode=False).default_api_key, "sk_test_foo")
-
-    def tearDown(self):
-        reload(djstripe_settings)

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -10,6 +10,7 @@ from django.test.testcases import TestCase
 
 from djstripe.enums import ChargeStatus, LegacySourceType
 from djstripe.models import Charge, DjstripePaymentMethod
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_BALANCE_TRANSACTION,
@@ -195,7 +196,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         default_account_mock.return_value = self.account
 
@@ -219,7 +219,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge_retrieve_mock.assert_not_called()
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION["id"],
             stripe_account=None,
@@ -270,8 +270,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         # first sync charge (as per test_sync_from_stripe_data)
         # then sync refunded version, to hit the update code-path instead of insert
 
-        from djstripe.settings import STRIPE_SECRET_KEY
-
         default_account_mock.return_value = self.account
 
         fake_charge_copy = deepcopy(FAKE_CHARGE)
@@ -310,7 +308,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge_retrieve_mock.assert_not_called()
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION_REFUND["id"],
             stripe_account=None,
@@ -383,7 +381,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         default_account_mock.return_value = self.account
         fake_charge_copy = deepcopy(FAKE_CHARGE_REFUNDED)
@@ -404,13 +401,13 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock.assert_has_calls(
             [
                 call(
-                    api_key=STRIPE_SECRET_KEY,
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_BALANCE_TRANSACTION["id"],
                     stripe_account=None,
                 ),
                 call(
-                    api_key=STRIPE_SECRET_KEY,
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_BALANCE_TRANSACTION_REFUND["id"],
                     stripe_account=None,
@@ -546,7 +543,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         default_account_mock.return_value = self.account
 
@@ -561,7 +557,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         charge_retrieve_mock.assert_not_called()
 
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION["id"],
             stripe_account=None,
@@ -597,7 +593,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         default_account_mock.return_value = self.account
 
@@ -619,7 +614,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge_retrieve_mock.assert_not_called()
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION["id"],
             stripe_account=None,
@@ -683,7 +678,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         default_account_mock.return_value = self.account
 
@@ -705,7 +699,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge_retrieve_mock.assert_not_called()
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION["id"],
             stripe_account=None,
@@ -765,7 +759,6 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         account_retrieve_mock,
         charge_retrieve_mock,
     ):
-        from djstripe.settings import STRIPE_SECRET_KEY
 
         account_retrieve_mock.return_value = FAKE_STANDARD_ACCOUNT
 
@@ -779,7 +772,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge_retrieve_mock.assert_not_called()
         balance_transaction_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_BALANCE_TRANSACTION["id"],
             stripe_account=None,

--- a/tests/test_idempotency_keys.py
+++ b/tests/test_idempotency_keys.py
@@ -4,20 +4,20 @@ from django.test import TestCase
 from django.utils.timezone import now
 
 from djstripe.models import IdempotencyKey
-from djstripe.settings import get_idempotency_key
+from djstripe.settings import djstripe_settings
 from djstripe.utils import clear_expired_idempotency_keys
 
 
 class IdempotencyKeyTest(TestCase):
     def test_generate_idempotency_key(self):
-        key1 = get_idempotency_key("customer", "create:1", False)
-        key2 = get_idempotency_key("customer", "create:1", False)
+        key1 = djstripe_settings.get_idempotency_key("customer", "create:1", False)
+        key2 = djstripe_settings.get_idempotency_key("customer", "create:1", False)
         self.assertTrue(key1 == key2)
 
-        key3 = get_idempotency_key("customer", "create:2", False)
+        key3 = djstripe_settings.get_idempotency_key("customer", "create:2", False)
         self.assertTrue(key1 != key3)
 
-        key4 = get_idempotency_key("charge", "create:1", False)
+        key4 = djstripe_settings.get_idempotency_key("charge", "create:1", False)
         self.assertTrue(key1 != key4)
 
         self.assertEqual(IdempotencyKey.objects.count(), 3)
@@ -28,12 +28,14 @@ class IdempotencyKeyTest(TestCase):
         self.assertEqual(str(key1_obj), str(key1_obj.uuid))
 
     def test_clear_expired_idempotency_keys(self):
-        expired_key = get_idempotency_key("customer", "create:1", False)
+        expired_key = djstripe_settings.get_idempotency_key(
+            "customer", "create:1", False
+        )
         expired_key_obj = IdempotencyKey.objects.get(uuid=expired_key)
         expired_key_obj.created = now() - timedelta(hours=25)
         expired_key_obj.save()
 
-        valid_key = get_idempotency_key("customer", "create:2", False)
+        valid_key = djstripe_settings.get_idempotency_key("customer", "create:2", False)
 
         self.assertEqual(IdempotencyKey.objects.count(), 2)
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -10,7 +10,7 @@ from stripe.error import InvalidRequestError
 
 from djstripe.enums import InvoiceStatus
 from djstripe.models import Invoice, Plan, Subscription, UpcomingInvoice
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_BALANCE_TRANSACTION,
@@ -449,7 +449,10 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         return_value = invoice.retry()
 
         invoice_retrieve_mock.assert_called_once_with(
-            id=invoice.id, api_key=STRIPE_SECRET_KEY, expand=[], stripe_account=None
+            id=invoice.id,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            expand=[],
+            stripe_account=None,
         )
         self.assertTrue(return_value)
 

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.test.testcases import TestCase
 
 from djstripe.models import InvoiceItem
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_BALANCE_TRANSACTION,
@@ -190,7 +190,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
 
         invoice_retrieve_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             id=FAKE_INVOICE_II["id"],
             stripe_account=None,

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -10,7 +10,7 @@ from django.test.testcases import TestCase
 
 from djstripe.mixins import PaymentsContextMixin, SubscriptionMixin
 from djstripe.models import Plan
-from djstripe.settings import STRIPE_PUBLIC_KEY
+from djstripe.settings import djstripe_settings
 
 from . import FAKE_CUSTOMER, FAKE_PLAN, FAKE_PLAN_II, FAKE_PRODUCT
 
@@ -30,7 +30,7 @@ class TestPaymentsContextMixin(TestCase):
         )
         self.assertEqual(
             context["STRIPE_PUBLIC_KEY"],
-            STRIPE_PUBLIC_KEY,
+            djstripe_settings.STRIPE_PUBLIC_KEY,
             "Incorrect STRIPE_PUBLIC_KEY.",
         )
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 
 from djstripe.enums import PriceUsageType
 from djstripe.models import Plan, Product
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_PLAN,
@@ -42,7 +42,7 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
         plan = Plan.create(**fake_plan)
 
         expected_create_kwargs = deepcopy(FAKE_PLAN)
-        expected_create_kwargs["api_key"] = STRIPE_SECRET_KEY
+        expected_create_kwargs["api_key"] = djstripe_settings.STRIPE_SECRET_KEY
 
         plan_create_mock.assert_called_once_with(**expected_create_kwargs)
 
@@ -64,7 +64,7 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
         expected_create_kwargs["product"] = self.stripe_product
 
         plan_create_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY, **expected_create_kwargs
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **expected_create_kwargs
         )
 
         self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
@@ -83,7 +83,9 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
 
         plan = Plan.create(**fake_plan)
 
-        plan_create_mock.assert_called_once_with(api_key=STRIPE_SECRET_KEY, **FAKE_PLAN)
+        plan_create_mock.assert_called_once_with(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **FAKE_PLAN
+        )
 
         self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
 
@@ -104,7 +106,7 @@ class PlanCreateTest(AssertStripeFksMixin, TestCase):
         expected_create_kwargs["metadata"] = metadata
 
         plan_create_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY, **expected_create_kwargs
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **expected_create_kwargs
         )
 
         self.assert_fks(plan, expected_blank_fks={"djstripe.Customer.coupon"})
@@ -128,7 +130,7 @@ class PlanTest(AssertStripeFksMixin, TestCase):
         stripe_plan = self.plan.api_retrieve()
         plan_retrieve_mock.assert_called_once_with(
             id=self.plan_data["id"],
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
             stripe_account=None,
         )

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from djstripe.enums import PriceType, PriceUsageType
 from djstripe.models import Price, Product
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_PRICE,
@@ -41,7 +41,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
         price = Price.create(**fake_price)
 
         expected_create_kwargs = deepcopy(FAKE_PRICE)
-        expected_create_kwargs["api_key"] = STRIPE_SECRET_KEY
+        expected_create_kwargs["api_key"] = djstripe_settings.STRIPE_SECRET_KEY
 
         price_create_mock.assert_called_once_with(**expected_create_kwargs)
 
@@ -63,7 +63,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
         expected_create_kwargs["product"] = self.stripe_product
 
         price_create_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY, **expected_create_kwargs
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **expected_create_kwargs
         )
 
         self.assert_fks(price, expected_blank_fks={"djstripe.Customer.coupon"})
@@ -83,7 +83,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
         price = Price.create(**fake_price)
 
         price_create_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY, **FAKE_PRICE
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **FAKE_PRICE
         )
 
         self.assert_fks(price, expected_blank_fks={"djstripe.Customer.coupon"})
@@ -105,7 +105,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
         expected_create_kwargs["metadata"] = metadata
 
         price_create_mock.assert_called_once_with(
-            api_key=STRIPE_SECRET_KEY, **expected_create_kwargs
+            api_key=djstripe_settings.STRIPE_SECRET_KEY, **expected_create_kwargs
         )
 
         self.assert_fks(price, expected_blank_fks={"djstripe.Customer.coupon"})
@@ -135,7 +135,7 @@ class PriceTest(AssertStripeFksMixin, TestCase):
         stripe_price = self.price.api_retrieve()
         price_retrieve_mock.assert_called_once_with(
             id=self.price_data["id"],
-            api_key=STRIPE_SECRET_KEY,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=["tiers"],
             stripe_account=None,
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,18 +9,12 @@ from django.db.models.base import ModelBase
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from djstripe import settings as djstripe_settings
-from djstripe.settings import (
-    get_callback_function,
-    get_stripe_api_version,
-    get_subscriber_model,
-    set_stripe_api_version,
-)
+from djstripe import settings
 
 
 class TestSubscriberModelRetrievalMethod(TestCase):
     def test_with_user(self):
-        user_model = get_subscriber_model()
+        user_model = settings.djstripe_settings.get_subscriber_model()
         self.assertTrue(isinstance(user_model, ModelBase))
 
     @override_settings(
@@ -28,7 +22,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
         DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK=(lambda request: request.org),
     )
     def test_with_org(self):
-        org_model = get_subscriber_model()
+        org_model = settings.djstripe_settings.get_subscriber_model()
         self.assertTrue(isinstance(org_model, ModelBase))
 
     @override_settings(
@@ -36,7 +30,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
         DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK=(lambda request: request.org),
     )
     def test_with_org_static(self):
-        org_model = get_subscriber_model()
+        org_model = settings.djstripe_settings.get_subscriber_model()
         self.assertTrue(isinstance(org_model, ModelBase))
 
     @override_settings(
@@ -47,7 +41,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
         self.assertRaisesMessage(
             ImproperlyConfigured,
             "DJSTRIPE_SUBSCRIBER_MODEL must be of the form 'app_label.model_name'.",
-            get_subscriber_model,
+            settings.djstripe_settings.get_subscriber_model,
         )
 
     @override_settings(
@@ -59,7 +53,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
             ImproperlyConfigured,
             "DJSTRIPE_SUBSCRIBER_MODEL refers to model 'testapp.UnknownModel' "
             "that has not been installed.",
-            get_subscriber_model,
+            settings.djstripe_settings.get_subscriber_model,
         )
 
     @override_settings(
@@ -70,7 +64,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
         self.assertRaisesMessage(
             ImproperlyConfigured,
             "DJSTRIPE_SUBSCRIBER_MODEL must have an email attribute.",
-            get_subscriber_model,
+            settings.djstripe_settings.get_subscriber_model,
         )
 
     @override_settings(DJSTRIPE_SUBSCRIBER_MODEL="testapp.Organization")
@@ -79,7 +73,7 @@ class TestSubscriberModelRetrievalMethod(TestCase):
             ImproperlyConfigured,
             "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be implemented "
             "if a DJSTRIPE_SUBSCRIBER_MODEL is defined.",
-            get_subscriber_model,
+            settings.djstripe_settings.get_subscriber_model,
         )
 
     @override_settings(
@@ -90,67 +84,76 @@ class TestSubscriberModelRetrievalMethod(TestCase):
         self.assertRaisesMessage(
             ImproperlyConfigured,
             "DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must be callable.",
-            get_subscriber_model,
+            settings.djstripe_settings.get_subscriber_model,
         )
 
     @override_settings(DJSTRIPE_TEST_CALLBACK=(lambda: "ok"))
     def test_get_callback_function_with_valid_func_callable(self):
-        func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
+        func = settings.djstripe_settings.get_callback_function(
+            "DJSTRIPE_TEST_CALLBACK"
+        )
         self.assertEqual("ok", func())
 
     @override_settings(DJSTRIPE_TEST_CALLBACK="foo.valid_callback")
-    @patch.object(djstripe_settings, "import_string", return_value=(lambda: "ok"))
+    @patch.object(settings, "import_string", return_value=(lambda: "ok"))
     def test_get_callback_function_with_valid_string_callable(self, import_string_mock):
-        func = get_callback_function("DJSTRIPE_TEST_CALLBACK")
+        func = settings.djstripe_settings.get_callback_function(
+            "DJSTRIPE_TEST_CALLBACK"
+        )
         self.assertEqual("ok", func())
         import_string_mock.assert_called_with("foo.valid_callback")
 
     @override_settings(DJSTRIPE_TEST_CALLBACK="foo.non_existant_callback")
     def test_get_callback_function_import_error(self):
         with self.assertRaises(ImportError):
-            get_callback_function("DJSTRIPE_TEST_CALLBACK")
+            settings.djstripe_settings.get_callback_function("DJSTRIPE_TEST_CALLBACK")
 
     @override_settings(DJSTRIPE_TEST_CALLBACK="foo.invalid_callback")
-    @patch.object(djstripe_settings, "import_string", return_value="not_callable")
+    @patch.object(settings, "import_string", return_value="not_callable")
     def test_get_callback_function_with_non_callable_string(self, import_string_mock):
         with self.assertRaises(ImproperlyConfigured):
-            get_callback_function("DJSTRIPE_TEST_CALLBACK")
+            settings.djstripe_settings.get_callback_function("DJSTRIPE_TEST_CALLBACK")
         import_string_mock.assert_called_with("foo.invalid_callback")
 
     @override_settings(DJSTRIPE_TEST_CALLBACK="foo.non_existant_callback")
     def test_get_callback_function_(self):
         with self.assertRaises(ImportError):
-            get_callback_function("DJSTRIPE_TEST_CALLBACK")
+            settings.djstripe_settings.get_callback_function("DJSTRIPE_TEST_CALLBACK")
 
 
 @override_settings(STRIPE_API_VERSION=None)
 class TestGetStripeApiVersion(TestCase):
     def test_with_default(self):
         self.assertEqual(
-            djstripe_settings.DEFAULT_STRIPE_API_VERSION, get_stripe_api_version()
+            settings.djstripe_settings.DEFAULT_STRIPE_API_VERSION,
+            settings.djstripe_settings.get_stripe_api_version(),
         )
 
     @override_settings(STRIPE_API_VERSION="2016-03-07")
     def test_with_override(self):
-        self.assertEqual("2016-03-07", get_stripe_api_version())
+        self.assertEqual(
+            "2016-03-07", settings.djstripe_settings.get_stripe_api_version()
+        )
 
 
 @override_settings(STRIPE_API_VERSION=None)
 class TestSetStripeApiVersion(TestCase):
     def test_with_default(self):
-        djstripe_settings.set_stripe_api_version()
+        settings.djstripe_settings.set_stripe_api_version()
         self.assertEqual(
-            djstripe_settings.DEFAULT_STRIPE_API_VERSION, stripe.api_version
+            settings.djstripe_settings.DEFAULT_STRIPE_API_VERSION, stripe.api_version
         )
 
     def test_with_valid_date(self):
-        djstripe_settings.set_stripe_api_version(version="2016-03-07")
+        settings.djstripe_settings.set_stripe_api_version(version="2016-03-07")
         self.assertEqual("2016-03-07", stripe.api_version)
 
     def test_with_invalid_date(self):
         with self.assertRaises(ValueError):
-            set_stripe_api_version(version="foobar")
+            settings.djstripe_settings.set_stripe_api_version(version="foobar")
 
     def test_with_invalid_date_and_no_validation(self):
-        set_stripe_api_version(version="foobar", validate=False)
+        settings.djstripe_settings.set_stripe_api_version(
+            version="foobar", validate=False
+        )
         self.assertEqual("foobar", stripe.api_version)

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -7,7 +7,7 @@ import pytest
 from django.test import TestCase
 
 from djstripe.models import Account, Customer, StripeModel
-from djstripe.settings import STRIPE_SECRET_KEY
+from djstripe.settings import djstripe_settings
 
 
 class TestStripeModel(StripeModel):
@@ -38,7 +38,10 @@ class StripeModelExceptionsTest(TestCase):
 @pytest.mark.parametrize("stripe_account", (None, "acct_fakefakefakefake001"))
 @pytest.mark.parametrize(
     "api_key, expected_api_key",
-    ((None, STRIPE_SECRET_KEY), ("sk_fakefakefake01", "sk_fakefakefake01")),
+    (
+        (None, djstripe_settings.STRIPE_SECRET_KEY),
+        ("sk_fakefakefake01", "sk_fakefakefake01"),
+    ),
 )
 @pytest.mark.parametrize("extra_kwargs", ({}, {"foo": "bar"}))
 @patch.object(target=StripeModel, attribute="api_retrieve", autospec=True)
@@ -64,7 +67,10 @@ def test__api_delete(
 @pytest.mark.parametrize("stripe_account", (None, "acct_fakefakefakefake001"))
 @pytest.mark.parametrize(
     "api_key, expected_api_key",
-    ((None, STRIPE_SECRET_KEY), ("sk_fakefakefake01", "sk_fakefakefake01")),
+    (
+        (None, djstripe_settings.STRIPE_SECRET_KEY),
+        ("sk_fakefakefake01", "sk_fakefakefake01"),
+    ),
 )
 @pytest.mark.parametrize("expand_fields", ([], ["foo", "bar"]))
 @patch.object(target=StripeModel, attribute="stripe_class")

--- a/tests/test_zz_jsonfield.py
+++ b/tests/test_zz_jsonfield.py
@@ -4,15 +4,13 @@ Tests for JSONField
 Due to their nature messing with subclassing, these tests must be run last.
 """
 import sys
-from importlib import reload
 from unittest import skipUnless
 
 from django.test import TestCase
 from django.test.utils import override_settings
 from jsonfield import JSONField as UglyJSONField
 
-from djstripe import fields as fields
-from djstripe import settings as djstripe_settings
+from djstripe.fields import import_jsonfield
 
 try:
     try:
@@ -26,25 +24,11 @@ except ImportError:
 @override_settings(DJSTRIPE_USE_NATIVE_JSONFIELD=False)
 class TestFallbackJSONField(TestCase):
     def test_jsonfield_inheritance(self):
-        reload(djstripe_settings)
-        reload(fields)
-
-        self.assertTrue(issubclass(fields.JSONField, UglyJSONField))
-
-    def tearDown(self):
-        reload(djstripe_settings)
-        reload(fields)
+        self.assertTrue(issubclass(import_jsonfield(), UglyJSONField))
 
 
 @skipUnless("psycopg2" in sys.modules, "psycopg2 isn't present")
 @override_settings(DJSTRIPE_USE_NATIVE_JSONFIELD=True)
 class TestNativeJSONField(TestCase):
     def test_jsonfield_inheritance(self):
-        reload(djstripe_settings)
-        reload(fields)
-
-        self.assertTrue(issubclass(fields.JSONField, DjangoJSONField))
-
-    def tearDown(self):
-        reload(djstripe_settings)
-        reload(fields)
+        self.assertTrue(issubclass(import_jsonfield(), DjangoJSONField))


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR contains the following changes:

1. Refactored `djstripe.settings` module to expose all settings  as class properties of the `djstripe_settings` class object in the `djstripe.settings` module
2. Refactored `djstripe.fields` module to import `JSONField` in a function to avoid module import side-effects.
3. Updated the application code to access all settings via the `djstripe_settings` object
4. Updated the tests to access all settings via the `djstripe_settings` object and consequently simplified the tests.
5. Updated `docs` to ensure all references of changing settings from the `djstripe.settings` module get changed to `djstripe.settings.djstripe_settings` object.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

This PR accomplishes the following:
1. Encapsulates the logic to classes and functions to avoid side-effects of importing modules.
2. Allows one to dynamically update settings in the `django.conf` object and automatically get the updated values in `djstripe_settings` object. Currently being handled by `reloading` modules.
2. Fixes https://github.com/dj-stripe/dj-stripe/issues/1231
