### PR TITLE
Fix Customer and SUBSCRIBER_CUSTOMER_KEY relation when a new customer is created directly from Stripe Checkout

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -593,6 +593,7 @@ FAKE_SESSION_I = {
     "submit_type": None,
     "subscription": None,
     "success_url": "https://example.com/success",
+    "metadata": {},
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,12 @@
 Module for creating re-usable fixtures to be used across the test suite
 """
 import pytest
+from django.contrib.auth import get_user_model
 
 from djstripe.enums import APIKeyType
 from djstripe.models import APIKey
 
-from . import FAKE_PLATFORM_ACCOUNT
+from . import FAKE_CUSTOMER, FAKE_PLATFORM_ACCOUNT
 
 pytestmark = pytest.mark.django_db
 
@@ -27,3 +28,17 @@ def create_account_and_stripe_apikeys(settings):
         livemode=False,
         djstripe_owner_account=djstripe_platform_account,
     )
+
+
+@pytest.fixture
+def fake_user():
+    user = get_user_model().objects.create_user(
+        username="arnav", email="arnav13@gmail.com"
+    )
+    return user
+
+
+@pytest.fixture
+def fake_customer(fake_user):
+    customer = FAKE_CUSTOMER.create_for_user(fake_user)
+    return customer

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,11 +4,20 @@ dj-stripe Session Model Tests.
 from copy import deepcopy
 from unittest.mock import patch
 
+import pytest
+import stripe
 from django.test import TestCase
 
 from djstripe.models import Session
+from djstripe.settings import djstripe_settings
+from tests import (
+    FAKE_CUSTOMER,
+    FAKE_PAYMENT_INTENT_I,
+    FAKE_SESSION_I,
+    AssertStripeFksMixin,
+)
 
-from . import FAKE_CUSTOMER, FAKE_PAYMENT_INTENT_I, FAKE_SESSION_I, AssertStripeFksMixin
+pytestmark = pytest.mark.django_db
 
 
 class SessionTest(AssertStripeFksMixin, TestCase):
@@ -69,3 +78,69 @@ class SessionTest(AssertStripeFksMixin, TestCase):
                 "djstripe.Session.subscription",
             },
         )
+
+
+class TestSession:
+
+    key = djstripe_settings.SUBSCRIBER_CUSTOMER_KEY
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {},
+            {"key1": "val1", key: "random"},
+        ],
+    )
+    def test__attach_objects_post_save_hook(
+        self, monkeypatch, fake_user, fake_customer, metadata
+    ):
+        """
+        Test for Checkout Session _attach_objects_post_save_hook
+        """
+        user = fake_user
+        customer = fake_customer
+
+        # because create_for_user method adds subscriber
+        customer.subcriber = None
+        customer.save()
+
+        # update metadata
+        if metadata.get(self.key, ""):
+            metadata[self.key] = user.id
+
+        fake_stripe_session = deepcopy(FAKE_SESSION_I)
+        fake_stripe_session["metadata"] = metadata
+
+        def patched_checkout_session(*args, **kwargs):
+            """Monkeypatched stripe.Session.retrieve"""
+            return fake_stripe_session
+
+        def patched_customer(*args, **kwargs):
+            """Monkeypatched stripe.Customer.retrieve"""
+            fake_customer = deepcopy(FAKE_CUSTOMER)
+            return fake_customer
+
+        def patched_payment_intent(*args, **kwargs):
+            """Monkeypatched stripe.PaymentIntent.retrieve"""
+            fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
+            return fake_payment_intent
+
+        # monkeypatch stripe.checkout.Session.retrieve, stripe.Customer.retrieve, stripe.PaymentIntent.retrieve
+        monkeypatch.setattr(
+            stripe.checkout.Session, "retrieve", patched_checkout_session
+        )
+        monkeypatch.setattr(stripe.Customer, "modify", patched_customer)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", patched_payment_intent)
+
+        # Invoke the sync to invoke _attach_objects_post_save_hook()
+        session = Session.sync_from_stripe_data(fake_stripe_session)
+
+        # refresh self.customer from db
+        customer.refresh_from_db()
+
+        assert session.customer.id == customer.id
+        assert customer.subscriber == user
+        if metadata.get(self.key, ""):
+            assert customer.metadata == {self.key: metadata.get(self.key)}
+        else:
+            assert customer.metadata == {}


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description
Due to a race condition in the webhooks `checkout.session.completed` and `customer.created`,  no relation with the related model using the `SUBSCRIBER_CUSTOMER_KEY` was being created. This was because by the time the `update_customer_helper` was invoked in `event_handlers`, the customer didn't exist locally.


<!-- What are you proposing? -->

This PR contains the following changes:

1. Moved `update_customer_helper` from `event_handlers.checkout_webhook_handler` to `Session._attach_objects_post_save_hook`. That way the customer already exists and is associated with the `Session` object along with any metadata.
2. For `Customers` created directly from `Stripe Checkout` that have `SUBSCRIBER_CUSTOMER_KEY` in their metadict, also updated the `Customer` object upstream in Stripe. This is because when `djstripe_sync_models` is run **only** on the `Customer` model, the saved metadict would get wiped off as it doesn't exist or worse may be different in upstream.
3. Updated Corresponding Tests

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

All `Customers` objects either created directly using `dj-stripe` or via `Stripe Checkout` will have the same metadata dict and be related to the model referenced using `SUBSCRIBER_CUSTOMER_KEY`
