### PR TITLE
Added Generic Sync Support for PaymentMethodForeignKeys

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -414,13 +414,17 @@ class StripeModel(StripeBaseModel):
         :type stripe_account: string
         :return:
         """
+        from djstripe.models import DjstripePaymentMethod
+
         field_data = None
         field_name = field.name
         raw_field_data = manipulated_data.get(field_name)
         refetch = False
         skip = False
 
-        if issubclass(field.related_model, StripeModel):
+        if issubclass(field.related_model, StripeModel) or issubclass(
+            field.related_model, DjstripePaymentMethod
+        ):
             id_ = cls._id_from_data(raw_field_data)
 
             if not raw_field_data:

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1336,6 +1336,7 @@ class Subscription(StripeModel):
         "subscription. This value will be `null` for subscriptions where "
         "`billing=charge_automatically`.",
     )
+    # todo not in record_data.items() --> Expected to sync. Need to test
     default_payment_method = StripeForeignKey(
         "PaymentMethod",
         null=True,
@@ -1357,6 +1358,7 @@ class Subscription(StripeModel):
         "and be in a chargeable state. If not set, defaults to the customer’s "
         "default source.",
     )
+    # todo not in record_data.items() --> Expected to sync. Need to test
     default_tax_rates = models.ManyToManyField(
         "TaxRate",
         # explicitly specify the joining table name as though the joining model
@@ -1392,6 +1394,7 @@ class Subscription(StripeModel):
         "pending invoice items. It is analogous to calling Create an invoice "
         "for the given subscription at the specified interval.",
     )
+    # todo not in record_data.items() --> Expected to sync. Need to test
     pending_setup_intent = StripeForeignKey(
         "SetupIntent",
         null=True,
@@ -1424,6 +1427,7 @@ class Subscription(StripeModel):
         help_text="The quantity applied to this subscription. This value will be "
         "`null` for multi-plan subscriptions",
     )
+    # todo not in record_data.items() --> Expected to sync. Need to test
     schedule = models.ForeignKey(
         "SubscriptionSchedule",
         null=True,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -367,6 +367,7 @@ class Charge(StripeModel):
             self.fraud_details and list(self.fraud_details.values())[0] == "fraudulent"
         )
 
+    # todo may be unnecessary after this PR
     def _attach_objects_hook(self, cls, data, current_ids=None):
         from .payment_methods import DjstripePaymentMethod
 
@@ -1290,6 +1291,8 @@ class Customer(StripeModel):
 
         save = False
 
+        # todo check all "reverse" PaymentMethod FKs model's attach and attach post swave hooks for sources syncs.
+        # todo should be unnecessary after this pr
         customer_sources = data.get("sources")
         sources = {}
         if customer_sources:

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -556,7 +556,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
         charge = Charge.sync_from_stripe_data(fake_charge_copy)
         self.assertEqual("test_id", charge.source_id)
-        self.assertEqual("unsupported", charge.source.type)
+        self.assertEqual("UNSUPPORTED_test_id", charge.source.type)
         self.assertEqual(charge.source, DjstripePaymentMethod.objects.get(id="test_id"))
 
         charge_retrieve_mock.assert_not_called()

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -24,6 +24,7 @@ from djstripe.models import (
     Plan,
     Price,
     Product,
+    Source,
     Subscription,
 )
 from djstripe.settings import djstripe_settings
@@ -50,6 +51,7 @@ from . import (
     FAKE_PRICE,
     FAKE_PRODUCT,
     FAKE_SOURCE,
+    FAKE_SOURCE_II,
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_II,
     FAKE_UPCOMING_INVOICE,
@@ -117,12 +119,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         user = get_user_model().objects.create_user(
             username="test_user_sync_unsupported_source"
         )
-        synced_customer = fake_customer.create_for_user(user)
-        self.assertEqual(0, synced_customer.legacy_cards.count())
-        self.assertEqual(0, synced_customer.sources.count())
-        self.assertEqual(
-            synced_customer.default_source,
-            DjstripePaymentMethod.objects.get(id=fake_customer["default_source"]["id"]),
+        self.assertRaisesRegexp(
+            ValueError,
+            "Trying to fit a 'fish' into 'Card'. Aborting.",
+            fake_customer.create_for_user,
+            user,
         )
 
     def test_customer_sync_has_subscriber_metadata(self):
@@ -210,24 +211,46 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             },
         )
 
+    @patch.object(Card, "_get_or_create_from_stripe_object")
+    @patch("stripe.Customer.retrieve", autospec=True)
     @patch(
         "stripe.Card.retrieve",
-        return_value=FAKE_CUSTOMER_II["default_source"],
         autospec=True,
     )
-    def test_customer_sync_non_local_card(self, card_retrieve_mock):
+    def test_customer_sync_non_local_card(
+        self, card_retrieve_mock, customer_retrieve_mock, card_get_or_create_mock
+    ):
         fake_customer = deepcopy(FAKE_CUSTOMER_II)
         fake_customer["id"] = fake_customer["sources"]["data"][0][
             "customer"
         ] = "cus_test_sync_non_local_card"
+        fake_customer["default_source"]["id"] = fake_customer["sources"]["data"][0][
+            "id"
+        ] = "card_cus_test_sync_non_local_card"
+
+        customer_retrieve_mock.return_value = fake_customer
+
+        fake_card = deepcopy(fake_customer["default_source"])
+        fake_card["customer"] = "cus_test_sync_non_local_card"
+        card_retrieve_mock.return_value = fake_card
+        card_get_or_create_mock.return_value = fake_card
 
         user = get_user_model().objects.create_user(
             username="test_user_sync_non_local_card"
         )
+
+        # create a source object so that FAKE_CUSTOMER_III with a default source
+        # can be created correctly.
+        fake_source_data = deepcopy(FAKE_SOURCE_II)
+        fake_source_data["card"] = deepcopy(fake_card)
+        fake_source_data["customer"] = fake_customer
+
+        Source.sync_from_stripe_data(fake_source_data)
+
         customer = fake_customer.create_for_user(user)
 
-        self.assertEqual(customer.sources.count(), 0)
-        self.assertEqual(customer.legacy_cards.count(), 1)
+        self.assertEqual(customer.sources.count(), 1)
+        self.assertEqual(customer.legacy_cards.count(), 0)
         self.assertEqual(
             customer.default_source.id, fake_customer["default_source"]["id"]
         )
@@ -292,12 +315,13 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     def test_customer_sync_default_source_string(self):
         Customer.objects.all().delete()
         Card.objects.all().delete()
+
         customer_fake = deepcopy(FAKE_CUSTOMER)
-        customer_fake["default_source"] = customer_fake["sources"]["data"][0][
-            "id"
-        ] = "card_sync_source_string"
+
         customer = Customer.sync_from_stripe_data(customer_fake)
-        self.assertEqual(customer.default_source.id, customer_fake["default_source"])
+        self.assertEqual(
+            customer.default_source.id, customer_fake["default_source"]["id"]
+        )
         self.assertEqual(customer.legacy_cards.count(), 2)
         self.assertEqual(len(list(customer.customer_payment_methods)), 2)
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -25,6 +25,13 @@ class SourceTest(AssertStripeFksMixin, TestCase):
         user = get_user_model().objects.create_user(
             username="testuser", email="djstripe@example.com"
         )
+
+        # create a source object so that FAKE_CUSTOMER_III with a default source
+        # can be created correctly.
+        fake_source_data = deepcopy(FAKE_SOURCE)
+        fake_source_data["customer"] = None
+        self.source = Source.sync_from_stripe_data(fake_source_data)
+
         self.customer = FAKE_CUSTOMER_III.create_for_user(user)
         self.customer.sources.all().delete()
         self.customer.legacy_cards.all().delete()

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -14,6 +14,7 @@ from djstripe.enums import SubscriptionStatus
 from djstripe.models import Plan, Product, Subscription
 
 from . import (
+    FAKE_CARD,
     FAKE_CUSTOMER,
     FAKE_CUSTOMER_II,
     FAKE_PLAN,
@@ -143,6 +144,27 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
             subscription, expected_blank_fks=self.default_expected_blank_fks
         )
         self.assertEqual(datetime_to_unix(subscription.cancel_at), 1624553655)
+
+    @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    def test_sync_from_stripe_data_default_source_string(
+        self, customer_retrieve_mock, product_retrieve_mock, plan_retrieve_mock
+    ):
+        subscription_fake = deepcopy(FAKE_SUBSCRIPTION)
+        subscription_fake["default_source"] = FAKE_CARD["id"]
+
+        subscription = Subscription.sync_from_stripe_data(subscription_fake)
+        self.assertEqual(subscription.default_source.id, FAKE_CARD["id"])
+
+        # pop out "djstripe.Subscription.default_source" from self.assert_fks
+        expected_blank_fks = deepcopy(self.default_expected_blank_fks)
+        expected_blank_fks.remove("djstripe.Subscription.default_source")
+        self.assert_fks(subscription, expected_blank_fks=expected_blank_fks)
 
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II), autospec=True)
     @patch(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added Generic Sync Support for `PaymentMethodForeignKey`s. Earlier `PaymentMethodForeignKey`s were only being synced if the model was manually syncing them in one of its `_attach_objects_hook` methods, which was not a good approach as it had to be done for every field of every model that had a `PaymentMethodForeignKey`. Moreover the default behaviour was to `skip` sync of these fields in `_stripe_object_field_to_foreign_key`.
2. After this PR, manual sync in `_attach_objects_hook` can be dropped which should simplify the codebase as well. 
3. Added Corresponding Tests. 


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
All `PaymentMethodForeignKey`s will now be synced as part of the generic sync support in `_stripe_object_field_to_foreign_key`