### PR TITLE
Remove 3.6 py version from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     services:
       postgres:


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed `3.6` from `ci.yml` as `python3.6` support is being removed.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Removed `3.6` from `ci.yml`.