### PR TITLE
Updated docs with steps on how to use Stripe in a Dockerised Django Container

### DIFF
--- a/docs/usage/using_with_docker.md
+++ b/docs/usage/using_with_docker.md
@@ -1,0 +1,62 @@
+# Using with Docker
+
+A [Docker image](https://hub.docker.com/r/stripe/stripe-cli) allows you to run the Stripe CLI in a container.
+
+Here is a sample `docker-compose.yaml` file that sets up all the services to use `Stripe CLI` in a `dockerised django container (with djstripe)`
+
+
+```yaml
+version: "3.9"
+
+
+volumes:
+    postgres-data: {}
+
+
+services:
+
+  db:
+    image: postgres:12
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=random_number
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=random_number
+
+
+  web:
+    build:
+      context: .
+      dockerfile: <PATH_TO_DOCKERFILE>
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+        # Stripe specific keys
+        - STRIPE_PUBLIC_KEY=pk_test_******
+        - STRIPE_SECRET_KEY=sk_test_******
+        - DJSTRIPE_TEST_WEBHOOK_SECRET=whsec_******
+
+        # Database Specific Settings
+        - DJSTRIPE_TEST_DB_VENDOR=postgres
+        - DJSTRIPE_TEST_DB_PORT=5432
+        - DJSTRIPE_TEST_DB_USER=root
+        - DJSTRIPE_TEST_DB_NAME=random_number
+        - DJSTRIPE_TEST_DB_PASS=random_number
+        - DJSTRIPE_TEST_DB_HOST=db
+
+  stripe:
+    image: stripe/stripe-cli:v1.7.4
+    command: listen --forward-to http://web:8000/djstripe/webhook/
+    depends_on:
+      - web
+    environment:
+      - STRIPE_API_KEY=sk_test_******
+      - STRIPE_DEVICE_NAME=djstripe_docker
+
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - Creating individual charges: usage/creating_individual_charges.md
     - Creating Usage Records: usage/creating_usage_record.md
     - Using Stripe Checkout: usage/using_stripe_checkout.md
+    - Using with Docker: usage/using_with_docker.md
   - Project:
     - Contributing: project/contributing.md
     - Test Fixtures: project/test_fixtures.md


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `docs` with steps on how to use `Stripe` in a `Dockerised Django Container (with dj-stripe)`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Users who want to run their services in a microservices architecture will now know how to easily setup communication between the `local stripe server (for webhooks)` and their `web` container.

Fix: #1456