### PR TITLE
Update documentation with a note on expected type of STRIPE_LIVE_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__
 dj_stripe.egg-info
 *.mo
 
+# Environments
+.venv
+
 # mkdocs
 site/
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Assuming the tests are run against PostgreSQL:
 
 # Changelog
 
-[See release notes on Read the Docs](https://dj-stripe.readthedocs.io/en/latest/history/2_4_0/).
+[See release notes on Read the Docs](https://dj-stripe.readthedocs.io/en/latest/history/2_5_0/).
 
 # Funding this project
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,10 @@ Add your Stripe keys and set the operating mode:
     DJSTRIPE_WEBHOOK_SECRET = "whsec_xxx"  # Get it from the section in the Stripe dashboard where you added the webhook endpoint
     DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
 
+!!! note
+
+    djstripe expects `STRIPE_LIVE_MODE` to be a Boolean Type. In case you use `Bash env vars or equivalent` to inject its value, make sure to convert it to a Boolean type. We highly recommended the library [django-environ](https://django-environ.readthedocs.io/en/latest/)
+
 Add some payment plans via the Stripe.com dashboard.
 
 Run the commands:


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

A note on the expected type of `STRIPE_LIVE_MODE`.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Will make users not fall for the trap of exporting `STRIPE_LIVE_MODE` as a string type.
Fixes: #1424
