### PR TITLE
Boatcoder better logging

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -144,14 +144,18 @@ class WebhookEventTrigger(models.Model):
 
         local_data = self.json_body
         if "id" not in local_data or "livemode" not in local_data:
+            logger.error(
+                '"id" not in json body or "livemode" not in json body(%s)', local_data
+            )
             return False
 
         if self.is_test_event:
-            logger.info("Test webhook received: {}".format(local_data))
+            logger.info("Test webhook received and discarded: {}".format(local_data))
             return False
 
         if djstripe_settings.WEBHOOK_VALIDATION is None:
             # validation disabled
+            warnings.warn("WEBHOOK VALIDATION is disabled.")
             return True
         elif (
             djstripe_settings.WEBHOOK_VALIDATION == "verify_signature"
@@ -167,6 +171,7 @@ class WebhookEventTrigger(models.Model):
                     djstripe_settings.WEBHOOK_TOLERANCE,
                 )
             except stripe.error.SignatureVerificationError:
+                logger.exception("Failed to verify header")
                 return False
             else:
                 return True

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -30,16 +30,18 @@ class ProcessWebhookView(View):
         if "HTTP_STRIPE_SIGNATURE" not in request.META:
             # Do not even attempt to process/store the event if there is
             # no signature in the headers so we avoid overfilling the db.
+            logger.error("HTTP_STRIPE_SIGNATURE is missing")
             return HttpResponseBadRequest()
 
         trigger = WebhookEventTrigger.from_request(request)
 
         if trigger.is_test_event:
             # Since we don't do signature verification, we have to skip trigger.valid
-            return HttpResponse("Test webhook successfully received!")
+            return HttpResponse("Test webhook successfully received and discarded!")
 
         if not trigger.valid:
             # Webhook Event did not validate, return 400
+            logger.error("Trigger object did not validate")
             return HttpResponseBadRequest()
 
         return HttpResponse(str(trigger.id))


### PR DESCRIPTION
Existing code returns errors around webhooks but doesn't tell you why, real PITA when you are trying to figure it out in prod, especially when the cause is known at this level

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

Better logging for webhook errors

This PR contains the following changes:

1. Error and Exception logging for the webhooks


Checklist:

- [ X ] I've updated the `tests` or confirm that my change doesn't require any updates.
- [ X ] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [ X ] I confirm that my change doesn't drop code coverage below the current level.
- [ X ] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

I wasted quite a bit of time trying to pin down why my webhooks were being failed with a 400, there were several possibilities.  Since these only fire when there is an error, it won't slow anything down and the logs will be very explicit as to where in the validation/processing portion of a webhook the problem happened.

I've also added a comment in there so you can see that test messages are just discarded and not processed.  Earlier I was kind of irate that djstripe wasn't calling my webhook with the messages.  Seemed appropriate to note that they were being discarded so I knew WHY my webhook callable was not being called.