### PR TITLE
Added Missing Checkout Session Sync Functionality

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -403,6 +403,13 @@ class SetupIntentAdmin(StripeModelAdmin):
     search_fields = ("customer__id", "status")
 
 
+@admin.register(models.Session)
+class SessionAdmin(StripeModelAdmin):
+    list_display = ("customer", "customer_email")
+    list_filter = ("customer", "mode")
+    search_fields = ("customer__id", "customer_email")
+
+
 @admin.register(models.Invoice)
 class InvoiceAdmin(StripeModelAdmin):
     list_display = ("total", "paid", "currency", "number", "customer", "due_date")

--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -224,6 +224,7 @@ def dispute_webhook_handler(event):
 
 
 @webhooks.handler(
+    "checkout",
     "coupon",
     "file",
     "invoice",
@@ -240,11 +241,12 @@ def dispute_webhook_handler(event):
 )
 def other_object_webhook_handler(event):
     """
-    Handle updates to coupon, file, invoice, invoiceitem, payment_intent,
+    Handle updates to checkout, coupon, file, invoice, invoiceitem, payment_intent,
     plan, product, setup_intent, subscription_schedule, source, tax_rate
     and transfer objects.
 
     Docs for:
+    - checkout: https://stripe.com/docs/api/checkout/sessions
     - coupon: https://stripe.com/docs/api/coupons
     - file: https://stripe.com/docs/api/files
     - invoice: https://stripe.com/docs/api/invoices
@@ -261,6 +263,7 @@ def other_object_webhook_handler(event):
     """
 
     target_cls = {
+        "checkout": models.Session,
         "coupon": models.Coupon,
         "file": models.File,
         "invoice": models.Invoice,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2006,6 +2006,18 @@ FAKE_EVENT_DISPUTE_FUNDS_REINSTATED_PARTIAL = {
     "type": "charge.dispute.funds_reinstated",
 }
 
+FAKE_EVENT_SESSION_COMPLETED = {
+    "id": "evt_1JAyTxJSZQVUcJYgNk1Jqu8o",
+    "object": "event",
+    "api_version": "2020-08-27",
+    "created": 1439229084,
+    "data": {"object": deepcopy(FAKE_SESSION_I)},
+    "livemode": False,
+    "pending_webhooks": 0,
+    "request": "req_6lsB7hkicwhaDj",
+    "type": "checkout.session.completed",
+}
+
 
 FAKE_EVENT_INVOICE_CREATED = {
     "id": "evt_187IHD2eZvKYlo2C6YKQi2eZ",

--- a/tests/apps/example/templates/checkout.html
+++ b/tests/apps/example/templates/checkout.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <title>Checkout</title>
+    <script src="https://js.stripe.com/v3/"></script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      // Create a Stripe client.
+      var stripe = Stripe("{{STRIPE_PUBLIC_KEY}}");
+      stripe.redirectToCheckout({
+        // Get the id field from the Checkout Session creation API response
+            sessionId: '{{CHECKOUT_SESSION_ID}}'
+        })
+        .then(function (result) {
+            // If `redirectToCheckout` fails due to a browser or network
+            // error, display the localized error message to your customer
+            // using `result.error.message`.
+            if (result.error) {
+                alert(result.error.message);
+            }
+        })
+        .catch(function (error) {
+          console.error("Error:", error);
+       });
+    </script>
+  </body>
+</html>

--- a/tests/apps/example/templates/checkout_success.html
+++ b/tests/apps/example/templates/checkout_success.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block title %}Thanks for your order!{% endblock %}
+
+{% block content %}
+    <p>
+      We appreciate your business! If you have any questions, please email
+      <a href="mailto:orders@example.com">orders@example.com</a>.
+    </p>
+{% endblock content %}

--- a/tests/apps/example/urls.py
+++ b/tests/apps/example/urls.py
@@ -6,6 +6,12 @@ app_name = "djstripe_example"
 
 urlpatterns = [
     path(
+        "checkout/",
+        views.CreateCheckoutSessionView.as_view(),
+        name="checkout",
+    ),
+    path("success/", views.CheckoutSessionSuccessView.as_view(), name="success"),
+    path(
         "purchase-subscription",
         views.PurchaseSubscriptionView.as_view(),
         name="purchase_subscription",


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This PR contains the following changes:

1. Exposed `Session` model on the admin.
2. Updated code in the `example` app to demonstrate how to create a Stripe Checkout Session. This would also double up as a way to run quick tests on djstripe code changes related to `Checkouts` as well since they require user input.
3. `Session` model will now sync when any of the `checkout.session.completed` or `checkout.session.async_payment_completed` or `checkout.session.async_payment_failed` webhooks get fired. Also tested manually for `bacs_debit` payment method type.
4. Added Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`djstripe` support for `Stripe Checkout Sessions` will be improved as earlier `checkout` webhooks were not getting synced and there were no tests for any of the 3 checkout webhooks either. Also updated code in the `example` app to better demonstrate how to create a `Checkout` Session.

Fix: #1336