### PR TITLE
Made StripeModel._find_owner_account work for all object types

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -273,11 +273,21 @@ class StripeModel(StripeBaseModel):
         """
         from .account import Account
 
-        if data and data.get("account"):
-            # try to fetch by stripe_account. Also takes care of Stripe Connected Accounts
-            stripe_account = cls._id_from_data(data.get("account"))
-            if stripe_account:
-                return Account._get_or_retrieve(id=stripe_account)
+        # try to fetch by stripe_account. Also takes care of Stripe Connected Accounts
+        if data:
+            # case of Webhook Event Trigger
+            if data.get("object") == "event":
+                # if account key exists and has a not null value
+                if data.get("account"):
+                    stripe_account = cls._id_from_data(data.get("account"))
+                    if stripe_account:
+                        return Account._get_or_retrieve(id=stripe_account)
+
+            else:
+                if getattr(data, "stripe_account", ""):
+                    stripe_account = cls._id_from_data(data.stripe_account)
+                    if stripe_account:
+                        return Account._get_or_retrieve(id=stripe_account)
 
         # try to fetch by the given api_key.
         return Account.get_or_retrieve_for_api_key(api_key)

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -143,24 +143,18 @@ def test_api_retrieve_reverse_foreign_key_lookup(mock_stripe_class):
     mock_account_reverse_manager.first.assert_called_once_with()
 
 
-@pytest.mark.parametrize("stripe_account", (None, "acct_fakefakefakefake001"))
 @pytest.mark.parametrize("api_key", (None, "sk_fakefakefake01"))
 @patch.object(target=Account, attribute="get_or_retrieve_for_api_key")
-@patch.object(target=Account, attribute="_get_or_retrieve")
-def test__find_owner_account(
-    mock__get_or_retrieve, mock_get_or_retrieve_for_api_key, stripe_account, api_key
+def test__find_owner_account_for_empty_data(
+    mock_get_or_retrieve_for_api_key,
+    api_key,
 ):
     """
     Test that the correct classmethod is invoked with the correct arguments
     to get the owner account
     """
-    # fake_data used to invoke _find_owner_account classmethod
-    fake_data = {
-        "id": "test_XXXXXXXX",
-        "livemode": False,
-        "object": "customer",
-        "account": stripe_account,
-    }
+
+    fake_data = {}
 
     if api_key is None:
         # invoke _find_owner_account without the api_key parameter
@@ -169,12 +163,113 @@ def test__find_owner_account(
         # invoke _find_owner_account with the api_key parameter
         StripeModel._find_owner_account(fake_data, api_key=api_key)
 
-    # if stripe_account exists, assert _get_or_retrieve classmethod
-    # gets called
-    if stripe_account:
+    if api_key:
+        mock_get_or_retrieve_for_api_key.assert_called_once_with(api_key)
+    else:
+        mock_get_or_retrieve_for_api_key.assert_called_once_with(
+            djstripe_settings.STRIPE_SECRET_KEY
+        )
+
+
+@pytest.mark.parametrize(
+    "has_stripe_account_attr,stripe_account",
+    ((False, None), (True, ""), (True, "acct_fakefakefakefake001")),
+)
+@pytest.mark.parametrize("api_key", (None, "sk_fakefakefake01"))
+@patch.object(target=Account, attribute="get_or_retrieve_for_api_key")
+@patch.object(target=Account, attribute="_get_or_retrieve")
+def test__find_owner_account(
+    mock__get_or_retrieve,
+    mock_get_or_retrieve_for_api_key,
+    api_key,
+    stripe_account,
+    has_stripe_account_attr,
+    monkeypatch,
+):
+    """
+    Test that the correct classmethod is invoked with the correct arguments
+    to get the owner account
+    """
+    # fake_data_class used to invoke _find_owner_account classmethod
+    class fake_data_class:
+        @property
+        def stripe_account(self):
+            return stripe_account
+
+        def get(*args, **kwargs):
+            return "customer"
+
+    fake_data = fake_data_class()
+
+    if api_key is None:
+        # invoke _find_owner_account without the api_key parameter
+        StripeModel._find_owner_account(fake_data)
+    else:
+        # invoke _find_owner_account with the api_key parameter
+        StripeModel._find_owner_account(fake_data, api_key=api_key)
+
+    if has_stripe_account_attr and stripe_account:
         mock__get_or_retrieve.assert_called_once_with(id=stripe_account)
 
-    # if api_key exists and stripe_account doesn't, assert get_or_retrieve_for_api_key
-    # classmethod gets called
-    if api_key and not stripe_account:
-        mock_get_or_retrieve_for_api_key.assert_called_once_with(api_key)
+    else:
+        if api_key:
+            mock_get_or_retrieve_for_api_key.assert_called_once_with(api_key)
+        else:
+            mock_get_or_retrieve_for_api_key.assert_called_once_with(
+                djstripe_settings.STRIPE_SECRET_KEY
+            )
+
+
+@pytest.mark.parametrize(
+    "has_account_key,stripe_account",
+    ((False, None), (True, ""), (True, "acct_fakefakefakefake001")),
+)
+@pytest.mark.parametrize("api_key", (None, "sk_fakefakefake01"))
+@patch.object(target=Account, attribute="get_or_retrieve_for_api_key")
+@patch.object(target=Account, attribute="_get_or_retrieve")
+def test__find_owner_account_for_webhook_event_trigger(
+    mock__get_or_retrieve,
+    mock_get_or_retrieve_for_api_key,
+    api_key,
+    stripe_account,
+    has_account_key,
+):
+    """
+    Test that the correct classmethod is invoked with the correct arguments
+    to get the owner account
+    """
+
+    # should fake_data have the account key
+    if has_account_key:
+        # fake_data used to invoke _find_owner_account classmethod
+        fake_data = {
+            "id": "test_XXXXXXXX",
+            "livemode": False,
+            "object": "event",
+            "account": stripe_account,
+        }
+    else:
+        # fake_data used to invoke _find_owner_account classmethod
+        fake_data = {
+            "id": "test_XXXXXXXX",
+            "livemode": False,
+            "object": "event",
+        }
+
+    if api_key is None:
+        # invoke _find_owner_account without the api_key parameter
+        StripeModel._find_owner_account(fake_data)
+    else:
+        # invoke _find_owner_account with the api_key parameter
+        StripeModel._find_owner_account(fake_data, api_key=api_key)
+
+    if has_account_key and stripe_account:
+        mock__get_or_retrieve.assert_called_once_with(id=stripe_account)
+
+    else:
+        if api_key:
+            mock_get_or_retrieve_for_api_key.assert_called_once_with(api_key)
+        else:
+            mock_get_or_retrieve_for_api_key.assert_called_once_with(
+                djstripe_settings.STRIPE_SECRET_KEY
+            )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `StripeModel._find_owner_account()` to make it work for `event` as well as other `stripe objects` for both the `Platform` as well as `Connected` Accounts
2. Updated Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`djstripe_owner_account` model field will get populated correctly for all `Stripe Objects` on not only the `Platform` Accounts but also the `Connected Accounts`. Previously, they were not working correctly for `Connected Accounts`.