### PR TITLE
Dispute file creation

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -171,7 +171,7 @@ class Charge(StripeModel):
         related_name="charges",
         help_text="The customer associated with this charge.",
     )
-    # TODO Shouldn't this be on the Dispute model as charge field? Every dispute will have a Charge object
+
     dispute = StripeForeignKey(
         "Dispute",
         on_delete=models.SET_NULL,
@@ -1353,6 +1353,35 @@ class Dispute(StripeModel):
     def __str__(self):
         return f"{self.human_readable_amount} ({enums.DisputeStatus.humanize(self.status)}) "
 
+    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+
+        super()._attach_objects_post_save_hook(
+            cls, data, pending_relations=pending_relations
+        )
+
+        # Retrieve and save files from the dispute.evidence object.
+        # todo find a better way of retrieving and syncing File Type fields from Dispute object
+        for field in (
+            "cancellation_policy",
+            "customer_communication",
+            "customer_signature",
+            "duplicate_charge_documentation",
+            "receipt",
+            "refund_policy",
+            "service_documentation",
+            "shipping_documentation",
+            "uncategorized_file",
+        ):
+            file_upload_id = self.evidence.get(field, None)
+            if file_upload_id:
+                try:
+                    File.sync_from_stripe_data(File(id=file_upload_id).api_retrieve())
+                except stripe.error.PermissionError:
+                    # No permission to retrieve the data with the key
+                    pass
+                except stripe.error.InvalidRequestError:
+                    raise
+
 
 class Event(StripeModel):
     """
@@ -1984,7 +2013,6 @@ class Payout(StripeModel):
     )
     type = StripeEnumField(enum=enums.PayoutType)
 
-    # TODO Write corresponding test
     def __str__(self):
         return f"{self.amount} ({enums.PayoutStatus.humanize(self.status)})"
 
@@ -2249,6 +2277,7 @@ class Refund(StripeModel):
     status = StripeEnumField(
         blank=True, enum=enums.RefundStatus, help_text="Status of the refund."
     )
+    # todo implement source_transfer_reversal and transfer_reversal
 
     def get_stripe_dashboard_url(self):
         return self.charge.get_stripe_dashboard_url()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -793,7 +793,7 @@ FAKE_DISPUTE = {
         "duplicate_charge_explanation": None,
         "duplicate_charge_id": None,
         "product_description": None,
-        "receipt": "file_XXXXXXXXXXXXXXXXXXXXXXXX",
+        "receipt": "file_4hshrsKatMEEd6736724HYAXyj",
         "refund_policy": None,
         "refund_policy_disclosure": None,
         "refund_refusal_explanation": None,
@@ -1709,6 +1709,18 @@ FAKE_FILEUPLOAD_ICON = {
     "size": 6650,
     "type": "png",
     "url": "https://files.stripe.com/files/f_test_BTJFKcS7VDahgkjqw8EVNWlM",
+}
+
+FAKE_EVENT_FILE_CREATED = {
+    "id": "evt_1J5TusR44xKqawmIQVXSrGyf",
+    "object": "event",
+    "api_version": "2020-08-27",
+    "created": 1439229084,
+    "data": {"object": deepcopy(FAKE_FILEUPLOAD_ICON)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": "req_sTSstDDIOpKi2w",
+    "type": "file.created",
 }
 
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR contains the following changes:

1. Allowed File objects created during the dispute resolution process to get synced correctly using the `Dispute._attach_objects_post_save_hook()` method
2. Added ability to handle `file.created` webhook events. That is the only `File` object event supported by Stripe.
3. Refactored `charge.*` and `charge.dispute.*` webhook events to avoid future bugs because of mismatch between `event.type` and `target_cls attributes`.
4. Updated corresponding tests 

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Support for `File` objects will be improved.