### PR TITLE
Dj-Stripe docs will get built and deployed automatically

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,19 @@
+name: Build and deploy docs
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: # to trigger manually
+  
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: python -m pip install .[docs]
+
+      - name: Deploy docs to Github Pages
+      - run: mkdocs gh-deploy

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,6 +37,16 @@ To see the project's documentation live, run the following command:
 
 The documentation site will then be served on <http://127.0.0.1:8000>.
 
+!!! attention "In case of any installation error"
+
+    In case you get the error that some plugin is not installed, please run:
+        ``` bash
+
+        poetry install -E docs
+        ```
+
+
+
 If you wish to just generate the documentation, you can replace `serve` with `build`,
 and the docs will be generated into the `site/` folder.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # dj-stripe - Django + Stripe Made Easy
 
-[![Documentation](https://readthedocs.org/projects/dj-stripe/badge/)](https://dj-stripe.readthedocs.io/)
-[![Sponsor dj-stripe](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/dj-stripe)
+[![Documentation](https://img.shields.io/static/v1?label=Docs&message=READ&color=informational&style=plastic)](https://dj-stripe.github.io/dj-stripe/)
+[![Sponsor dj-stripe](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=red&style=plastic)](https://github.com/sponsors/dj-stripe)
 
 Stripe Models for Django.
 
@@ -12,7 +12,7 @@ webhook endpoint and start receiving model updates. You will then have
 a copy of all the Stripe models available in Django models, as soon as
 they are updated!
 
-The full documentation is available [on Read the Docs](https://dj-stripe.readthedocs.io/).
+The full documentation is available [on Read the Docs](https://dj-stripe.github.io/dj-stripe/).
 
 ## Features
 
@@ -38,7 +38,7 @@ The full documentation is available [on Read the Docs](https://dj-stripe.readthe
 
 ## Changelog
 
-[See release notes on Read the Docs](https://dj-stripe.readthedocs.io/en/latest/history/2_5_0/).
+[See release notes on Read the Docs](https://dj-stripe.github.io/dj-stripe/history/2_5_0/).
 
 ## Funding and Support
 

--- a/docs/history/2_x.md
+++ b/docs/history/2_x.md
@@ -156,7 +156,7 @@ pip uninstall jsonfield jsonfield2 -y && pip install "dj-stripe>=2.2.0"
 
 ### Note on usage of Stripe Elements JS
 
-See [Integrating Stripe Elements](https://dj-stripe.readthedocs.io/en/master/stripe_elements_js/)
+See [Integrating Stripe Elements](https://dj-stripe.github.io/dj-stripe/en/master/stripe_elements_js/)
 for notes about usage of the Stripe Elements frontend JS library.
 
 In summary: If you haven't yet migrated to PaymentIntents, prefer

--- a/docs/project/release_process.md
+++ b/docs/project/release_process.md
@@ -105,14 +105,6 @@ Push these changes to the appropriate `stable/MAJOR.MINOR` version
 branch (eg `stable/2.0`) if they're not already - note that this will
 trigger the readthedocs build
 
-## Configure readthedocs
-
-If this is this is a new stable branch then do the following on
-<https://readthedocs.org/projects/dj-stripe/versions/>
-
--   Find the new `stable/MAJOR.MINOR` branch name and mark it as active
-    (and then save).
-
 ## Release on pypi
 
 See

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Dj-Stripe
-site_url: https://dj-stripe.readthedocs.io/
+site_url: https://dj-stripe.github.io/dj-stripe/
 site_description: Django + Stripe Made Easy
 site_author: Dj-Stripe Team
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 readme = "docs/README.md"
 repository = "https://github.com/dj-stripe/dj-stripe"
-documentation = "https://dj-stripe.readthedocs.io/"
+documentation = "https://dj-stripe.github.io/dj-stripe/"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added a `Github Action` to automate `building` and `deploying` docs to `Github Pages` whenever there is a `push` to the `master` branch
2. Added a section to handle `plugin not found` errors while building the docs locally
3. Swapped the old docs link `https://dj-stripe.readthedocs.io/` with the new docs link `https://dj-stripe.github.io/dj-stripe/`


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`docs` will now be updated and auto deployed whenever there is a push to `master` thereby making managing and updating `docs` mostly automated.