### PR TITLE
Updated TaxId model to better support Stripe Events

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -996,22 +996,6 @@ class InvoiceItem(StripeModel):
                 cls._stripe_object_to_tax_rates(target_cls=TaxRate, data=data)
             )
 
-    @classmethod
-    def sync_from_stripe_data(cls, data):
-        invoice_data = data.get("invoice")
-
-        if invoice_data:
-            # sync the Invoice first if it doesn't yet exist in our DB
-            # to avoid recursive Charge/Invoice loop
-            invoice_id = cls._id_from_data(invoice_data)
-            if not Invoice.objects.filter(id=invoice_id).exists():
-                if invoice_id == invoice_data:
-                    # we only have the id, fetch the full data
-                    invoice_data = Invoice(id=invoice_id).api_retrieve()
-                Invoice.sync_from_stripe_data(data=invoice_data)
-
-        return super().sync_from_stripe_data(data)
-
     def __str__(self):
         return self.description
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1800,7 +1800,6 @@ class SubscriptionSchedule(StripeModel):
     )
 
 
-# TODO Add Tests
 class TaxId(StripeModel):
     """
     Add one or multiple tax IDs to a customer.

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -25,6 +25,7 @@ from ..managers import SubscriptionManager
 from ..settings import djstripe_settings
 from ..utils import QuerySetMock, get_friendly_currency_amount
 from .base import StripeModel
+from .core import Customer
 
 
 # TODO Add Tests
@@ -86,6 +87,16 @@ class DjstripeUpcomingInvoiceTotalTaxAmount(models.Model):
 
 
 class Coupon(StripeModel):
+    """
+    A coupon contains information about a percent-off or amount-off discount you might want to apply to a customer.
+    Coupons may be applied to invoices or orders.
+    Coupons do not work with conventional one-off charges.
+
+    Stripe documentation: https://stripe.com/docs/api/coupons
+    """
+
+    stripe_class = stripe.Coupon
+
     id = StripeIdField(max_length=500)
     amount_off = StripeDecimalCurrencyAmountField(
         null=True,
@@ -1807,6 +1818,14 @@ class SubscriptionSchedule(StripeModel):
 
 # TODO Add Tests
 class TaxId(StripeModel):
+    """
+    Add one or multiple tax IDs to a customer.
+    A customer's tax IDs are displayed on invoices and
+    credit notes issued for the customer.
+
+    Stripe documentation: https://stripe.com/docs/api/customer_tax_ids
+    """
+
     stripe_class = stripe.TaxId
     description = None
     metadata = None
@@ -1825,27 +1844,70 @@ class TaxId(StripeModel):
     verification = JSONField(help_text="Tax ID verification information.")
 
     def __str__(self):
-        return self.value
+        return f"{enums.TaxIdType.humanize(self.type)} {self.value} ({self.verification.get('status')})"
 
     class Meta:
         verbose_name = "Tax ID"
         verbose_name_plural = "Tax IDs"
 
+    @classmethod
+    def _api_create(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):
+        """
+        Call the stripe API's create operation for this model.
+
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        """
+
+        if not kwargs.get("id"):
+            raise KeyError("Customer Object ID is missing")
+
+        try:
+            Customer.objects.get(id=kwargs["id"])
+        except Customer.DoesNotExist:
+            raise
+
+        return stripe.Customer.create_tax_id(api_key=api_key, **kwargs)
+
     def api_retrieve(self, api_key=None, stripe_account=None):
+        """
+        Call the stripe API's retrieve operation for this model.
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        :param stripe_account: The optional connected account \
+            for which this request is being made.
+        :type stripe_account: string
+        """
+        nested_id = self.id
+        id = self.customer.id
+
+        # Prefer passed in stripe_account if set.
         if not stripe_account:
             stripe_account = self._get_stripe_account_id(api_key)
 
-        customer = self.customer.api_retrieve(
-            api_key=api_key or self.default_api_key,
-            stripe_account=stripe_account,
-        )
-        return customer.retrieve_tax_id(
-            customer.id,
-            self.id,
+        return stripe.Customer.retrieve_tax_id(
+            id=id,
+            nested_id=nested_id,
             api_key=api_key or self.default_api_key,
             expand=self.expand_fields,
             stripe_account=stripe_account,
         )
+
+    @classmethod
+    def api_list(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):
+        """
+        Call the stripe API's list operation for this model.
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        See Stripe documentation for accepted kwargs for each object.
+        :returns: an iterator over all items in the query
+        """
+        return stripe.Customer.list_tax_ids(
+            api_key=api_key, **kwargs
+        ).auto_paging_iter()
 
 
 class TaxRate(StripeModel):

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -518,7 +518,6 @@ class Card(LegacySourceMixin, StripeModel):
         return stripe.Token.create(api_key=api_key, card=card)
 
 
-#  todo imporve str_parts
 class Source(StripeModel):
     """
     Stripe documentation: https://stripe.com/docs/api#sources
@@ -764,7 +763,10 @@ class PaymentMethod(StripeModel):
 
     def _attach_objects_hook(self, cls, data, current_ids=None):
         customer = None
-        if current_ids is None or data.get("customer") not in current_ids:
+        # "customer" key could be like "cus_6lsBvm5rJ0zyHc" or {"id": "cus_6lsBvm5rJ0zyHc"}
+        customer_id = cls._id_from_data(data.get("customer"))
+
+        if current_ids is None or customer_id not in current_ids:
             customer = cls._stripe_object_to_customer(
                 target_cls=Customer, data=data, current_ids=current_ids
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1459,6 +1459,43 @@ FAKE_TAX_RATE_EXAMPLE_2_SALES = load_fixture(
     "tax_rate_txr_fakefakefakefakefake0002.json"
 )
 
+FAKE_TAX_ID = load_fixture("tax_id_txi_fakefakefakefakefake0001.json")
+
+
+FAKE_EVENT_TAX_ID_CREATED = {
+    "id": "evt_16YKQi2eZvKYlo2CT2oe5ff3",
+    "object": "event",
+    "api_version": "2020-08-27",
+    "created": 1439229084,
+    "data": {"object": deepcopy(FAKE_TAX_ID)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": "req_ZoH080M8fny6yR",
+    "type": "customer.tax_id.created",
+}
+
+FAKE_TAX_ID_UPDATED = deepcopy(FAKE_TAX_ID)
+FAKE_TAX_ID_UPDATED["verification"] = {
+    "status": "verified",
+    "verified_address": None,
+    "verified_name": "Test",
+}
+
+FAKE_EVENT_TAX_ID_UPDATED = {
+    "id": "evt_1J6Fy3JSZQVUcJYgnddjnMzx",
+    "object": "event",
+    "api_version": "2020-08-27",
+    "created": 1439229084,
+    "data": {"object": deepcopy(FAKE_TAX_ID_UPDATED)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": "req_ZoH080M8fny6yR",
+    "type": "customer.tax_id.updated",
+}
+
+FAKE_EVENT_TAX_ID_DELETED = deepcopy(FAKE_EVENT_TAX_ID_UPDATED)
+FAKE_EVENT_TAX_ID_DELETED["type"] = "customer.tax_id.deleted"
+
 FAKE_INVOICEITEM = {
     "id": "ii_16XVTY2eZvKYlo2Cxz5n3RaS",
     "object": "invoiceitem",

--- a/tests/fixtures/tax_id_txi_fakefakefakefakefake0001.json
+++ b/tests/fixtures/tax_id_txi_fakefakefakefakefake0001.json
@@ -1,0 +1,15 @@
+{
+    "id": "txi_1J5NznJSZQVUcJYgGWkyTcvb",
+    "object": "tax_id",
+    "livemode": false,
+    "created": 1570435136,
+    "country": "US",
+    "customer": "cus_6lsBvm5rJ0zyHc",
+    "type": "us_ein",
+    "value": "12-0982347",
+    "verification": {
+        "status": "unavailable",
+        "verified_address": null,
+        "verified_name": null
+    }
+}

--- a/tests/test_tax_id.py
+++ b/tests/test_tax_id.py
@@ -1,0 +1,190 @@
+"""
+dj-stripe TaxId model tests
+"""
+from copy import deepcopy
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from django.test.testcases import TestCase
+
+from djstripe import enums
+from djstripe.models.billing import TaxId
+from djstripe.models.core import Customer
+from djstripe.settings import djstripe_settings
+
+from . import (
+    FAKE_CUSTOMER,
+    FAKE_TAX_ID,
+    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    AssertStripeFksMixin,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class TestTaxIdStr:
+    @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Customer.retrieve_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test___str__(
+        self,
+        tax_id_retrieve_mock,
+        customer_retrieve_mock,
+    ):
+
+        tax_id = TaxId.sync_from_stripe_data(FAKE_TAX_ID)
+        assert (
+            str(tax_id)
+            == f"{enums.TaxIdType.humanize(FAKE_TAX_ID['type'])} {FAKE_TAX_ID['value']} ({FAKE_TAX_ID['verification']['status']})"
+        )
+
+
+class TestTransfer(AssertStripeFksMixin, TestCase):
+    @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Customer.retrieve_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test_sync_from_stripe_data(
+        self,
+        tax_id_retrieve_mock,
+        customer_retrieve_mock,
+    ):
+
+        tax_id = TaxId.sync_from_stripe_data(FAKE_TAX_ID)
+        assert tax_id.id == FAKE_TAX_ID["id"]
+        assert tax_id.customer.id == FAKE_CUSTOMER["id"]
+        self.assert_fks(
+            tax_id,
+            expected_blank_fks={
+                "djstripe.Customer.coupon",
+                "djstripe.Customer.default_payment_method",
+                "djstripe.Customer.subscriber",
+            },
+        )
+
+    # we are returning any value for the Customer.objects.get as we only need to avoid the Customer.DoesNotExist error
+    @patch(
+        "djstripe.models.core.Customer.objects.get",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Customer.create_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test__api_create(
+        self,
+        tax_id_create_mock,
+        customer_get_mock,
+    ):
+
+        STRIPE_DATA = TaxId._api_create(
+            id=FAKE_CUSTOMER["id"], type=FAKE_TAX_ID["type"], value=FAKE_TAX_ID["value"]
+        )
+
+        assert STRIPE_DATA == FAKE_TAX_ID
+        tax_id_create_mock.assert_called_once_with(
+            id=FAKE_CUSTOMER["id"],
+            type=FAKE_TAX_ID["type"],
+            value=FAKE_TAX_ID["value"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        )
+
+    # we are returning any value for the Customer.objects.get as we only need to avoid the Customer.DoesNotExist error
+    @patch(
+        "djstripe.models.core.Customer.objects.get",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Customer.create_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test__api_create_no_id_kwarg(
+        self,
+        tax_id_create_mock,
+        customer_get_mock,
+    ):
+        with pytest.raises(KeyError) as exc:
+            TaxId._api_create(
+                FAKE_CUSTOMER["id"],
+                type=FAKE_TAX_ID["type"],
+                value=FAKE_TAX_ID["value"],
+            )
+        assert "Customer Object ID is missing" in str(exc.value)
+
+    @patch(
+        "stripe.Customer.create_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test__api_create_no_customer(
+        self,
+        tax_id_create_mock,
+    ):
+        with pytest.raises(Customer.DoesNotExist):
+            TaxId._api_create(
+                id=FAKE_CUSTOMER["id"],
+                type=FAKE_TAX_ID["type"],
+                value=FAKE_TAX_ID["value"],
+            )
+
+    @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Customer.retrieve_tax_id",
+        return_value=deepcopy(FAKE_TAX_ID),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test_api_retrieve(
+        self,
+        tax_id_retrieve_mock,
+        customer_retrieve_mock,
+    ):
+
+        tax_id = TaxId.sync_from_stripe_data(FAKE_TAX_ID)
+        tax_id.api_retrieve()
+
+        tax_id_retrieve_mock.assert_called_once_with(
+            id=FAKE_CUSTOMER["id"],
+            nested_id=FAKE_TAX_ID["id"],
+            expand=[],
+            stripe_account=None,
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        )
+
+    @patch(
+        "stripe.Customer.list_tax_ids",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    def test_api_list(
+        self,
+        tax_id_list_mock,
+    ):
+        p = PropertyMock(return_value=deepcopy(FAKE_TAX_ID))
+        type(tax_id_list_mock).auto_paging_iter = p
+
+        TaxId.api_list(id=FAKE_CUSTOMER["id"])
+
+        tax_id_list_mock.assert_called_once_with(
+            id=FAKE_CUSTOMER["id"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR contains the following changes:

1. Updated `PaymentMethod._attach_objects_hook` to handle nested `Customer` Object.
2. Updated `TaxId` with custom methods to `retrieve`, `list`, and `create` TaxId. This in turn would also allow them to get synced with data from stripe using the `djstripe_sync_models`
3. Updated `TaxId.__str__` to better reflect what is displayed on the Stripe Dashboard.
4. Removed `InvoiceItem.sync_from_stripe_data()` as Infinite Recursive Sync was addressed in #1387
5. Added tests for `TaxId` model in its custom module as well as updated the module `test_event_handlers` to handle all `customer.taxid.*` webhook events



Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
This would greatly improve support for `TaxId` model