### PR TITLE
Installing `docs dev-dependencies` using `poetry`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,9 +15,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-          python-version: 3.8
-    - name: Install dependencies
-      run: python -m pip install .[docs]
+          python-version: 3.9
+  
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.1.11
 
     - name: Deploy docs to Github Pages
       run: mkdocs gh-deploy


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Installing `poetry` to easily install all optional `docs` dependencies as well. This was required because there is no straightforward way to install `dev-dependencies` using `pip install`


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Turns out there is no easy way to install `dev-dependencies` using pip even if it is mentioned in the `optional` section.