### PR TITLE
Made StripeModel._api_update more efficient and faster.

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -244,8 +244,9 @@ class StripeModel(StripeBaseModel):
         if not stripe_account:
             stripe_account = self._get_stripe_account_id(api_key)
 
-        instance = self.api_retrieve(api_key=api_key, stripe_account=stripe_account)
-        return instance.request("post", instance.instance_url(), params=kwargs)
+        return self.stripe_class.modify(
+            self.id, stripe_account=stripe_account, **kwargs
+        )
 
     def str_parts(self) -> List[str]:
         """


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `StripeModel._api_update()` to make it more efficient by updating the instance directly as opposed to first retrieving it and then `POSTing` the parameters to update it. All we need is the `instance id` to update it anyway.
2. Updated Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will update models in 1 call as opposed to 2 calls making it more efficient and faster.