### PR TITLE
Fixed Stale data issue with StripePercentField and models.DecimalField

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -13,7 +13,13 @@ from stripe.error import InvalidRequestError
 
 from djstripe.utils import get_friendly_currency_amount
 
-from ..fields import JSONField, StripeDateTimeField, StripeForeignKey, StripeIdField
+from ..fields import (
+    JSONField,
+    StripeDateTimeField,
+    StripeForeignKey,
+    StripeIdField,
+    StripePercentField,
+)
 from ..managers import StripeModelManager
 from ..settings import djstripe_settings
 
@@ -940,6 +946,11 @@ class StripeModel(StripeBaseModel):
             instance._attach_objects_hook(cls, data, current_ids=current_ids)
             instance.save()
             instance._attach_objects_post_save_hook(cls, data)
+
+        for field in instance._meta.concrete_fields:
+            if isinstance(field, StripePercentField):
+                # get rid of cached values
+                delattr(instance, field.name)
 
         return instance
 

--- a/tests/fields/models.py
+++ b/tests/fields/models.py
@@ -1,0 +1,9 @@
+"""Models used exclusively for testing"""
+
+from django.db import models
+
+from djstripe.fields import StripePercentField
+
+
+class TestDecimalModel(models.Model):
+    noval = StripePercentField()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -81,6 +81,8 @@ INSTALLED_APPS = [
     "jsonfield",
     "djstripe",
     "tests",
+    # to load custom models defined to test fields.py
+    "tests.fields",
     "tests.apps.testapp",
     "tests.apps.example",
 ]

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from decimal import Decimal
 
 import pytest
 from django.test.testcases import TestCase
@@ -105,3 +106,32 @@ class TestCouponStr(TestCase):
     def test_blank_coupon_str(self):
         coupon = Coupon()
         self.assertEqual(str(coupon).strip(), "(invalid amount) off")
+
+
+class TestCouponDecimal:
+    @pytest.mark.parametrize(
+        "inputted,expected",
+        [
+            (Decimal("1"), Decimal("1.00")),
+            (Decimal("1.5234567"), Decimal("1.52")),
+            (Decimal("0"), Decimal("0.00")),
+            (Decimal("23.2345678"), Decimal("23.23")),
+            ("1", Decimal("1.00")),
+            ("1.5234567", Decimal("1.52")),
+            ("0", Decimal("0.00")),
+            ("23.2345678", Decimal("23.23")),
+            (1, Decimal("1.00")),
+            (1.5234567, Decimal("1.52")),
+            (0, Decimal("0.00")),
+            (23.2345678, Decimal("23.24")),
+        ],
+    )
+    def test_decimal_percent_off_coupon(self, inputted, expected):
+        fake_coupon = deepcopy(FAKE_COUPON)
+        fake_coupon["percent_off"] = inputted
+
+        coupon = Coupon.sync_from_stripe_data(fake_coupon)
+        field_data = coupon.percent_off
+
+        assert isinstance(field_data, Decimal)
+        assert field_data == expected

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,6 +9,7 @@ from django.test.testcases import TestCase
 from django.test.utils import override_settings
 
 from djstripe.fields import StripeDateTimeField, StripeDecimalCurrencyAmountField
+from tests.fields.models import TestDecimalModel
 
 pytestmark = pytest.mark.django_db
 
@@ -43,3 +44,33 @@ class TestStripeDateTimeField(TestCase):
             datetime(1997, 9, 18, 7, 48, 35, tzinfo=timezone.utc),
             self.noval.stripe_to_db({"noval": 874568915}),
         )
+
+
+class TestStripePercentField:
+    @pytest.mark.parametrize(
+        "inputted,expected",
+        [
+            (Decimal("1"), Decimal("1.00")),
+            (Decimal("1.5234567"), Decimal("1.52")),
+            (Decimal("0"), Decimal("0.00")),
+            (Decimal("23.2345678"), Decimal("23.23")),
+            ("1", Decimal("1.00")),
+            ("1.5234567", Decimal("1.52")),
+            ("0", Decimal("0.00")),
+            ("23.2345678", Decimal("23.23")),
+            (1, Decimal("1.00")),
+            (1.5234567, Decimal("1.52")),
+            (0, Decimal("0.00")),
+            (23.2345678, Decimal("23.24")),
+        ],
+    )
+    def test_stripe_percent_field(self, inputted, expected):
+        # create a model with the StripePercentField
+        model_field = TestDecimalModel(noval=inputted)
+        model_field.save()
+
+        # get the field data
+        field_data = TestDecimalModel.objects.get(pk=model_field.pk).noval
+
+        assert isinstance(field_data, Decimal)
+        assert field_data == expected


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Force `refreshed` the newly `updated/synced` model instance. This was done because `DecimalField` and `StripePercentField defaults` were not getting picked up by the supposedly updated instance causing stale data issues.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1494 
The synced `instance` returned by `StripeModel.sync_from_stripe_data()` would have completely updated data now for `StripePercentField` and `DecimalField` model fields.