### PR TITLE
Made Plan.__str__() backwards compatible in case Product is null

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1182,7 +1182,9 @@ class Plan(StripeModel):
         from .billing import Subscription
 
         subscriptions = Subscription.objects.filter(plan__id=self.id).count()
-        return f"{self.human_readable_price} for {self.product.name} ({subscriptions} subscriptions)"
+        if self.product and self.product.name:
+            return f"{self.human_readable_price} for {self.product.name} ({subscriptions} subscriptions)"
+        return f"{self.human_readable_price} ({subscriptions} subscriptions)"
 
     @property
     def amount_in_cents(self):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. `__str__()` would fail incase `Product=null` in model `Plan`. 


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Model `Plan` will still work in case `Product` is `null` for backwards compatibility.