### PR TITLE
Added a Github Action that will help in closing stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs at mightnight daily
+  workflow_dispatch:  # to trigger manually
+
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 60 days.'
+          stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 60 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 60 days with no activity.'
+          days-before-stale: 180
+          days-before-close: 60
+          # never actually close a stale PR
+          days-before-pr-close: -1


### PR DESCRIPTION
After `180 days` of inactivity on an `issue or a PR`, a `comment` and `label` would be added. If there is still no activity within the next `60 days`, the **issue would be closed**. Note that **Stale PRs will never actually get closed**

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

To be able to manage all open issues and PRs, this automated action will nudge issue openers to not abandon the issue if they still need help while also helping keep the open issues and PRs manageable.