### PR TITLE
Fix customer uniqueness checks

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -832,9 +832,6 @@ class Customer(StripeModel):
     )
     date_purged = models.DateTimeField(null=True, editable=False)
 
-    class Meta(StripeModel.Meta):
-        unique_together = ("subscriber", "livemode", "djstripe_owner_account")
-
     def __str__(self):
         if self.subscriber:
             return str(self.subscriber)

--- a/docs/history/3_0_0.md
+++ b/docs/history/3_0_0.md
@@ -34,3 +34,7 @@
 
 
 ## Other changes
+- Dropped `unique_together` constraint on the `Customer` model. This was done because given the same `livemode` and `djstripe_owner_account`, a `subscriber` can be associated with multiple customers and that is Stripe's default behavior.
+- Added missing model fields to Checkout Sessions.
+- `LineItem` instances can also get synced using the `djstripe_sync_models` management command.
+-  Updated `check_stripe_api_key` django system check to not be a blocker for new dj-stripe users by raising Info warnings on the console. If the Stripe keys were not defined in the settings file, the `Critical` warning was preventing users to add them directly from the admin as mentioned in the docs. This was creating a chicken-egg situation where one could only add keys in the admin before they were defined in settings.


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed the incorrect Customer `unique_together` constraint `("subscriber", "livemode", "djstripe_owner_account")`. This is because given the same `livemode` and `djstripe_owner_account`, a `subscriber` can be associated with multiple  `customer` and that is Stripe's default behavior.  The only reason this wasn't caught up until now is because `customers` created using `Stripe Checkout` were not getting associated with `Subscriber` correctly.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
1 `Subscriber` can be associated with multiple `customer` accounts.

Fix: #1812 