### PR TITLE
djstripe_sync_models will now also sync data for Connected Accounts

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -1,3 +1,13 @@
+"""Module for the djstripe_sync_model management command to sync
+all Stripe objects to the local db.
+
+Invoke like so:
+    1) To sync all Objects:
+        python manage.py djstripe_sync_models
+
+    2) To only sync Stripe Accounts:
+        python manage.py djstripe_sync_models Account
+"""
 from typing import List
 
 from django.apps import apps
@@ -69,7 +79,7 @@ class Command(BaseCommand):
 
         return True, ""
 
-    def sync_model(self, model):
+    def sync_model(self, model):  # noqa: C901
         model_name = model.__name__
 
         should_sync, reason = self._should_sync_model(model)
@@ -82,42 +92,47 @@ class Command(BaseCommand):
         count = 0
         try:
             for list_kwargs in self.get_list_kwargs(model):
+                stripe_account = list_kwargs.get("stripe_account", "")
 
-                if model is models.Account:
+                if (
+                    model is models.Account
+                    and stripe_account == models.Account.get_default_account().id
+                ):
                     # special case, since own account isn't returned by Account.api_list
                     stripe_obj = models.Account.stripe_class.retrieve(
                         api_key=djstripe_settings.STRIPE_SECRET_KEY
                     )
-                    count += 1
+
                     djstripe_obj = model.sync_from_stripe_data(stripe_obj)
                     self.stdout.write(
-                        "  id={id}, pk={pk} ({djstripe_obj})".format(
-                            id=djstripe_obj.id,
-                            pk=djstripe_obj.pk,
-                            djstripe_obj=djstripe_obj,
-                        )
+                        f"  id={djstripe_obj.id}, pk={djstripe_obj.pk} ({djstripe_obj} on {stripe_account})"
                     )
 
                     # syncing BankAccount and Card objects of Stripe Connected Express and Custom Accounts
-                    self.sync_bank_accounts_and_cards(djstripe_obj)
+                    self.sync_bank_accounts_and_cards(
+                        djstripe_obj, stripe_account=stripe_account
+                    )
+                    count += 1
 
-                for stripe_obj in model.api_list(**list_kwargs):
-                    # Skip model instances that throw an error
-                    try:
-                        djstripe_obj = model.sync_from_stripe_data(stripe_obj)
-                        self.stdout.write(
-                            "  id={id}, pk={pk} ({djstripe_obj})".format(
-                                id=djstripe_obj.id,
-                                pk=djstripe_obj.pk,
-                                djstripe_obj=djstripe_obj,
+                try:
+                    for stripe_obj in model.api_list(**list_kwargs):
+                        # Skip model instances that throw an error
+                        try:
+                            djstripe_obj = model.sync_from_stripe_data(stripe_obj)
+                            self.stdout.write(
+                                f"  id={djstripe_obj.id}, pk={djstripe_obj.pk} ({djstripe_obj} on {stripe_account})"
                             )
-                        )
-                        # syncing BankAccount and Card objects of Stripe Connected Express and Custom Accounts
-                        self.sync_bank_accounts_and_cards(djstripe_obj)
-                        count += 1
-                    except Exception as e:
-                        self.stderr.write(f"Skipping {stripe_obj.get('id')}: {e}")
-                        continue
+                            # syncing BankAccount and Card objects of Stripe Connected Express and Custom Accounts
+                            self.sync_bank_accounts_and_cards(
+                                djstripe_obj, stripe_account=stripe_account
+                            )
+                            count += 1
+                        except Exception as e:
+                            self.stderr.write(f"Skipping {stripe_obj.get('id')}: {e}")
+
+                            continue
+                except Exception as e:
+                    self.stderr.write(f"Skipping: {e}")
 
             if count == 0:
                 self.stdout.write("  (no results)")
@@ -131,8 +146,137 @@ class Command(BaseCommand):
         except Exception as e:
             self.stderr.write(str(e))
 
-    # todo Handle syncing data for connected accounts as well. # https://stripe.com/docs/api/accounts/list
-    # ! Will need to re-run with different values of stripe_account
+    @classmethod
+    def get_stripe_account(cls, *args, **kwargs):
+        """Get set of all stripe account ids including the Platform Acccount"""
+        accs_set = set()
+
+        # special case, since own account isn't returned by Account.api_list
+        stripe_platform_obj = models.Account.stripe_class.retrieve(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )
+        accs_set.add(stripe_platform_obj.id)
+
+        for stripe_connected_obj in models.Account.api_list(**kwargs):
+            accs_set.add(stripe_connected_obj.id)
+
+        return accs_set
+
+    @staticmethod
+    def get_default_list_kwargs(model, accounts_set):
+        """Returns default sequence of kwargs to sync
+        all Stripe Accounts"""
+
+        if getattr(model, "expand_fields", []):
+            default_list_kwargs = [
+                {
+                    "expand": [f"data.{k}" for k in model.expand_fields],
+                    "stripe_account": account,
+                }
+                for account in accounts_set
+            ]
+
+        else:
+            default_list_kwargs = [
+                {"stripe_account": account} for account in accounts_set
+            ]
+
+        return default_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_pm(default_list_kwargs):
+        """Returns sequence of kwrags to sync Payment Methods for
+        all Stripe Accounts"""
+
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for stripe_customer in models.Customer.api_list(
+                stripe_account=stripe_account
+            ):
+                all_list_kwargs.append(
+                    {"customer": stripe_customer.id, "type": "card", **def_kwarg}
+                )
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_si(default_list_kwargs):
+        """Returns sequence of kwrags to sync Subscription Items for
+        all Stripe Accounts"""
+
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for subscription in models.Subscription.api_list(
+                stripe_account=stripe_account
+            ):
+                all_list_kwargs.append({"subscription": subscription.id, **def_kwarg})
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_country_spec(default_list_kwargs):
+        """Returns sequence of kwrags to sync Country Specs for
+        all Stripe Accounts"""
+
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            all_list_kwargs.append({"limit": 50, **def_kwarg})
+
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_trr(default_list_kwargs):
+        """Returns sequence of kwrags to sync Transfer Reversals for
+        all Stripe Accounts"""
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for transfer in models.Transfer.api_list(stripe_account=stripe_account):
+                all_list_kwargs.append({"id": transfer.id, **def_kwarg})
+
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_fee_refund(default_list_kwargs):
+        """Returns sequence of kwrags to sync Application Fee Refunds for
+        all Stripe Accounts"""
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for fee in models.ApplicationFee.api_list(stripe_account=stripe_account):
+                all_list_kwargs.append({"id": fee.id, **def_kwarg})
+
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_tax_id(default_list_kwargs):
+        """Returns sequence of kwrags to sync Tax Ids for
+        all Stripe Accounts"""
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for customer in models.Customer.api_list(stripe_account=stripe_account):
+                all_list_kwargs.append({"id": customer.id, **def_kwarg})
+
+        return all_list_kwargs
+
+    @staticmethod
+    def get_list_kwargs_sis(default_list_kwargs):
+        """Returns sequence of kwrags to sync Usage Record Summarys for
+        all Stripe Accounts"""
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            for subscription in models.Subscription.api_list(
+                stripe_account=stripe_account
+            ):
+                for subscription_item in models.SubscriptionItem.api_list(
+                    subscription=subscription.id, stripe_account=stripe_account
+                ):
+                    all_list_kwargs.append({"id": subscription_item.id, **def_kwarg})
+
+        return all_list_kwargs
+
     # todo handle supoorting double + nested fields like data.invoice.subscriptions.customer etc?
     def get_list_kwargs(self, model):
         """
@@ -143,60 +287,31 @@ class Command(BaseCommand):
         :param model:
         :return: Sequence[dict]
         """
-        all_list_kwargs = (
-            [{"expand": [f"data.{k}" for k in model.expand_fields]}]
-            if getattr(model, "expand_fields", [])
-            else [{}]
+
+        list_kwarg_handlers_dict = {
+            "PaymentMethod": self.get_list_kwargs_pm,
+            "SubscriptionItem": self.get_list_kwargs_si,
+            "CountrySpec": self.get_list_kwargs_country_spec,
+            "TransferReversal": self.get_list_kwargs_trr,
+            "ApplicationFeeRefund": self.get_list_kwargs_fee_refund,
+            "TaxId": self.get_list_kwargs_tax_id,
+            "UsageRecordSummary": self.get_list_kwargs_sis,
+        }
+
+        # get all Stripe Accounts for the given platform account.
+        # note that we need to fetch from Stripe as we have no way of knowing that the ones in the local db are up to date
+        # as this can also be the first time the user runs sync.
+        accs_set = self.get_stripe_account()
+
+        default_list_kwargs = self.get_default_list_kwargs(model, accs_set)
+
+        handler = list_kwarg_handlers_dict.get(
+            model.__name__, lambda _: default_list_kwargs
         )
 
-        if model is models.PaymentMethod:
-            # special case
-            all_list_kwargs = [
-                {"customer": stripe_customer.id, "type": "card", **all_list_kwargs[0]}
-                for stripe_customer in models.Customer.api_list()
-            ]
+        return handler(default_list_kwargs)
 
-        elif model is models.SubscriptionItem:
-            all_list_kwargs = [
-                {"subscription": subscription.id, **all_list_kwargs[0]}
-                for subscription in models.Subscription.api_list()
-            ]
-
-        elif model is models.CountrySpec:
-            all_list_kwargs.extend(({"limit": 50},))
-
-        elif model is models.TransferReversal:
-            all_list_kwargs = [
-                {"id": transfer.id, **all_list_kwargs[0]}
-                for transfer in models.Transfer.api_list()
-            ]
-
-        elif model is models.ApplicationFeeRefund:
-            all_list_kwargs = [
-                {"id": fee.id, **all_list_kwargs[0]}
-                for fee in models.ApplicationFee.api_list()
-            ]
-        elif model is models.TaxId:
-            all_list_kwargs = [
-                {"id": customer.id, **all_list_kwargs[0]}
-                for customer in models.Customer.api_list()
-            ]
-
-        elif model is models.UsageRecordSummary:
-            all_list_kwargs = [
-                {"id": subscription_item.id, **all_list_kwargs[0]}
-                for subscription in models.Subscription.api_list()
-                for subscription_item in models.SubscriptionItem.api_list(
-                    subscription=subscription.id
-                )
-            ]
-
-        elif not all_list_kwargs:
-            all_list_kwargs.append({})
-
-        return all_list_kwargs
-
-    def sync_bank_accounts_and_cards(self, instance):
+    def sync_bank_accounts_and_cards(self, instance, *, stripe_account):
         """
         Syncs Bank Accounts and Cards for both customers and all external accounts
         """
@@ -204,6 +319,7 @@ class Command(BaseCommand):
         kwargs = {
             "id": instance.id,
             "api_key": djstripe_settings.STRIPE_SECRET_KEY,
+            "stripe_account": stripe_account,
         }
 
         if type in (enums.AccountType.custom, enums.AccountType.express) and isinstance(
@@ -211,7 +327,9 @@ class Command(BaseCommand):
         ):
 
             # fetch all Card and BankAccount objects associated with the instance
-            items = models.Account.stripe_class.list_external_accounts(**kwargs)
+            items = models.Account.stripe_class.list_external_accounts(
+                **kwargs
+            ).auto_paging_iter()
 
             self.start_sync(items, instance)
         elif isinstance(instance, models.Customer):
@@ -219,14 +337,16 @@ class Command(BaseCommand):
                 kwargs["object"] = object
 
                 # fetch all Card and BankAccount objects associated with the instance
-                items = models.Customer.stripe_class.list_sources(**kwargs)
+                items = models.Customer.stripe_class.list_sources(
+                    **kwargs
+                ).auto_paging_iter()
 
                 self.start_sync(items, instance)
 
     def start_sync(self, items, instance):
         bank_count = 0
         card_count = 0
-        for item in items.auto_paging_iter():
+        for item in items:
 
             if item.object == "bank_account":
                 model = models.BankAccount

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -579,11 +579,14 @@ class Product(StripeModel):
     def __str__(self):
         # 1 product can have 1 or more than 1 related price
         price_qs = Price.objects.filter(product__id=self.id)
+        price_count = price_qs.count()
 
-        if price_qs.count() > 1:
-            return f"{self.name} ({price_qs.count()} prices)"
-        else:
+        if price_count > 1:
+            return f"{self.name} ({price_count} prices)"
+        elif price_count == 1:
             return f"{self.name} ({price_qs[0].human_readable_price})"
+        else:
+            return self.name
 
 
 class Customer(StripeModel):

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -26,7 +26,7 @@ class DjstripePaymentMethod(models.Model):
 
     Contains two fields: `id` and `type`:
     - `id` is the id of the Stripe object.
-    - `type` can be `card`, `bank_account` or `source`.
+    - `type` can be `card`, `bank_account` `account` or `source`.
     """
 
     id = models.CharField(max_length=255, primary_key=True)
@@ -65,6 +65,8 @@ class DjstripePaymentMethod(models.Model):
             return Source
         elif type == "bank_account":
             return BankAccount
+        elif type == "account":
+            return Account
 
         raise ValueError("Unknown source type: {}".format(type))
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Added missing `account` source type to the `DjStripePaymentMethod` model. This is required for syncing sources for `Connected Accounts`.
2. Updated `Product.__str__()` to also handle the case that a `Price` is not attached to a `Product`. This is a corner case that can occur if a `Product` is created along with the `Price` object and the webhooks so fired create the `Price` object locally before the `Product`.
3.  Made `djstripe_sync_models` also sync data for `Connected Accounts` as well.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`djstripe_sync_models` will now also sync data for `Stripe Connected Accounts`.