### PR TITLE
Improved management command formatting and output

### DIFF
--- a/djstripe/management/commands/djstripe_init_customers.py
+++ b/djstripe/management/commands/djstripe_init_customers.py
@@ -16,9 +16,13 @@ class Command(BaseCommand):
         """
         Create Customer objects for Subscribers without Customer objects associated.
         """
-        for subscriber in djstripe_settings.get_subscriber_model().objects.filter(
+        subscriber_qs = djstripe_settings.get_subscriber_model().objects.filter(
             djstripe_customers=None
-        ):
-            # use get_or_create in case of race conditions on large subscriber bases
-            Customer.get_or_create(subscriber=subscriber)
-            print("Created subscriber for {0}".format(subscriber.email))
+        )
+        if subscriber_qs:
+            for subscriber in subscriber_qs:
+                # use get_or_create in case of race conditions on large subscriber bases
+                Customer.get_or_create(subscriber=subscriber)
+                self.stdout.write(f"Created subscriber for {subscriber.email}")
+        else:
+            self.stdout.write("All Customers already have subscribers")

--- a/djstripe/management/commands/djstripe_process_events.py
+++ b/djstripe/management/commands/djstripe_process_events.py
@@ -98,19 +98,13 @@ class Command(VerbosityAwareOutputMixin, BaseCommand):
                 total += 1
                 event = models.Event.process(data=event_data)
                 count += 1
-                self.verbose_output("  Synced Event {id}".format(id=event.id))
+                self.verbose_output(f"\tSynced Event {event.id}")
             except Exception as exception:
-                self.verbose_output(
-                    "  Failed processing Event {id}".format(id=event_data["id"])
-                )
-                self.output("  {exception}".format(exception=exception))
+                self.verbose_output(f"\tFailed processing Event {event_data['id']}")
+                self.output(f"\t{exception}")
                 self.verbose_traceback()
 
         if total == 0:
-            self.output("  (no results)")
+            self.output("\t(no results)")
         else:
-            self.output(
-                "  Processed {count} out of {total} Events".format(
-                    count=count, total=total
-                )
-            )
+            self.output(f"\tProcessed {count} out of {total} Events")


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR contains the following changes:

1. Replaced 2 spaces with a tab character for consistency
2. Updated the code to inform the user when they already have the customers in the DB. Earlier the management command init_customers would not inform the users that they already have the customers


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Makes the management commands a bit more user friendly.
