### PR TITLE
SubscriptionItem objects will sync along with Subscription objects

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -822,6 +822,10 @@ class StripeModel(StripeBaseModel):
             item, _ = target_cls._get_or_create_from_stripe_object(
                 item_data, refetch=False
             )
+
+            # sync the SubscriptionItem
+            target_cls.sync_from_stripe_data(item_data)
+
             pks.append(item.pk)
             subscriptionitems.append(item)
         subscription.items.exclude(pk__in=pks).delete()


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->
This PR will now automatically sync `SubscriptionItem` objects whenever `Subscription` objects get synced. The only webhook that is fired when a `SubscriptionItem` gets updated is `customer.subscription.updated`. 

This PR needs to get merged for the webhooks to work smoothly: https://github.com/dj-stripe/dj-stripe/issues/1374
Fixes: https://github.com/dj-stripe/dj-stripe/issues/1352, https://github.com/dj-stripe/dj-stripe/issues/1089

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
So far, all implemented models in `dj-stripe` have an associated `Stripe Webhook` (exposed by Stripe) that would ultimately invoke the correct `CRUD` operation in `webhook.py` module. Unfortunately, Stripe has no such webhook for `SubscriptionItem` (even `InvoiceItem` has one!). And that is why this functionality was probably overlooked. 

