### PR TITLE
Added github action to auto update pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,0 +1,35 @@
+# Run pre-commit autoupdate every day at midnight
+# and create PRs for any updates
+
+
+name: Pre-commit auto-update
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch: # to trigger manually
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit autoupdate
+      run: pre-commit autoupdate
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3.10.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: update/pre-commit-autoupdate
+        title: Auto-update pre-commit hooks
+        commit-message: Auto-update pre-commit hooks
+        body: Update versions of tools in pre-commit configs to latest version
+        labels: update


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR will allow all `pre-commit` hooks to automatically get updated. A cron job will check every day at midnight for updates and in case of an update, a PR will be raised.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will make the lives of the maintainers slightly easier!