### PR TITLE
Add customer subscriber metadata

### DIFF
--- a/docs/usage/using_stripe_checkout.md
+++ b/docs/usage/using_stripe_checkout.md
@@ -1,0 +1,7 @@
+# Create a Stripe Checkout Session
+
+
+For your convenience, dj-stripe has provided an example implementation on how to use `Checkouts` [here](../../tests/apps/example/views.py)
+
+
+Please note that in order for dj-stripe to create a link between your `customers` and your `subscribers`, you need to add the `DJSTRIPE_SUBSCRIBER_CUSTOMER_KEY` key to the `metadata` parameter of `Checkout`. This has also been demonstrated in the aforementioned [example](../../tests/apps/example/views.py)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1864,6 +1864,10 @@ FAKE_EVENT_CUSTOMER_CREATED = {
     "type": "customer.created",
 }
 
+FAKE_EVENT_CUSTOMER_UPDATED = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
+FAKE_EVENT_CUSTOMER_UPDATED["type"] = "customer.updated"
+
+
 FAKE_EVENT_CUSTOMER_DELETED = deepcopy(FAKE_EVENT_CUSTOMER_CREATED)
 FAKE_EVENT_CUSTOMER_DELETED.update(
     {"id": "evt_38DHch3whaDvKYlo2jksfsFFxy", "type": "customer.deleted"}


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

This PR builds on top of https://github.com/dj-stripe/dj-stripe/pull/1415. Please merge that before merging this


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Newly `created/updated` customers on Stripe that have the `DJSTRIPE_SUBSCRIBER_CUSTOMER_KEY` set will have their `subscriber` key updated correctly. Please note that this happens if and onty if the `customer`, `subscriber`, and the `SUBSCRIBER_CUSTOMER_KEY` are all present. Both cases of customer creation from `Checkout` as well as manual creation from the stripe `dashboard` have been handled.
2. Updated the `example` app in the `tests` directory on how to use `metadata` in Stripe Checkout.
3. Updated `Usage docs` with an example on how to use `Checkouts` with djstripe.
4. Added Corresponding Tests.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix #911 
Fix #1402
Fix #1403

Will improve the sync ability of `djstripe` in general.