### PR TITLE
Fixed bug in djstripe_settings object setattr and delattr methods

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -42,10 +42,10 @@ class DjstripeSettings:
 
     # generic setter and deleter methods to ensure object patching works
     def __setattr__(self, name, value):
-        self.__dict__["name"] = value
+        self.__dict__[name] = value
 
     def __delattr__(self, name):
-        del self.__dict__["name"]
+        del self.__dict__[name]
 
     @property
     def SUBSCRIPTION_REDIRECT(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -157,3 +157,14 @@ class TestSetStripeApiVersion(TestCase):
             version="foobar", validate=False
         )
         self.assertEqual("foobar", stripe.api_version)
+
+
+class TestObjectPatching(TestCase):
+    @patch.object(
+        settings.djstripe_settings,
+        "DJSTRIPE_WEBHOOK_URL",
+        return_value=r"^webhook/sample/$",
+    )
+    def test_object_patching(self, mock):
+        webhook_url = settings.djstripe_settings.DJSTRIPE_WEBHOOK_URL
+        self.assertTrue(webhook_url, r"^webhook/sample/$")


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR addresses a bug in how `djstripe_settings` object was getting patched. `"name"` was written instead of `name` which was causing incorrect `key:value` pair getting created whenever anyone tried to patch the `djstripe_settings` object.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
