### PR TITLE
Added Missing Tests and Fixed Bug with null settings in Account Model

### DIFF
--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -193,7 +193,9 @@ class Account(StripeModel):
 
         # Retrieve and save the Files in the settings.branding object.
         for field in "icon", "logo":
-            file_upload_id = self.settings.get("branding", {}).get(field)
+            file_upload_id = self.settings and self.settings.get("branding", {}).get(
+                field
+            )
             if file_upload_id:
                 try:
                     File.sync_from_stripe_data(

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -19,6 +19,8 @@ from . import (
     AssertStripeFksMixin,
 )
 
+pytestmark = pytest.mark.django_db
+
 
 class TestAccount(AssertStripeFksMixin, TestCase):
     @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
@@ -53,6 +55,123 @@ class TestAccount(AssertStripeFksMixin, TestCase):
         account.business_profile = None
         self.assertEqual(account.business_url, "")
 
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test_sync_from_stripe_data(
+        self, fileupload_retrieve_mock, account_retrieve_mock
+    ):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+
+        self.assertGreater(len(account.business_profile), 0)
+        self.assertGreater(len(account.settings), 0)
+
+        self.assertEqual(account.branding_icon.id, FAKE_FILEUPLOAD_ICON["id"])
+        self.assertEqual(account.branding_logo.id, FAKE_FILEUPLOAD_LOGO["id"])
+
+        self.assertEqual(account.settings["branding"]["icon"], account.branding_icon.id)
+        self.assertEqual(account.settings["branding"]["logo"], account.branding_logo.id)
+
+        self.assertNotEqual(account.branding_logo.id, account.branding_icon.id)
+
+        self.assert_fks(account, expected_blank_fks={})
+
+        self.assertEqual(account.business_url, "https://djstripe.com")
+
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test__find_owner_account(self, fileupload_retrieve_mock, account_retrieve_mock):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+        self.assertEqual(None, Account._find_owner_account(account))
+
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test_business_url(self, fileupload_retrieve_mock, account_retrieve_mock):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+        self.assertEqual(fake_account["business_profile"]["url"], account.business_url)
+
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test_branding_logo(self, fileupload_retrieve_mock, account_retrieve_mock):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+        self.assertEqual(
+            fake_account["settings"]["branding"]["logo"], account.branding_logo.id
+        )
+
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test_branding_icon(self, fileupload_retrieve_mock, account_retrieve_mock):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+        self.assertEqual(
+            fake_account["settings"]["branding"]["icon"], account.branding_icon.id
+        )
+
+    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test__attach_objects_post_save_hook(
+        self, fileupload_retrieve_mock, account_retrieve_mock
+    ):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"]["branding"]["icon"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        Account.sync_from_stripe_data(fake_account)
+
+        fileupload_retrieve_mock.assert_called_with(
+            id=fake_account["settings"]["branding"]["logo"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            expand=[],
+            stripe_account=fake_account["id"],
+        )
+
     @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
     @patch(
         "stripe.File.retrieve",
@@ -82,36 +201,65 @@ class TestAccount(AssertStripeFksMixin, TestCase):
         )
 
 
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    ("business_profile_update", "settings_dashboard_update", "expected_account_str"),
-    (
-        ({}, {}, "dj-stripe"),
-        ({}, {"display_name": "some display name"}, "some display name"),
-        ({"name": "some business name"}, {"display_name": ""}, "some business name"),
-        ({"name": ""}, {"display_name": ""}, "<id=acct_1032D82eZvKYlo2C>"),
-    ),
-)
-@patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
-@patch(
-    "stripe.File.retrieve",
-    return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
-    autospec=True,
-)
-def test_account_str(
-    fileupload_retrieve_mock,
-    account_retrieve_mock,
-    business_profile_update,
-    settings_dashboard_update,
-    expected_account_str,
-):
-    fake_account = deepcopy(FAKE_ACCOUNT)
-    fake_account["business_profile"].update(business_profile_update)
-    fake_account["settings"]["dashboard"].update(settings_dashboard_update)
-    account_retrieve_mock.return_value = fake_account
-    account = Account.get_default_account()
+class TestAccountStr:
+    @pytest.mark.parametrize(
+        (
+            "business_profile_update",
+            "settings_dashboard_update",
+            "expected_account_str",
+        ),
+        (
+            ({}, {}, "dj-stripe"),
+            ({}, {"display_name": "some display name"}, "some display name"),
+            (
+                {"name": "some business name"},
+                {"display_name": ""},
+                "some business name",
+            ),
+            ({"name": ""}, {"display_name": ""}, "<id=acct_1032D82eZvKYlo2C>"),
+        ),
+    )
+    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test_account_str(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+        business_profile_update,
+        settings_dashboard_update,
+        expected_account_str,
+    ):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["business_profile"].update(business_profile_update)
+        fake_account["settings"]["dashboard"].update(settings_dashboard_update)
+        account_retrieve_mock.return_value = fake_account
+        account = Account.get_default_account()
 
-    assert str(account) == expected_account_str
+        assert str(account) == expected_account_str
+
+    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test__str__null_settings_null_business_profile(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+    ):
+        """Test that __str__ doesn't crash when settings and business_profile are NULL."""
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"] = None
+        fake_account["business_profile"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        account = Account.sync_from_stripe_data(fake_account)
+        assert str(account) == "<id=acct_1032D82eZvKYlo2C>"
 
 
 class TestAccountRestrictedKeys(TestCase):
@@ -167,11 +315,3 @@ def test_account__create_from_stripe_object(
         save=True,
         stripe_account=expected_stripe_account,
     )
-
-
-def test__str__null_settings_null_business_profile():
-    """Test that __str__ doesn't crash when settings and business_profile are NULL."""
-    account = Account()
-    account.settings = None
-    account.business_profile = None
-    assert str(account) == "<id=>"


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed bug in `Account._attach_objects_post_save_hook` when `settings=null` due to the line `file_upload_id=self.settings.get("branding", {}).get(field)`
2. Added missing `Account` model tests.
3. Refactored the existing tests to better organise them.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve the stability of the `Account` model.