### PR TITLE
Replaced Tox Lint with pre-commit as well as the Github Action Linting job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,11 @@ on:
     branches: [master]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: python -m pip install flake8 isort black . djangorestframework
-      - name: Install and Run Pre-commit 
-        uses: pre-commit/action@v2.0.3
-      - name: Check for missing migrations
-        run: python manage.py makemigrations --check --dry-run
-        env:
-          DJSTRIPE_TEST_DB_VENDOR: sqlite
 
-#  todo remove lint job and manage everything in tox.ini
 #  todo remove docs job and manage everything in tox.ini
 
   docs:
     runs-on: ubuntu-latest
-    needs: ["lint"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -44,7 +27,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: ["lint", "docs"]
+    needs: ["docs"]
     strategy:
       fail-fast: true
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,3 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-isort]
-
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-    autoupdate_schedule: weekly
-    skip: []
-    submodules: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
+    pre-commit
     py{36,37}-django{22,30,31,32}-{postgres,postgres-nativejson,mysql,sqlite}
     py{38,39}-django{22,30}-{postgres,postgres-nativejson,mysql,sqlite}
     py{38,39}-django{31,32,main}-{postgres,mysql,sqlite}{,-nativejson}
@@ -10,7 +11,7 @@ skip_missing_interpreters = True
 python =
     3.6: py36
     3.7: py37
-    3.8: py38
+    3.8: py38, pre-commit
     3.9: py39
 
 [testenv]
@@ -38,16 +39,10 @@ deps =
     pytest-django
     pytest-cov
 
-[testenv:lint]
+[testenv:pre-commit]
 skip_install = True
-deps =
-    flake8
-    isort
-    black
-commands =
-    flake8 {toxinidir} {posargs}
-    isort {toxinidir} --check --diff
-    black {toxinidir} --check
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
 
 
 [pytest]
@@ -78,5 +73,3 @@ max-line-length = 88
 
 
 # todo add a section for docs
-# todo add lint to gh-actions and envlist
-# todo add a section for pre-commit


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge #1443 before merging this.

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Tox will now run `pre-commit` job instead of a standalone Github Action `lint` job.
    1. This would ensure that we only have to maintain `pre-commit` to ensure code quality and style is good and consistent
    2. Moreover, another `Github Action` will auto update versions in `.pre-commit-config.yaml` anyway!


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`lint` will be managed in one place instead of 2 places. More `DRY`. And there is already a Github Action to update versions of hooks mentioned in the `.pre-commit-config.yaml` 
