### PR TITLE
Updated Subscription.__str__ to better reflect Stripe Dashboard

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1454,9 +1454,15 @@ class Subscription(StripeModel):
     objects = SubscriptionManager()
 
     def __str__(self):
-        return "{customer} on {plan}".format(
-            customer=str(self.customer), plan=str(self.plan)
-        )
+
+        subscriptions_lst = self.customer._get_valid_subscriptions()
+        products_lst = [
+            subscription.plan.product.name
+            for subscription in subscriptions_lst
+            if subscription and subscription.plan
+        ]
+
+        return f"{self.customer} on {' and '.join(products_lst)}"
 
     def update(
         self,


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated the `str` representation of `Subscription` objects to better reflect with how they are displayed on Stripe.
2. Added corresponding Tests.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve parity with Stripe especially for customers subscribing to more than 1 plan.
Fixes: #1290