### PR TITLE
Added djstripe_owner_account model field to Admin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -182,19 +182,23 @@ class StripeModelAdmin(admin.ModelAdmin):
         self.raw_id_fields = get_forward_relation_fields_for_model(self.model)
 
     def get_list_display(self, request):
-        return ("__str__", "id") + self.list_display + ("created", "livemode")
+        return (
+            ("__str__", "id", "djstripe_owner_account")
+            + self.list_display
+            + ("created", "livemode")
+        )
 
     def get_list_filter(self, request):
         return self.list_filter + ("created", "livemode")
 
     def get_readonly_fields(self, request, obj=None):
-        return self.readonly_fields + ("id", "created")
+        return self.readonly_fields + ("id", "djstripe_owner_account", "created")
 
     def get_search_fields(self, request):
         return self.search_fields + ("id",)
 
     def get_fieldsets(self, request, obj=None):
-        common_fields = ("livemode", "id", "created")
+        common_fields = ("livemode", "id", "djstripe_owner_account", "created")
         # Have to remove the fields from the common set,
         # otherwise they'll show up twice.
         fields = [f for f in self.get_fields(request, obj) if f not in common_fields]
@@ -209,7 +213,7 @@ class SubscriptionInline(admin.StackedInline):
 
     model = models.Subscription
     extra = 0
-    readonly_fields = ("id", "created")
+    readonly_fields = ("id", "created", "djstripe_owner_account")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -236,7 +240,7 @@ class SubscriptionItemInline(admin.StackedInline):
 
     model = models.SubscriptionItem
     extra = 0
-    readonly_fields = ("id", "created")
+    readonly_fields = ("id", "created", "djstripe_owner_account")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -246,7 +250,7 @@ class InvoiceItemInline(admin.StackedInline):
 
     model = models.InvoiceItem
     extra = 0
-    readonly_fields = ("id", "created")
+    readonly_fields = ("id", "created", "djstripe_owner_account")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -258,9 +262,10 @@ class AccountAdmin(StripeModelAdmin):
     search_fields = ("settings", "business_profile")
 
 
+# todo perhaps make the djstripe_owner_account modelfield updateable for pub and webhook secret since we cannot query stripe for that info?
 @admin.register(models.APIKey)
 class APIKeyAdmin(StripeModelAdmin):
-    list_display = ("type", "djstripe_owner_account")
+    list_display = ("type",)
     list_filter = ("type",)
     search_fields = ("name",)
 
@@ -271,7 +276,6 @@ class APIKeyAdmin(StripeModelAdmin):
         fields.remove("id")
         fields.remove("created")
         if obj is None:
-            fields.remove("djstripe_owner_account")
             fields.remove("type")
             fields.remove("livemode")
         return fields

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -136,7 +136,13 @@ class TestAdminRegisteredModels(TestCase):
                         all(
                             [
                                 1
-                                for i in ["__str__", "id", "created", "livemode"]
+                                for i in [
+                                    "__str__",
+                                    "id",
+                                    "djstripe_owner_account",
+                                    "created",
+                                    "livemode",
+                                ]
                                 if i in list_display
                             ]
                         )
@@ -219,7 +225,13 @@ class TestAdminRegisteredModels(TestCase):
                 # for models inheriting from StripeModelAdmin verify:
                 if model.__name__ not in self.ignore_models:
                     self.assertTrue(
-                        all([1 for i in ["created", "id"] if i in readonly_fields])
+                        all(
+                            [
+                                1
+                                for i in ["created", "djstripe_owner_account", "id"]
+                                if i in readonly_fields
+                            ]
+                        )
                     )
 
     def test_get_list_select_related(self):
@@ -298,7 +310,16 @@ class TestAdminRegisteredModels(TestCase):
                 if model.__name__ not in self.ignore_models:
                     self.assertTrue(
                         all(
-                            [1 for i in ["created", "livemode", "id"] if i in fieldsets]
+                            [
+                                1
+                                for i in [
+                                    "created",
+                                    "livemode",
+                                    "djstripe_owner_account",
+                                    "id",
+                                ]
+                                if i in fieldsets
+                            ]
                         )
                     )
 

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -11,7 +11,12 @@ from djstripe.enums import APIKeyType
 from djstripe.models import Account, APIKey
 from djstripe.models.api import get_api_key_details_by_prefix
 
-from . import FAKE_FILEUPLOAD_ICON, FAKE_STANDARD_ACCOUNT
+from . import (
+    FAKE_FILEUPLOAD_ICON,
+    FAKE_FILEUPLOAD_LOGO,
+    FAKE_PLATFORM_ACCOUNT,
+    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+)
 
 # avoid literal api keys to prevent git secret scanners false-positives
 SK_TEST = "sk_test_" + "XXXXXXXXXXXXXXXXXXXX1234"
@@ -50,7 +55,7 @@ def test_clean_public_apikey():
 
 
 @pytest.mark.django_db
-@patch("stripe.Account.retrieve", return_value=deepcopy(FAKE_STANDARD_ACCOUNT))
+@patch("stripe.Account.retrieve", return_value=deepcopy(FAKE_PLATFORM_ACCOUNT))
 @patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD_ICON))
 def test_apikey_detect_livemode_and_type(
     fileupload_retrieve_mock, account_retrieve_mock
@@ -75,8 +80,8 @@ def test_apikey_detect_livemode_and_type(
 class APIKeyTest(TestCase):
     def setUp(self):
 
-        # create a Standard Stripe Account
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
 
         self.apikey_test = APIKey.objects.create(
             type=APIKeyType.secret,
@@ -117,11 +122,16 @@ class APIKeyTest(TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
-    @patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD_ICON))
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
     def test_refresh_account(self, fileupload_retrieve_mock, account_retrieve_mock):
         self.apikey_test.djstripe_owner_account = None
         self.apikey_test.save()
         self.apikey_test.clean()
-        assert self.apikey_test.djstripe_owner_account.id == FAKE_STANDARD_ACCOUNT["id"]
+        assert self.apikey_test.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]

--- a/tests/test_balance_transaction.py
+++ b/tests/test_balance_transaction.py
@@ -27,43 +27,45 @@ from . import (
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize("transaction_status", BalanceTransactionStatus.__members__)
-def test___str__(transaction_status):
-    modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
-    modified_balance_transaction["status"] = transaction_status
+class TestBalanceTransactionStr:
+    @pytest.mark.parametrize("transaction_status", BalanceTransactionStatus.__members__)
+    def test___str__(self, transaction_status):
+        modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
+        modified_balance_transaction["status"] = transaction_status
 
-    balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
-        modified_balance_transaction
-    )
-    assert (
-        f"{get_friendly_currency_amount(modified_balance_transaction['amount'], modified_balance_transaction['currency'])}"
-        f" ({BalanceTransactionStatus.humanize(modified_balance_transaction['status'])})"
-    ) == str(balance_transaction)
-
-
-@pytest.mark.parametrize("transaction_type", ["card", "payout", "refund"])
-def test_get_source_class_success(transaction_type):
-    modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
-    modified_balance_transaction["type"] = transaction_type
-
-    balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
-        modified_balance_transaction
-    )
-    assert balance_transaction.get_source_class() is getattr(
-        models, transaction_type.capitalize(), None
-    )
+        balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
+            modified_balance_transaction
+        )
+        assert (
+            f"{get_friendly_currency_amount(modified_balance_transaction['amount'], modified_balance_transaction['currency'])}"
+            f" ({BalanceTransactionStatus.humanize(modified_balance_transaction['status'])})"
+        ) == str(balance_transaction)
 
 
-@pytest.mark.parametrize("transaction_type", ["network_cost", "payment_refund"])
-def test_get_source_class_failure(transaction_type):
-    modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
-    modified_balance_transaction["type"] = transaction_type
+class TestBalanceTransactionSourceClass:
+    @pytest.mark.parametrize("transaction_type", ["card", "payout", "refund"])
+    def test_get_source_class_success(self, transaction_type):
+        modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
+        modified_balance_transaction["type"] = transaction_type
 
-    balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
-        modified_balance_transaction
-    )
-    with pytest.raises(LookupError):
-        balance_transaction.get_source_class()
+        balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
+            modified_balance_transaction
+        )
+        assert balance_transaction.get_source_class() is getattr(
+            models, transaction_type.capitalize(), None
+        )
+
+    @pytest.mark.parametrize("transaction_type", ["network_cost", "payment_refund"])
+    def test_get_source_class_failure(self, transaction_type):
+
+        modified_balance_transaction = deepcopy(FAKE_BALANCE_TRANSACTION)
+        modified_balance_transaction["type"] = transaction_type
+
+        balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
+            modified_balance_transaction
+        )
+        with pytest.raises(LookupError):
+            balance_transaction.get_source_class()
 
 
 class TestBalanceTransaction(TestCase):

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -12,9 +12,7 @@ from stripe.error import InvalidRequestError
 
 from djstripe import enums
 from djstripe.exceptions import StripeObjectManipulationException
-from djstripe.models import Card
-from djstripe.models.account import Account
-from djstripe.models.core import Customer
+from djstripe.models import Account, Card, Customer
 
 from . import (
     FAKE_CARD,

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -9,8 +9,7 @@ from django.contrib.auth import get_user_model
 from django.test.testcases import TestCase
 
 from djstripe.enums import ChargeStatus, LegacySourceType
-from djstripe.models import Charge, DjstripePaymentMethod
-from djstripe.models.connect import Transfer
+from djstripe.models import Charge, DjstripePaymentMethod, Transfer
 from djstripe.settings import djstripe_settings
 
 from . import (
@@ -25,6 +24,7 @@ from . import (
     FAKE_INVOICE,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_REFUND,
     FAKE_STANDARD_ACCOUNT,
@@ -38,11 +38,14 @@ from . import (
 class ChargeTest(AssertStripeFksMixin, TestCase):
     @classmethod
     def setUp(self):
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         user = get_user_model().objects.create_user(
             username="testuser", email="djstripe@example.com"
         )
         self.customer = FAKE_CUSTOMER.create_for_user(user)
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+
         self.default_expected_blank_fks = {
             "djstripe.Charge.application_fee",
             "djstripe.Charge.dispute",

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -101,6 +101,7 @@ class HumanReadableCouponTest(TestCase):
         self.assertEqual(str(coupon), coupon.human_readable)
 
 
-def test_blank_coupon_str():
-    coupon = Coupon()
-    assert str(coupon).strip() == "(invalid amount) off"
+class TestCouponStr(TestCase):
+    def test_blank_coupon_str(self):
+        coupon = Coupon()
+        self.assertEqual(str(coupon).strip(), "(invalid amount) off")

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -46,10 +46,10 @@ from . import (
     FAKE_PAYMENT_INTENT_I,
     FAKE_PAYMENT_METHOD_I,
     FAKE_PLAN,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRICE,
     FAKE_PRODUCT,
     FAKE_SOURCE,
-    FAKE_STANDARD_ACCOUNT,
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_II,
     FAKE_UPCOMING_INVOICE,
@@ -62,6 +62,9 @@ from . import (
 
 class TestCustomer(AssertStripeFksMixin, TestCase):
     def setUp(self):
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -74,8 +77,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
         self.customer.default_source = self.payment_method
         self.customer.save()
-
-        self.account = FAKE_STANDARD_ACCOUNT.create()
 
     def test___str__(self):
         self.assertEqual(str(self.customer), str(self.user))
@@ -1036,12 +1037,12 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.customer.charge(
             amount=decimal.Decimal("10.00"),
             capture=True,
-            destination=FAKE_STANDARD_ACCOUNT["id"],
+            destination=FAKE_PLATFORM_ACCOUNT["id"],
         )
 
         _, kwargs = charge_create_mock.call_args
         self.assertEqual(kwargs["capture"], True)
-        self.assertEqual(kwargs["destination"], FAKE_STANDARD_ACCOUNT["id"])
+        self.assertEqual(kwargs["destination"], FAKE_PLATFORM_ACCOUNT["id"])
 
     @patch(
         "djstripe.models.Account.get_default_account",
@@ -1872,6 +1873,9 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 # These tests use Plan which is deprecated in favor of Price
 class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
     def setUp(self):
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -1884,8 +1888,6 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
 
         self.customer.default_source = self.payment_method
         self.customer.save()
-
-        self.account = FAKE_STANDARD_ACCOUNT.create()
 
     @patch(
         "stripe.Subscription.create",

--- a/tests/test_dispute.py
+++ b/tests/test_dispute.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.test.testcases import TestCase
 
 from djstripe import enums
-from djstripe.models.core import Dispute
+from djstripe.models import Dispute
 from djstripe.settings import djstripe_settings
 
 from . import (

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,7 +1,15 @@
 from django.core.management import call_command
 from django.test import TestCase
+from django.test.utils import override_settings
 
 
 class TestRunManagePyCheck(TestCase):
+    @override_settings(
+        STRIPE_TEST_SECRET_KEY="sk_test_foo",
+        STRIPE_LIVE_SECRET_KEY="sk_live_foo",
+        STRIPE_TEST_PUBLIC_KEY="pk_test_foo",
+        STRIPE_LIVE_PUBLIC_KEY="pk_live_foo",
+        STRIPE_LIVE_MODE=True,
+    )
     def test_manage_py_check(self):
         call_command("check")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -14,7 +14,7 @@ from djstripe.models import Event, Transfer
 from . import (
     FAKE_CUSTOMER,
     FAKE_EVENT_TRANSFER_CREATED,
-    FAKE_STANDARD_ACCOUNT,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_TRANSFER,
     IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
@@ -22,6 +22,7 @@ from . import (
 
 class EventTest(TestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -158,7 +159,7 @@ class EventRaceConditionTest(TestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -125,6 +125,7 @@ from . import (
     FAKE_PAYMENT_METHOD_I,
     FAKE_PAYMENT_METHOD_II,
     FAKE_PLAN,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRICE,
     FAKE_PRODUCT,
     FAKE_SESSION_I,
@@ -688,6 +689,9 @@ class TestAccountEvents(EventTestCase):
 
 class TestChargeEvents(EventTestCase):
     def setUp(self):
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -739,7 +743,7 @@ class TestChargeEvents(EventTestCase):
         fake_stripe_event = deepcopy(FAKE_EVENT_CHARGE_SUCCEEDED)
         event_retrieve_mock.return_value = fake_stripe_event
         charge_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
-        account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
+        account_mock.return_value = self.account
 
         event = Event.sync_from_stripe_data(fake_stripe_event)
         event.invoke_webhook_handlers()
@@ -754,6 +758,7 @@ class TestChargeEvents(EventTestCase):
 
 class TestCheckoutEvents(EventTestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -882,6 +887,7 @@ class TestCheckoutEvents(EventTestCase):
 
 class TestCustomerEvents(EventTestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )
@@ -1179,6 +1185,7 @@ class TestCustomerEvents(EventTestCase):
 
 class TestDisputeEvents(EventTestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_user(
             username="fake_customer_1", email=FAKE_CUSTOMER["email"]
         )
@@ -1500,6 +1507,13 @@ class TestDisputeEvents(EventTestCase):
 
 
 class TestFileEvents(EventTestCase):
+    def setUp(self):
+
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com"
+        )
+        self.customer = FAKE_CUSTOMER.create_for_user(self.user)
+
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
@@ -1519,8 +1533,15 @@ class TestFileEvents(EventTestCase):
 
 
 class TestInvoiceEvents(EventTestCase):
+    def setUp(self):
+
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com"
+        )
+
     @patch(
         "djstripe.models.Account.get_default_account",
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -1567,7 +1588,6 @@ class TestInvoiceEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        default_account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
 
         fake_stripe_event = deepcopy(FAKE_EVENT_INVOICE_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
@@ -1583,6 +1603,7 @@ class TestInvoiceEvents(EventTestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -1627,12 +1648,8 @@ class TestInvoiceEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        default_account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
 
-        user = get_user_model().objects.create_user(
-            username="pydanny", email="pydanny@gmail.com"
-        )
-        FAKE_CUSTOMER.create_for_user(user)
+        FAKE_CUSTOMER.create_for_user(self.user)
 
         fake_stripe_event = deepcopy(FAKE_EVENT_INVOICE_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
@@ -1651,6 +1668,7 @@ class TestInvoiceEvents(EventTestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -1691,12 +1709,8 @@ class TestInvoiceEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        default_account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
 
-        user = get_user_model().objects.create_user(
-            username="pydanny", email="pydanny@gmail.com"
-        )
-        FAKE_CUSTOMER.create_for_user(user)
+        FAKE_CUSTOMER.create_for_user(self.user)
 
         event = self._create_event(FAKE_EVENT_INVOICE_CREATED)
         event.invoke_webhook_handlers()
@@ -1717,8 +1731,15 @@ class TestInvoiceEvents(EventTestCase):
 
 
 class TestInvoiceItemEvents(EventTestCase):
+    def setUp(self):
+
+        self.user = get_user_model().objects.create_user(
+            username="pydanny", email="pydanny@gmail.com"
+        )
+
     @patch(
         "djstripe.models.Account.get_default_account",
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -1765,12 +1786,8 @@ class TestInvoiceItemEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        default_account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
 
-        user = get_user_model().objects.create_user(
-            username="pydanny", email="pydanny@gmail.com"
-        )
-        FAKE_CUSTOMER_II.create_for_user(user)
+        FAKE_CUSTOMER_II.create_for_user(self.user)
 
         fake_stripe_event = deepcopy(FAKE_EVENT_INVOICEITEM_CREATED)
         event_retrieve_mock.return_value = fake_stripe_event
@@ -1790,6 +1807,7 @@ class TestInvoiceItemEvents(EventTestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -1838,12 +1856,7 @@ class TestInvoiceItemEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
-        default_account_mock.return_value = FAKE_STANDARD_ACCOUNT.create()
-
-        user = get_user_model().objects.create_user(
-            username="pydanny", email="pydanny@gmail.com"
-        )
-        FAKE_CUSTOMER_II.create_for_user(user)
+        FAKE_CUSTOMER_II.create_for_user(self.user)
 
         event = self._create_event(FAKE_EVENT_INVOICEITEM_CREATED)
         event.invoke_webhook_handlers()
@@ -1987,6 +2000,7 @@ class TestPriceEvents(EventTestCase):
 
 class TestPaymentMethodEvents(AssertStripeFksMixin, EventTestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_user(
             username="fake_customer_1", email=FAKE_CUSTOMER["email"]
         )
@@ -2415,7 +2429,7 @@ class TestTransferEvents(EventTestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Transfer.retrieve", autospec=True)
@@ -2443,7 +2457,7 @@ class TestTransferEvents(EventTestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Transfer.retrieve", return_value=FAKE_TRANSFER, autospec=True)

--- a/tests/test_file_link.py
+++ b/tests/test_file_link.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
+from django.test import TestCase
 
 from djstripe.models import File, FileLink
 from djstripe.settings import djstripe_settings
@@ -14,45 +15,47 @@ from . import FAKE_FILEUPLOAD_ICON
 pytestmark = pytest.mark.django_db
 
 
-@patch(
-    target="stripe.File.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
-)
-@patch(
-    target="stripe.FileLink.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0]),
-)
-def test___str__(mock_file_link_retrieve, mock_file_upload_retrieve):
-    file_link_data = deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0])
-    file_link = FileLink.sync_from_stripe_data(file_link_data)
-    assert (f"{FAKE_FILEUPLOAD_ICON['filename']}, {file_link_data['url']}") == str(
-        file_link
+class TestFileLink(TestCase):
+    @patch(
+        target="stripe.File.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
     )
-
-
-@patch(
-    target="stripe.File.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
-)
-@patch(
-    target="stripe.FileLink.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0]),
-)
-def test_sync_from_stripe_data(mock_file_link_retrieve, mock_file_upload_retrieve):
-    file_link_data = deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0])
-    file_link = FileLink.sync_from_stripe_data(file_link_data)
-
-    mock_file_link_retrieve.assert_not_called()
-    mock_file_upload_retrieve.assert_called_once_with(
-        id=file_link_data["file"],
-        api_key=djstripe_settings.STRIPE_SECRET_KEY,
-        expand=[],
-        stripe_account=None,
+    @patch(
+        target="stripe.FileLink.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0]),
     )
+    def test___str__(self, mock_file_link_retrieve, mock_file_upload_retrieve):
+        file_link_data = deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0])
+        file_link = FileLink.sync_from_stripe_data(file_link_data)
+        assert (f"{FAKE_FILEUPLOAD_ICON['filename']}, {file_link_data['url']}") == str(
+            file_link
+        )
 
-    assert file_link.file == File.objects.get(id=file_link_data["file"])
-    assert file_link.url == file_link_data["url"]
+    @patch(
+        target="stripe.File.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
+    )
+    @patch(
+        target="stripe.FileLink.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0]),
+    )
+    def test_sync_from_stripe_data(
+        self, mock_file_link_retrieve, mock_file_upload_retrieve
+    ):
+        file_link_data = deepcopy(FAKE_FILEUPLOAD_ICON["links"]["data"][0])
+        file_link = FileLink.sync_from_stripe_data(file_link_data)
+
+        mock_file_link_retrieve.assert_not_called()
+        mock_file_upload_retrieve.assert_called_once_with(
+            id=file_link_data["file"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            expand=[],
+            stripe_account=None,
+        )
+
+        assert file_link.file == File.objects.get(id=file_link_data["file"])
+        assert file_link.url == file_link_data["url"]

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from unittest.mock import ANY, call, patch
 
 import pytest
+from django.test import TestCase
 
 from djstripe.enums import FilePurpose
 from djstripe.models import Account, File
@@ -14,55 +15,60 @@ from . import FAKE_ACCOUNT, FAKE_FILEUPLOAD_ICON, FAKE_FILEUPLOAD_LOGO
 pytestmark = pytest.mark.django_db
 
 
-@patch(
-    target="stripe.File.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
-)
-def test_file_upload_api_retrieve(mock_file_upload_retrieve):
-    """Expect file_upload to use the ID of the account referring
-    to it to retrieve itself.
-    """
-    # Create files
-    icon_file = File._get_or_create_from_stripe_object(data=FAKE_FILEUPLOAD_ICON)[0]
-    logo_file = File._get_or_create_from_stripe_object(data=FAKE_FILEUPLOAD_LOGO)[0]
-    # Create account to associate the files to it
-    account = Account._get_or_create_from_stripe_object(data=FAKE_ACCOUNT)[0]
-
-    # Call the API retrieve methods.
-    icon_file.api_retrieve()
-    logo_file.api_retrieve()
-
-    # Ensure the correct Account ID was used in retrieval
-    mock_file_upload_retrieve.assert_has_calls(
-        (
-            call(id=icon_file.id, api_key=ANY, expand=ANY, stripe_account=account.id),
-            call(id=logo_file.id, api_key=ANY, expand=ANY, stripe_account=account.id),
-        )
+class TestFileLink(TestCase):
+    @patch(
+        target="stripe.File.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
     )
+    def test_file_upload_api_retrieve(self, mock_file_upload_retrieve):
+        """Expect file_upload to use the ID of the account referring
+        to it to retrieve itself.
+        """
+        # Create files
+        icon_file = File._get_or_create_from_stripe_object(data=FAKE_FILEUPLOAD_ICON)[0]
+        logo_file = File._get_or_create_from_stripe_object(data=FAKE_FILEUPLOAD_LOGO)[0]
+        # Create account to associate the files to it
+        account = Account._get_or_create_from_stripe_object(data=FAKE_ACCOUNT)[0]
+
+        # Call the API retrieve methods.
+        icon_file.api_retrieve()
+        logo_file.api_retrieve()
+
+        # Ensure the correct Account ID was used in retrieval
+        mock_file_upload_retrieve.assert_has_calls(
+            (
+                call(
+                    id=icon_file.id, api_key=ANY, expand=ANY, stripe_account=account.id
+                ),
+                call(
+                    id=logo_file.id, api_key=ANY, expand=ANY, stripe_account=account.id
+                ),
+            )
+        )
+
+    @patch(
+        target="stripe.File.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
+    )
+    def test_sync_from_stripe_data(self, mock_file_upload_retrieve):
+        file = File.sync_from_stripe_data(deepcopy(FAKE_FILEUPLOAD_ICON))
+
+        mock_file_upload_retrieve.assert_not_called()
+
+        assert file.id == FAKE_FILEUPLOAD_ICON["id"]
+        assert file.purpose == FAKE_FILEUPLOAD_ICON["purpose"]
+        assert file.type == FAKE_FILEUPLOAD_ICON["type"]
 
 
-@patch(
-    target="stripe.File.retrieve",
-    autospec=True,
-    return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
-)
-def test_sync_from_stripe_data(mock_file_upload_retrieve):
-    file = File.sync_from_stripe_data(deepcopy(FAKE_FILEUPLOAD_ICON))
+class TestFileUploadStr:
+    @pytest.mark.parametrize("file_purpose", FilePurpose.__members__)
+    def test___str__(self, file_purpose):
+        modified_file_data = deepcopy(FAKE_FILEUPLOAD_ICON)
+        modified_file_data["purpose"] = file_purpose
 
-    mock_file_upload_retrieve.assert_not_called()
-
-    assert file.id == FAKE_FILEUPLOAD_ICON["id"]
-    assert file.purpose == FAKE_FILEUPLOAD_ICON["purpose"]
-    assert file.type == FAKE_FILEUPLOAD_ICON["type"]
-
-
-@pytest.mark.parametrize("file_purpose", FilePurpose.__members__)
-def test___str__(file_purpose):
-    modified_file_data = deepcopy(FAKE_FILEUPLOAD_ICON)
-    modified_file_data["purpose"] = file_purpose
-
-    file = File.sync_from_stripe_data(modified_file_data)
-    assert (
-        f"{modified_file_data['filename']}, {FilePurpose.humanize(modified_file_data['purpose'])}"
-    ) == str(file)
+        file = File.sync_from_stripe_data(modified_file_data)
+        assert (
+            f"{modified_file_data['filename']}, {FilePurpose.humanize(modified_file_data['purpose'])}"
+        ) == str(file)

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -21,8 +21,8 @@ from . import (
     FAKE_INVOICEITEM_II,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
-    FAKE_STANDARD_ACCOUNT,
     FAKE_SUBSCRIPTION,
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
     FAKE_TAX_RATE_EXAMPLE_2_SALES,
@@ -34,7 +34,9 @@ from . import (
 
 class InvoiceTest(AssertStripeFksMixin, TestCase):
     def setUp(self):
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -19,9 +19,9 @@ from . import (
     FAKE_PAYMENT_INTENT_II,
     FAKE_PAYMENT_METHOD_II,
     FAKE_PLAN_II,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRICE_II,
     FAKE_PRODUCT,
-    FAKE_STANDARD_ACCOUNT,
     FAKE_SUBSCRIPTION_III,
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
     IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
@@ -31,7 +31,8 @@ from . import (
 
 class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     def setUp(self):
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
 
         self.default_expected_blank_fks = {
             "djstripe.Account.branding_logo",

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -15,8 +15,8 @@ from djstripe.models import Charge, Customer, Plan, Subscription, Transfer
 from . import (
     FAKE_PLAN,
     FAKE_PLAN_II,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
-    FAKE_STANDARD_ACCOUNT,
     FAKE_TRANSFER,
     IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
@@ -24,6 +24,7 @@ from . import (
 
 class SubscriptionManagerTest(TestCase):
     def setUp(self):
+
         # create customers and current subscription records
         period_start = datetime.datetime(2013, 4, 1, tzinfo=timezone.utc)
         period_end = datetime.datetime(2013, 4, 30, tzinfo=timezone.utc)
@@ -152,7 +153,7 @@ class TransferManagerTest(TestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     def test_transfer_summary(
@@ -184,6 +185,7 @@ class TransferManagerTest(TestCase):
 
 class ChargeManagerTest(TestCase):
     def setUp(self):
+
         customer = Customer.objects.create(
             id="cus_XXXXXXX", livemode=False, balance=0, delinquent=False
         )

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -10,7 +10,8 @@ from django.test import TestCase
 
 from djstripe.enums import PaymentIntentStatus
 from djstripe.models import Account, Customer, PaymentIntent
-from tests import (
+
+from . import (
     FAKE_ACCOUNT,
     FAKE_CUSTOMER,
     FAKE_PAYMENT_INTENT_DESTINATION_CHARGE,

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -11,6 +11,8 @@ from djstripe.models import Product
 from djstripe.models.core import Price
 
 from . import (
+    FAKE_FILEUPLOAD_ICON,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRICE,
     FAKE_PRICE_METERED,
     FAKE_PRICE_ONETIME,
@@ -22,6 +24,16 @@ pytestmark = pytest.mark.django_db
 
 
 class TestProduct:
+
+    #
+    # Helper Methods for monkeypatching
+    #
+    def mock_file_retrieve(*args, **kwargs):
+        return deepcopy(FAKE_FILEUPLOAD_ICON)
+
+    def mock_account_retrieve(*args, **kwargs):
+        return deepcopy(FAKE_PLATFORM_ACCOUNT)
+
     def mock_product_get(self, *args, **kwargs):
         return deepcopy(FAKE_PRODUCT)
 
@@ -59,7 +71,6 @@ class TestProduct:
         # monkeypatch stripe.Product.retrieve call to return
         # the desired json response.
         monkeypatch.setattr(stripe.Product, "retrieve", self.mock_product_get)
-
         product = Product.sync_from_stripe_data(deepcopy(FAKE_PRODUCT))
 
         assert product.id == FAKE_PRODUCT["id"]

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -18,9 +18,9 @@ from . import (
     FAKE_CUSTOMER,
     FAKE_INVOICE,
     FAKE_PAYMENT_INTENT_I,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_REFUND,
-    FAKE_STANDARD_ACCOUNT,
     FAKE_SUBSCRIPTION,
     IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
@@ -29,7 +29,9 @@ from . import (
 
 class RefundTest(AssertStripeFksMixin, TestCase):
     def setUp(self):
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+        # create a Stripe Platform Account
+        self.account = FAKE_PLATFORM_ACCOUNT.create()
+
         user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"
         )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,12 +7,8 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from djstripe.models import Session
-from tests import (
-    FAKE_CUSTOMER,
-    FAKE_PAYMENT_INTENT_I,
-    FAKE_SESSION_I,
-    AssertStripeFksMixin,
-)
+
+from . import FAKE_CUSTOMER, FAKE_PAYMENT_INTENT_I, FAKE_SESSION_I, AssertStripeFksMixin
 
 
 class SessionTest(AssertStripeFksMixin, TestCase):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -14,7 +14,6 @@ from . import (
     FAKE_CUSTOMER_III,
     FAKE_SOURCE,
     FAKE_SOURCE_II,
-    FAKE_STANDARD_ACCOUNT,
     AssertStripeFksMixin,
     SourceDict,
 )
@@ -22,7 +21,7 @@ from . import (
 
 class SourceTest(AssertStripeFksMixin, TestCase):
     def setUp(self):
-        self.account = FAKE_STANDARD_ACCOUNT.create()
+
         user = get_user_model().objects.create_user(
             username="testuser", email="djstripe@example.com"
         )

--- a/tests/test_subscription_item.py
+++ b/tests/test_subscription_item.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from djstripe.models.billing import SubscriptionItem
+from djstripe.models import SubscriptionItem
 
 from . import (
     FAKE_CUSTOMER,

--- a/tests/test_tax_id.py
+++ b/tests/test_tax_id.py
@@ -8,8 +8,7 @@ import pytest
 from django.test.testcases import TestCase
 
 from djstripe import enums
-from djstripe.models.billing import TaxId
-from djstripe.models.core import Customer
+from djstripe.models import Customer, TaxId
 from djstripe.settings import djstripe_settings
 
 from . import (
@@ -22,7 +21,7 @@ from . import (
 pytestmark = pytest.mark.django_db
 
 
-class TestTaxIdStr:
+class TestTaxIdStr(TestCase):
     @patch(
         "stripe.Customer.retrieve",
         return_value=deepcopy(FAKE_CUSTOMER),
@@ -40,9 +39,9 @@ class TestTaxIdStr:
     ):
 
         tax_id = TaxId.sync_from_stripe_data(FAKE_TAX_ID)
-        assert (
-            str(tax_id)
-            == f"{enums.TaxIdType.humanize(FAKE_TAX_ID['type'])} {FAKE_TAX_ID['value']} ({FAKE_TAX_ID['verification']['status']})"
+        self.assertEqual(
+            str(tax_id),
+            f"{enums.TaxIdType.humanize(FAKE_TAX_ID['type'])} {FAKE_TAX_ID['value']} ({FAKE_TAX_ID['verification']['status']})",
         )
 
 

--- a/tests/test_transfer_reversal.py
+++ b/tests/test_transfer_reversal.py
@@ -7,13 +7,12 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from django.test.testcases import TestCase
 
-from djstripe.models import TransferReversal
-from djstripe.models.connect import Transfer
+from djstripe.models import Transfer, TransferReversal
 from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_BALANCE_TRANSACTION_II,
-    FAKE_STANDARD_ACCOUNT,
+    FAKE_PLATFORM_ACCOUNT,
     FAKE_TRANSFER,
     FAKE_TRANSFER_WITH_1_REVERSAL,
     IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
@@ -23,11 +22,11 @@ from . import (
 pytestmark = pytest.mark.django_db
 
 
-class TestTransferReversalStr:
+class TestTransferReversalStr(TestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -51,14 +50,14 @@ class TestTransferReversalStr:
         transfer_reversal = TransferReversal.sync_from_stripe_data(
             deepcopy(FAKE_TRANSFER_WITH_1_REVERSAL["reversals"]["data"][0])
         )
-        assert str(f"{transfer_reversal.transfer}") == str(transfer_reversal)
+        self.assertEqual(str(f"{transfer_reversal.transfer}"), str(transfer_reversal))
 
 
 class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(
@@ -100,7 +99,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch.object(Transfer, "_attach_objects_post_save_hook")
     @patch(
         "stripe.Account.retrieve",
-        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -12,8 +12,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from djstripe import webhooks
-from djstripe.models import Event, WebhookEventTrigger
-from djstripe.models.connect import Transfer
+from djstripe.models import Event, Transfer, WebhookEventTrigger
 from djstripe.settings import djstripe_settings
 from djstripe.webhooks import TEST_EVENT_ID, call_handlers, handler, handler_all
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Exposed the `djstripe_owner_account` model field on the `admin` page for all models.
2.  Added a `FAKE_PLATFORM_ACCOUNT` fixture to be used as a proxy for the Stripe Platform account to own all the default Stripe Keys.
3. Updated Corresponding tests and made some stylistic changes as well to convert function-based tests to class-based tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `djstripe_owner_account` model field will be used to keep track of the `Stripe Account` the given model instance belongs to and that would be of paramount importance once `Multiple Stripe Accounts` get supported.