### PR TITLE
Made StripeModel._api_delete() more efficient and faster.

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -224,8 +224,8 @@ class StripeModel(StripeBaseModel):
         if not stripe_account:
             stripe_account = self._get_stripe_account_id(api_key)
 
-        return self.api_retrieve(api_key=api_key, stripe_account=stripe_account).delete(
-            **kwargs
+        return self.stripe_class.delete(
+            self.id, api_key=api_key, stripe_account=stripe_account, **kwargs
         )
 
     def _api_update(self, api_key=None, stripe_account=None, **kwargs):

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -256,6 +256,33 @@ class LegacySourceMixin:
                 api_key=api_key,
             )
 
+    def _api_delete(self, api_key=None, stripe_account=None, **kwargs):
+        # OVERRIDING the parent version of this function
+        # Cards & Banks Accounts must be manipulated through a customer or account.
+
+        api_key = api_key or self.default_api_key
+        # Prefer passed in stripe_account if set.
+        if not stripe_account:
+            stripe_account = self._get_stripe_account_id(api_key)
+
+        if self.customer:
+            return stripe.Customer.delete_source(
+                self.customer.id,
+                self.id,
+                api_key=api_key,
+                stripe_account=stripe_account,
+                **kwargs,
+            )
+
+        if self.account:
+            return stripe.Account.delete_external_account(
+                self.account.id,
+                self.id,
+                api_key=api_key,
+                stripe_account=stripe_account,
+                **kwargs,
+            )
+
 
 class BankAccount(LegacySourceMixin, StripeModel):
     stripe_class = stripe.BankAccount

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -969,13 +969,22 @@ class TestCustomerEvents(EventTestCase):
         self.assertEqual(customer.metadata, {"djstripe_subscriber": self.user.id})
 
     @patch(
+        "stripe.Customer.delete_source",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    @patch("stripe.Customer.delete", autospec=True)
+    @patch(
         "stripe.Customer.retrieve_source",
         side_effect=[deepcopy(FAKE_CARD), deepcopy(FAKE_CARD_III)],
         autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     )
     @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
     def test_customer_deleted(
-        self, customer_retrieve_source_mock, customer_retrieve_mock
+        self,
+        customer_retrieve_mock,
+        customer_retrieve_source_mock,
+        customer_delete_mock,
+        customer_source_delete_mock,
     ):
 
         FAKE_CUSTOMER.create_for_user(self.user)

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -1,7 +1,7 @@
 """
 dj-stripe StripeModel Model Tests.
 """
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
@@ -46,23 +46,22 @@ class TestStripeModelExceptions(TestCase):
     ),
 )
 @pytest.mark.parametrize("extra_kwargs", ({}, {"foo": "bar"}))
-@patch.object(target=StripeModel, attribute="api_retrieve", autospec=True)
+@patch.object(target=StripeModel, attribute="stripe_class")
 def test__api_delete(
-    mock_api_retrieve, stripe_account, api_key, expected_api_key, extra_kwargs
+    mock_stripe_class, stripe_account, api_key, expected_api_key, extra_kwargs
 ):
     """Test that API delete properly uses the passed in parameters."""
     test_model = TestStripeModel()
+    mock_id = "id_fakefakefakefake01"
+    test_model.id = mock_id
+
+    # invoke _api_delete()
     test_model._api_delete(
         api_key=api_key, stripe_account=stripe_account, **extra_kwargs
     )
 
-    # Assert the chained calls happened as expected, since it should
-    # call api_retrieve() followed by delete()
-    assert (
-        mock_api_retrieve.mock_calls
-        == call(test_model, api_key=expected_api_key, stripe_account=stripe_account)
-        .delete(**extra_kwargs)
-        .call_list()
+    mock_stripe_class.delete.assert_called_once_with(
+        mock_id, api_key=expected_api_key, stripe_account=stripe_account, **extra_kwargs
     )
 
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -471,14 +471,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
-    @patch("stripe.Subscription.retrieve", autospec=True)
+    @patch("stripe.Subscription.delete", autospec=True)
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     def test_cancel_now(
         self,
         customer_retrieve_mock,
-        subscription_retrieve_mock,
+        subscription_delete_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
     ):
@@ -492,9 +492,8 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
         canceled_subscription_fake["status"] = SubscriptionStatus.canceled
         canceled_subscription_fake["canceled_at"] = cancel_timestamp
         canceled_subscription_fake["ended_at"] = cancel_timestamp
-        subscription_retrieve_mock.return_value = (
-            canceled_subscription_fake  # retrieve().delete()
-        )
+
+        subscription_delete_mock.return_value = canceled_subscription_fake
 
         self.assertTrue(self.customer.is_subscribed_to(FAKE_PRODUCT["id"]))
         self.assertEqual(self.customer.active_subscriptions.count(), 1)
@@ -523,14 +522,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
         "stripe.Subscription.modify",
         autospec=True,
     )
-    @patch("stripe.Subscription.retrieve", autospec=True)
+    @patch("stripe.Subscription.delete", autospec=True)
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     def test_cancel_at_period_end(
         self,
         customer_retrieve_mock,
-        subscription_retrieve_mock,
+        subscription_delete_mock,
         subscription_modify_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
@@ -547,7 +546,7 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
             current_period_end
         )
         canceled_subscription_fake["canceled_at"] = datetime_to_unix(timezone.now())
-        subscription_retrieve_mock.return_value = (
+        subscription_delete_mock.return_value = (
             canceled_subscription_fake  # retrieve().delete()
         )
 
@@ -582,14 +581,14 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
-    @patch("stripe.Subscription.retrieve", autospec=True)
+    @patch("stripe.Subscription.delete", autospec=True)
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     def test_cancel_during_trial_sets_at_period_end(
         self,
         customer_retrieve_mock,
-        subscription_retrieve_mock,
+        subscription_delete_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
     ):
@@ -603,9 +602,7 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
         canceled_subscription_fake["status"] = SubscriptionStatus.canceled
         canceled_subscription_fake["canceled_at"] = cancel_timestamp
         canceled_subscription_fake["ended_at"] = cancel_timestamp
-        subscription_retrieve_mock.return_value = (
-            canceled_subscription_fake  # retrieve().delete()
-        )
+        subscription_delete_mock.return_value = canceled_subscription_fake
 
         self.assertTrue(self.customer.is_subscribed_to(FAKE_PRODUCT["id"]))
         self.assertTrue(self.customer.has_any_active_subscription())


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `StripeModel._api_delete()` to make it more efficient by `deleting` the instance directly as opposed to first retrieving it and then `deleting` it. All we need is the `instance id` to delete it anyway.
2. Added `LegacySourceMixin._api_delete()` to take advantage of stripe methods like `stripe.Customer.delete_source` and `stripe.Account.delete_external_account` to delete `customer sources` and ` external accounts` directly instead of first retrieving them and then deleting them.
3. Updated Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will delete models in 1 call as opposed to 2 calls making it more efficient and faster.