### PR TITLE
Warn User if unable to retrieve Business icon or logo

### DIFF
--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -6,7 +6,7 @@ from ..enums import APIKeyType
 from ..fields import JSONField, StripeCurrencyCodeField, StripeEnumField
 from ..settings import djstripe_settings
 from .api import APIKey
-from .base import StripeModel
+from .base import StripeModel, logger
 
 
 class Account(StripeModel):
@@ -201,7 +201,9 @@ class Account(StripeModel):
                     )
                 except stripe.error.PermissionError:
                     # No permission to retrieve the data with the key
-                    pass
+                    logger.warning(
+                        f"Cannot retrieve business branding {field} for acct {self.id} with the key."
+                    )
                 except stripe.error.InvalidRequestError as e:
                     if "a similar object exists in" in str(e):
                         # HACK around a Stripe bug.


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->
This PR logs a warning to the console in case we are unable to retrieve the `icon` or `logo` of a Stripe Account.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will give the user a bit more information about any "weird" stripe behaviours.
