### PR TITLE
Customers can be subscribed to multiple plans

### DIFF
--- a/docs/usage/subscribing_customers.md
+++ b/docs/usage/subscribing_customers.md
@@ -1,25 +1,52 @@
-# Subscribing a customer to a price (or plan)
+# Subscribing a customer to one or more prices (or plans)
 
 For your convenience, dj-stripe provides a
 `djstripe.models.Customer.subscribe` method that will try to charge the
 customer immediately unless you specify `charge_immediately=False`
 
 ```py
-price = Price.objects.get(nickname="one_price")
+# Recommended Approach to use items dict with Prices
+## This will subscribe <customer> to both <price_1> and <price_2>
+price_1 = Price.objects.get(nickname="one_price")
+price_2 = Price.objects.get(nickname="two_price")
 customer = Customer.objects.first()
-customer.subscribe(price=price)
+customer.subscribe(items=[{"price": price_1}, {"price": price_2}])
+
+## This will subscribe <customer> to <price_1>
+price_1 = Price.objects.get(nickname="one_price")
+customer = Customer.objects.first()
+customer.subscribe(items=[{"price": price_1}])
+
+
+## (Alternate Approach) This will subscribe <customer> to <price_1>
+price_1 = Price.objects.get(nickname="one_price")
+customer = Customer.objects.first()
+customer.subscribe(price=price_1)
 
 # If you still use legacy Plans...
-plan = Plan.objects.get(nickname="one_plan")
+## This will subscribe <customer> to both <plan_1> and <plan_2>
+plan_1 = Plan.objects.get(nickname="one_plan")
+plan_2 = Plan.objects.get(nickname="two_plan")
 customer = Customer.objects.first()
-customer.subscribe(plan=plan)
+customer.subscribe(items=[{"plan": plan_1}, {"plan": plan_2}])
+
+## This will subscribe <customer> to <plan_1>
+plan_1 = Plan.objects.get(nickname="one_plan")
+customer = Customer.objects.first()
+customer.subscribe(items=[{"plan": plan_1}])
+
+
+## (Alternate Approach) This will subscribe <customer> to <plan_1>
+plan_1 = Plan.objects.get(nickname="one_plan")
+customer = Customer.objects.first()
+customer.subscribe(plan=plan_1)
 ```
 
 However in some cases `djstripe.models.Customer.subscribe` might not
 support all the arguments you need for your implementation. When this
 happens you can just call the official `stripe.Customer.subscribe()`.
 
-See this example from
+See [this](../../tests/apps/example/views.py) example from
 `tests.apps.example.views.PurchaseSubscriptionView.form_valid`.
 
 Note that PaymentMethods can be used instead of Cards/Source by


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `Customer.subscribe()` to allow a `customer` to be subscribed to multiple plans
2. Updated documentation with code on how to subscribe a customer to more than one plan using `Customer.subscribe()`
3. Updated Corresponding Tests.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve parity with Stripe by allowing 1 customer to be subscribed to multiple plans in one go.

Fixes: #1285
Fixes: #1324