### PR TITLE
Remove redundant attach hooks code

### DIFF
--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -700,9 +700,15 @@ class Source(StripeModel):
         return data
 
     def _attach_objects_hook(self, cls, data, current_ids=None):
-        customer = cls._stripe_object_to_customer(
-            target_cls=Customer, data=data, current_ids=current_ids
-        )
+        customer = None
+        # "customer" key could be like "cus_6lsBvm5rJ0zyHc" or {"id": "cus_6lsBvm5rJ0zyHc"}
+        customer_id = cls._id_from_data(data.get("customer"))
+
+        if current_ids is None or customer_id not in current_ids:
+            customer = cls._stripe_object_to_customer(
+                target_cls=Customer, data=data, current_ids=current_ids
+            )
+
         if customer:
             self.customer = customer
         else:

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -522,7 +522,8 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     def test_add_card_set_default_false(self, customer_retrieve_mock):
-        self.customer.add_card(FAKE_CARD["id"], set_default=False)
+
+        # self.customer already has FAKE_CARD as its default payment method
         self.customer.add_card(FAKE_CARD_III["id"], set_default=False)
 
         self.assertEqual(2, Card.objects.count())
@@ -534,9 +535,19 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     def test_add_card_set_default_false_with_single_card_still_becomes_default(
         self, customer_retrieve_mock
     ):
+        # delete all already added cards to self.customer
+        Card.objects.all().delete()
+
+        # assert self.customer has no cards
+        self.assertEqual(0, self.customer.legacy_cards.count())
+        self.assertEqual(0, self.customer.sources.count())
+
         self.customer.add_card(FAKE_CARD["id"], set_default=False)
 
-        self.assertEqual(2, Card.objects.count())
+        # assert new card got added to self.customer
+        self.assertEqual(1, Card.objects.count())
+
+        # self.customer already has FAKE_CARD as its default payment method
         self.assertEqual(FAKE_CARD["id"], self.customer.default_source.id)
 
     @patch(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->
Please merge https://github.com/dj-stripe/dj-stripe/pull/1515 or similar before merging this.

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed redundant `Charge._attach_objects_hook()` method. Has been rendered unnecessary by PR: #1495 
2. Updated `Customer._attach_objects_post_save_hook()` method to remove syncing for default_source. Has been rendered unnecessary by PR: #1495 
3. Made `Source._attach_objects_hook()` method more robust by also handling the case that `customer id` may be nested deep inside the sources dict.
4. Updated incorrect `Customer` tests due to a default card being cerated right in `setUp`.



Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Removed unnecessary code due to PR: #1495 