### PR TITLE
Expose CountrySpec Stripe Model on Admin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -316,6 +316,18 @@ class ChargeAdmin(StripeModelAdmin):
     list_filter = ("status", "paid", "refunded", "captured")
 
 
+@admin.register(models.CountrySpec)
+class CountrySpecAdmin(ReadOnlyMixin, admin.ModelAdmin):
+    list_display = ("id", "default_currency", "supported_payment_methods")
+    list_filter = ("default_currency", "supported_payment_methods")
+    search_fields = (
+        "default_currency",
+        "supported_payment_methods",
+        "supported_payment_currencies",
+        "supported_transfer_countries",
+    )
+
+
 @admin.register(models.Coupon)
 class CouponAdmin(StripeModelAdmin):
     list_display = (

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -52,7 +52,9 @@ def test_get_forward_relation_fields_for_model(output, input):
     assert output == djstripe_admin.get_forward_relation_fields_for_model(input)
 
 
-class TestAdminRegisteredModels(TestCase):
+class TestStripeModelAdminRegisteredModels(TestCase):
+    """Test class for all admin classes that inherit from StripeModelAdmin"""
+
     def setUp(self):
         self.admin = get_user_model().objects.create_superuser(
             username="admin", email="admin@djstripe.com", password="xxx"
@@ -60,7 +62,7 @@ class TestAdminRegisteredModels(TestCase):
         self.factory = RequestFactory()
         # the 2 models that do not inherit from StripeModel and hence
         # do not inherit from StripeModelAdmin
-        self.ignore_models = ["WebhookEventTrigger", "IdempotencyKey"]
+        self.ignore_models = ["WebhookEventTrigger", "IdempotencyKey", "CountrySpec"]
 
     def test_get_list_display_links(self):
         app_label = "djstripe"
@@ -413,6 +415,8 @@ class TestAdminRegisteredModels(TestCase):
 
 
 class TestAdminInlineModels(TestCase):
+    """Test class for all admin classes that inherit from admin.StackedInline or admin.TabularInline"""
+
     def test_readonly_fields_exist(self):
         """
         Ensure all fields in BaseModelAdmin.readonly_fields exist on the model
@@ -430,6 +434,8 @@ class TestAdminInlineModels(TestCase):
 
 
 class TestAdminSite(TestCase):
+    """Test class for all admin model classes"""
+
     def setUp(self):
         self.empty_value = "-empty-"
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Exposed the `CountrySpec` Stripe Model on the `django` admin.
2. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
All Stripe models should be exposed on the Admin for better user experience.