### PR TITLE
Show dj-stripe version (release) based docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,13 +2,21 @@ name: Build and deploy docs
 
 on:
   push:
-    branches: [master]
+    branches:
+      - "master"
+      # Push events to branches matching 
+        # refs/heads/stable/2.5
+        # refs/heads/stable/10
+        # refs/heads/stable/2
+        # refs/heads/stable/2.5.6
+      - "stable/[0-9]+(.[0-9])*(.[0-9])*"
 
   workflow_dispatch: # to trigger manually
 
 env:
   POETRY_VERSION: "1.1.11"
   POETRY_VIRTUALENVS_IN_PROJECT: "1"
+  LATEST_STABLE_BRANCH: "stable/2.5"
 
 jobs:
 
@@ -49,5 +57,19 @@ jobs:
     - name: Install dependencies
       run: poetry install -E docs
 
-    - name: Deploy docs to Github Pages
-      run: poetry run mkdocs gh-deploy --force
+    - name: Configure git user to make commit
+      run: |      
+        git config user.name "Arnav Choudhury"
+        git config user.email "arnav13@gmail.com"
+
+    - name: Fetch gh-pages remote changes (if any)
+      run: git fetch origin gh-pages --depth=1
+
+    - name: Deploy (and Update) docs for the branch, ${GITHUB_REF##*/}
+      run: poetry run mike deploy --push --rebase "${GITHUB_REF##*/}"
+
+    - name: Set default docs to ${LATEST_STABLE_BRANCH##*/}
+      run: poetry run mike set-default --push --rebase "${LATEST_STABLE_BRANCH##*/}"
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ plugins:
       watch:
         - .
       enable_inventory: true
+  - mike:
 
 nav:
   - Home: README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ mkdocs = {version = "^1.1.2", optional = true}
 mkdocstrings = {version = "^0.16.0", optional = true}
 mkdocs-material = {version = "^7.2.8", optional = true}
 mkdocs-autorefs = "^0.3.0"
+mike = "^1.1.2"
 
 
 [tool.poetry.dev-dependencies]
@@ -59,7 +60,7 @@ pytest-django = "^4.3.0"
 mypy = "^0.920"
 
 [tool.poetry.extras]
-docs = ["mkdocs", "mkdocstrings", "mkdocs-material", "mkdocs-autorefs", "psycopg2"]
+docs = ["mkdocs", "mkdocstrings", "mkdocs-material", "mkdocs-autorefs", "psycopg2", "mike"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `mike` as a `docs` dependency to show the user `release/version` based `dj-stripe` docs.
2. Updated `docs.yaml` to trigger docs build whenever a `push` event takes place on the master and any branch that has the form `stable/[0-9]+(.[0-9])*(.[0-9])*` so `push` events on branches like `stable/2.6` or `stable/3.4.5` will all trigger auto build and deploy of docs.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Currently the only docs `deployed` are in sync with `master` and not `version/release` based as users may want in case they are using an older version of `dj-stripe`.