### PR TITLE
Removed Redundant Flake8 section

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,12 +64,3 @@ omit =
 
 [coverage:html]
 directory = cover
-
-[flake8]
-max-complexity = 10
-exclude = djstripe/migrations/, .tox/, build/lib/, .venv/
-ignore = W191, W503, E203, E501
-max-line-length = 88
-
-
-# todo add a section for docs


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed the redundant `[flake8]` section from `tox.ini` as linting is being managed by pre-commit anyway.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Better maintainability by reducing number of things to manage. Project is `DRYer`.