### PR TITLE
Blank currency & subscriber fields in customer model

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -752,6 +752,7 @@ class Migration(migrations.Migration):
                 (
                     "currency",
                     djstripe.fields.StripeCurrencyCodeField(
+                        blank=True,
                         default="",
                         help_text="The currency the customer can be charged in for recurring billing purposes",
                         max_length=3,
@@ -813,6 +814,7 @@ class Migration(migrations.Migration):
                 (
                     "subscriber",
                     models.ForeignKey(
+                        blank=True,
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="djstripe_customers",

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -614,6 +614,7 @@ class Customer(StripeModel):
         ),
     )
     currency = StripeCurrencyCodeField(
+        blank=True,
         default="",
         help_text="The currency the customer can be charged in for "
         "recurring billing purposes",
@@ -701,6 +702,7 @@ class Customer(StripeModel):
     # dj-stripe fields
     subscriber = models.ForeignKey(
         djstripe_settings.get_subscriber_model_string(),
+        blank=True,
         null=True,
         on_delete=models.SET_NULL,
         related_name="djstripe_customers",


### PR DESCRIPTION
## Description

Allow for a blank field in `currency` & `subscriber` in customer model.

Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

Fix #1408 