### PR TITLE
Fix djstripe owner account model field not getting populated for all models

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -263,7 +263,7 @@ class StripeModel(StripeBaseModel):
         return data
 
     @classmethod
-    def _find_owner_account(cls, data):
+    def _find_owner_account(cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY):
         """
         Fetches the Stripe Account (djstripe_owner_account model field)
         linked to the class, cls.
@@ -272,13 +272,13 @@ class StripeModel(StripeBaseModel):
         """
         from .account import Account
 
+        # try to fetch by stripe_account. Also takes care of Stripe Connected Accounts
         stripe_account = cls._id_from_data(data.get("account"))
         if stripe_account:
             return Account._get_or_retrieve(id=stripe_account)
 
-        api_key = data.get("api_key", "")
-        if api_key:
-            return Account.get_or_retrieve_for_api_key(api_key)
+        # try to fetch by the given api_key.
+        return Account.get_or_retrieve_for_api_key(api_key)
 
     @classmethod
     def _stripe_object_to_record(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -257,6 +257,9 @@ FAKE_STANDARD_ACCOUNT = AccountDict(
     load_fixture("account_standard_acct_1Fg9jUA3kq9o1aTc.json")
 )
 
+# Stripe Platform Account to which the STRIPE_SECRET_KEY belongs to
+FAKE_PLATFORM_ACCOUNT = deepcopy(FAKE_STANDARD_ACCOUNT)
+
 FAKE_CUSTOM_ACCOUNT = AccountDict(
     load_fixture("account_custom_acct_1IuHosQveW0ONQsd.json")
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""
+Module for creating re-usable fixtures to be used across the test suite
+"""
+import pytest
+
+from djstripe.enums import APIKeyType
+from djstripe.models import APIKey
+
+from . import FAKE_PLATFORM_ACCOUNT
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def create_account_and_stripe_apikeys(settings):
+    """
+    Fixture to automatically create and assign the default testing keys to the Platform Account
+    """
+    # create a Stripe Platform Account
+    djstripe_platform_account = FAKE_PLATFORM_ACCOUNT.create()
+
+    # create and assign APIKey instances to the djstripe Platform Account
+    APIKey.objects.get_or_create(
+        type=APIKeyType.secret,
+        name="Test Secret Key",
+        secret=settings.STRIPE_TEST_SECRET_KEY,
+        livemode=False,
+        djstripe_owner_account=djstripe_platform_account,
+    )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -95,10 +95,20 @@ MIDDLEWARE = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
-STRIPE_LIVE_PUBLIC_KEY = os.environ.get("STRIPE_PUBLIC_KEY", "pk_test_123")
-STRIPE_LIVE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY", "sk_test_123")
-STRIPE_TEST_PUBLIC_KEY = os.environ.get("STRIPE_PUBLIC_KEY", "pk_test_123")
-STRIPE_TEST_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY", "sk_test_123")
+STRIPE_LIVE_PUBLIC_KEY = os.environ.get(
+    "STRIPE_PUBLIC_KEY", "pk_live_XXXXXXXXXXXXXXXXXXXXXXXXX"
+)
+STRIPE_LIVE_SECRET_KEY = os.environ.get(
+    "STRIPE_SECRET_KEY", "sk_live_XXXXXXXXXXXXXXXXXXXXXXXXX"
+)
+STRIPE_TEST_PUBLIC_KEY = os.environ.get(
+    "STRIPE_PUBLIC_KEY",
+    "pk_test_XXXXXXXXXXXXXXXXXXXXXXXXX",
+)
+STRIPE_TEST_SECRET_KEY = os.environ.get(
+    "STRIPE_SECRET_KEY",
+    "sk_test_XXXXXXXXXXXXXXXXXXXXXXXXX",
+)
 
 DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS = (
     "(admin)",

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -16,6 +16,8 @@ from jsonfield import JSONField
 from djstripe import admin as djstripe_admin
 from djstripe import models
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.parametrize(
     "output,input",

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -21,6 +21,8 @@ RK_LIVE = "rk_live_" + "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5432"
 PK_TEST = "pk_test_" + "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXAAAA"
 PK_LIVE = "pk_live_" + "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXBBBB"
 
+pytestmark = pytest.mark.django_db
+
 
 def test_get_api_key_details_by_prefix():
     assert get_api_key_details_by_prefix(SK_TEST) == (APIKeyType.secret, False)

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -1,10 +1,13 @@
 from copy import deepcopy
 
+import pytest
 from django.test.testcases import TestCase
 
 from djstripe.models import Coupon
 
 from . import FAKE_COUPON
+
+pytestmark = pytest.mark.django_db
 
 
 class TransferTest(TestCase):

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -97,15 +97,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.assertEqual(self.customer.pending_charges, 0)
 
     def test_customer_dashboard_url(self):
-        expected_url = "https://dashboard.stripe.com/test/customers/{}".format(
-            self.customer.id
-        )
+        expected_url = f"https://dashboard.stripe.com/{self.customer.djstripe_owner_account.id}/test/customers/{self.customer.id}"
         self.assertEqual(self.customer.get_stripe_dashboard_url(), expected_url)
 
         self.customer.livemode = True
-        expected_url = "https://dashboard.stripe.com/customers/{}".format(
-            self.customer.id
-        )
+        expected_url = f"https://dashboard.stripe.com/{self.customer.djstripe_owner_account.id}/customers/{self.customer.id}"
         self.assertEqual(self.customer.get_stripe_dashboard_url(), expected_url)
 
         unsaved_customer = Customer()
@@ -436,7 +432,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             id=self.customer.id,
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=ANY,
-            stripe_account=None,
+            stripe_account=self.customer.djstripe_owner_account.id,
         )
         self.assertEqual(1, customer_retrieve_mock.call_count)
 
@@ -455,7 +451,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             id=self.customer.id,
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=ANY,
-            stripe_account=None,
+            stripe_account=self.customer.djstripe_owner_account.id,
         )
 
     def test_can_charge(self):
@@ -656,7 +652,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=ANY,
             id=FAKE_CUSTOMER["id"],
-            stripe_account=None,
+            stripe_account=self.customer.djstripe_owner_account.id,
         )
 
     @patch("stripe.Coupon.retrieve", return_value=deepcopy(FAKE_COUPON), autospec=True)
@@ -685,7 +681,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=ANY,
             id=FAKE_CUSTOMER["id"],
-            stripe_account=None,
+            stripe_account=self.customer.djstripe_owner_account.id,
         )
 
         self.customer.refresh_from_db()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -10,6 +10,8 @@ from django.test.utils import override_settings
 
 from djstripe.fields import StripeDateTimeField, StripeDecimalCurrencyAmountField
 
+pytestmark = pytest.mark.django_db
+
 
 class TestStripeDecimalCurrencyAmountField:
     noval = StripeDecimalCurrencyAmountField(name="noval")

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -452,7 +452,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
             id=invoice.id,
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=[],
-            stripe_account=None,
+            stripe_account=invoice.djstripe_owner_account.id,
         )
         self.assertTrue(return_value)
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -140,7 +140,7 @@ class PlanTest(AssertStripeFksMixin, TestCase):
             id=self.plan_data["id"],
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=["tiers"],
-            stripe_account=None,
+            stripe_account=self.plan.djstripe_owner_account.id,
         )
         plan = Plan.sync_from_stripe_data(stripe_plan)
         assert plan.amount_in_cents == plan.amount * 100

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -168,7 +168,7 @@ class PriceTest(AssertStripeFksMixin, TestCase):
             id=self.price_data["id"],
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=["tiers"],
-            stripe_account=None,
+            stripe_account=self.price.djstripe_owner_account.id,
         )
         price = Price.sync_from_stripe_data(stripe_price)
 

--- a/tests/test_tax_id.py
+++ b/tests/test_tax_id.py
@@ -167,7 +167,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
             id=FAKE_CUSTOMER["id"],
             nested_id=FAKE_TAX_ID["id"],
             expand=[],
-            stripe_account=None,
+            stripe_account=tax_id.djstripe_owner_account.id,
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
         )
 

--- a/tests/test_transfer_reversal.py
+++ b/tests/test_transfer_reversal.py
@@ -131,7 +131,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
             nested_id=FAKE_TRANSFER_WITH_1_REVERSAL["reversals"]["data"][0]["id"],
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             expand=["balance_transaction", "transfer"],
-            stripe_account=None,
+            stripe_account=transfer_reversal.djstripe_owner_account.id,
         )
 
     @patch.object(Transfer, "_attach_objects_post_save_hook")


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. `djstripe_owner_account` model field will now get populated for all models.
2.  Updated the placeholder Stripe keys in `tests.settings` module to better reflect actual Stripe Keys which need to be at least 32 characters long.
3.  Added a `FAKE_PLATFORM_ACCOUNT` fixture to be used as a proxy for the Stripe Platform account to own all the default Stripe Keys.
4. Added a pytest fixture to create the `Default Stripe Platform Account` along with `Test Keys` to be used for testing.
5. Updated Corresponding tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `djstripe_owner_account` model field will be used to keep track of the `Stripe Account` the given model instance belongs to and that would be of paramount importance once `Multiple Stripe Accounts` get supported.