### PR TITLE
Added tests to ensure Customer.subscriber FK points to the correct configured model

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,43 @@
+"""
+dj-stripe Migrations Tests
+"""
+import pytest
+
+from django.test import TestCase, override_settings
+from django.conf import settings
+from djstripe.settings import djstripe_settings
+from djstripe.models.core import Customer
+from django.contrib.auth import get_user_model
+
+class TestCustomerSubscriberFK(TestCase):
+
+    @override_settings(
+        DJSTRIPE_SUBSCRIBER_MODEL="testapp.Organization",
+        DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK=(lambda request: request.org),
+    )
+    def setUp(self):
+        return super().setUp()
+
+
+    def test_customer_subscriber_fk_to_subscriber_model(self):
+        """
+        Test to ensure customer.subscriber fk points to the configured model
+        set by DJSTRIPE_SUBSCRIBER_MODEL
+        """
+        field = Customer._meta.get_field("subscriber")
+
+        self.assertEqual(field.related_model, djstripe_settings.get_subscriber_model())
+        self.assertNotEqual(field.related_model, settings.AUTH_USER_MODEL)
+
+
+    def test_customer_subscriber_fk_fallback_to_auth_user_model(self):
+        """
+        Test to ensure customer.subscriber fk points to the fallback AUTH_USER_MODEL 
+        when DJSTRIPE_SUBSCRIBER_MODEL is not set
+        """
+        # assert DJSTRIPE_SUBSCRIBER_MODEL has not been set
+        with pytest.raises(AttributeError):
+            settings.DJSTRIPE_SUBSCRIBER_MODEL
+
+        field = Customer._meta.get_field("subscriber")    
+        self.assertEqual(field.related_model, get_user_model())


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR adds tests to ensure `Customer.subscriber` FK will point to the model set by `DJSTRIPE_SUBSCRIBER_MODEL` and only when it is unset that will it point to the `AUTH_USER_MODEL `

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

This will catch cases when squashing migrations for a release will overwrite to `to` field for `Customer.subscriber` to point to 
the `AUTH_USER_MODEL ` instead of the model set by `DJSTRIPE_SUBSCRIBER_MODEL` 

Fix: #1418