### PR TITLE
CI will run tests for all  supported databases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install tox codecov
     - name: Test with tox
-      run: tox -e postgres,postgres-nativejson
+      run: tox
     - name: Check test coverage
       run: codecov


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->
Please merge https://github.com/dj-stripe/dj-stripe/pull/1441 before merging this PR.


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Tox will now run tests on all databases.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

CI tests will run on all supported databases and not just `postgres` and `postgres-nativejson`.
Fix: #1436