### PR TITLE
Replaced get_stripe_api_version() method with STRIPE_API_VERSION property

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -52,7 +52,7 @@ def check_stripe_api_version(app_configs=None, **kwargs):
 
     messages = []
     default_version = djstripe_settings.DEFAULT_STRIPE_API_VERSION
-    version = djstripe_settings.get_stripe_api_version()
+    version = djstripe_settings.STRIPE_API_VERSION
 
     if not validate_stripe_api_version(version):
         msg = "Invalid Stripe API version: {}".format(version)

--- a/djstripe/context_managers.py
+++ b/djstripe/context_managers.py
@@ -15,7 +15,7 @@ def stripe_temporary_api_version(version, validate=True):
     The original value is restored as soon as context exits.
     """
 
-    old_version = djstripe_settings.get_stripe_api_version()
+    old_version = djstripe_settings.STRIPE_API_VERSION
 
     try:
         djstripe_settings.set_stripe_api_version(version, validate=validate)

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -147,6 +147,12 @@ class DjstripeSettings:
             STRIPE_PUBLIC_KEY = getattr(settings, "STRIPE_TEST_PUBLIC_KEY", "")
         return STRIPE_PUBLIC_KEY
 
+    @property
+    def STRIPE_API_VERSION(self):
+        """Get the desired API version to use for Stripe requests."""
+        version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
+        return version or self.DEFAULT_STRIPE_API_VERSION
+
     def get_callback_function(self, setting_name, default=None):
         """
         Resolve a callback function based on a setting name.
@@ -254,13 +260,6 @@ class DjstripeSettings:
 
         return subscriber_model
 
-    # TODO convert to STRIPE_API_VERSION property
-    def get_stripe_api_version(self):
-        """Get the desired API version to use for Stripe requests."""
-        version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
-        return version or self.DEFAULT_STRIPE_API_VERSION
-
-    # TODO convert to setter for STRIPE_API_VERSION property
     def set_stripe_api_version(self, version=None, validate=True):
         """
         Set the desired API version to use for Stripe requests.
@@ -270,7 +269,7 @@ class DjstripeSettings:
         :param validate: If True validate the value for the specified version).
         :type validate: ``bool``
         """
-        version = version or self.get_stripe_api_version()
+        version = version or self.STRIPE_API_VERSION
 
         if validate:
             valid = validate_stripe_api_version(version)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -126,13 +126,14 @@ class TestGetStripeApiVersion(TestCase):
     def test_with_default(self):
         self.assertEqual(
             settings.djstripe_settings.DEFAULT_STRIPE_API_VERSION,
-            settings.djstripe_settings.get_stripe_api_version(),
+            settings.djstripe_settings.STRIPE_API_VERSION,
         )
 
     @override_settings(STRIPE_API_VERSION="2016-03-07")
     def test_with_override(self):
         self.assertEqual(
-            "2016-03-07", settings.djstripe_settings.get_stripe_api_version()
+            "2016-03-07",
+            settings.djstripe_settings.STRIPE_API_VERSION,
         )
 
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Converted `get_stripe_api_version()` method to `STRIPE_API_VERSION` property to make querying the Stripe API version more intuitive.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will make `djstripe` a bit more User Friendly.