### PR TITLE
Added Support for Reverse OneToOneField Sync

### DIFF
--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -1653,14 +1653,10 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.assert_fks(price, expected_blank_fks={})
 
         # ensure DeprecationWarning is triggered
-        with pytest.warns(DeprecationWarning) as recorded_warning:
+        with pytest.warns(
+            DeprecationWarning, match=r"not be accepting price \(or price id\)"
+        ):
             self.customer.subscribe(price=price.id)
-
-        assert len(recorded_warning) == 1
-        assert (
-            "not be accepting price (or price id)"
-            in recorded_warning[0].message.args[0]
-        )
 
     @patch("stripe.Subscription.create", autospec=True)
     @patch(
@@ -1694,14 +1690,10 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
         self.customer.subscribe(price=price)
         # ensure DeprecationWarning is triggered
-        with pytest.warns(DeprecationWarning) as recorded_warning:
+        with pytest.warns(
+            DeprecationWarning, match=r"not be accepting price \(or price id\)"
+        ):
             self.customer.subscribe(price=price)
-
-        assert len(recorded_warning) == 1
-        assert (
-            "not be accepting price (or price id)"
-            in recorded_warning[0].message.args[0]
-        )
 
         self.assertEqual(2, self.customer.subscriptions.count())
         self.assertEqual(2, len(self.customer.valid_subscriptions))
@@ -2056,14 +2048,10 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         subscription_create_mock.return_value = subscription_fake
 
         # ensure DeprecationWarning is triggered
-        with pytest.warns(DeprecationWarning) as recorded_warning:
+        with pytest.warns(
+            DeprecationWarning, match=r"not be accepting price \(or price id\)"
+        ):
             self.customer.subscribe(price=price)
-
-        assert len(recorded_warning) == 1
-        assert (
-            "not be accepting price (or price id)"
-            in recorded_warning[0].message.args[0]
-        )
 
         assert self.customer.is_subscribed_to(product.id)
 
@@ -2142,14 +2130,10 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         subscription_create_mock.return_value = fake_subscription
 
         # ensure DeprecationWarning is triggered
-        with pytest.warns(DeprecationWarning) as recorded_warning:
+        with pytest.warns(
+            DeprecationWarning, match=r"not be accepting price \(or price id\)"
+        ):
             self.customer.subscribe(plan=plan.id)
-
-        assert len(recorded_warning) == 1
-        assert (
-            "not be accepting price (or price id)"
-            in recorded_warning[0].message.args[0]
-        )
 
     @patch("stripe.Subscription.create", autospec=True)
     @patch(

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -768,10 +768,34 @@ class TestCheckoutEvents(EventTestCase):
     @patch(
         "stripe.checkout.Session.retrieve", return_value=FAKE_SESSION_I, autospec=True
     )
-    @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=FAKE_PAYMENT_INTENT_I,
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
@@ -780,6 +804,12 @@ class TestCheckoutEvents(EventTestCase):
         event_retrieve_mock,
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_SESSION_COMPLETED)
@@ -794,10 +824,34 @@ class TestCheckoutEvents(EventTestCase):
     @patch(
         "stripe.checkout.Session.retrieve", return_value=FAKE_SESSION_I, autospec=True
     )
-    @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=FAKE_PAYMENT_INTENT_I,
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
@@ -806,6 +860,12 @@ class TestCheckoutEvents(EventTestCase):
         event_retrieve_mock,
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_SESSION_COMPLETED)
@@ -822,10 +882,34 @@ class TestCheckoutEvents(EventTestCase):
     @patch(
         "stripe.checkout.Session.retrieve", return_value=FAKE_SESSION_I, autospec=True
     )
-    @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=FAKE_PAYMENT_INTENT_I,
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
@@ -834,6 +918,12 @@ class TestCheckoutEvents(EventTestCase):
         event_retrieve_mock,
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_SESSION_COMPLETED)
@@ -848,6 +938,28 @@ class TestCheckoutEvents(EventTestCase):
         self.assertEqual(session.customer.id, self.customer.id)
 
     @patch("stripe.checkout.Session.retrieve", autospec=True)
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     @patch(
         "stripe.Customer.modify",
         return_value=deepcopy(FAKE_CUSTOMER),
@@ -864,6 +976,12 @@ class TestCheckoutEvents(EventTestCase):
         event_retrieve_mock,
         payment_intent_retrieve_mock,
         customer_modify_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
         # because create_for_user method adds subscriber
@@ -1815,7 +1933,6 @@ class TestInvoiceItemEvents(EventTestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -1845,6 +1962,10 @@ class TestInvoiceItemEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
@@ -1900,7 +2021,6 @@ class TestInvoiceItemEvents(EventTestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -1932,6 +2052,10 @@ class TestInvoiceItemEvents(EventTestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
+
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
         subscription_retrieve_mock.return_value = fake_subscription

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -183,7 +183,6 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -212,6 +211,9 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
@@ -236,6 +238,12 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.InvoiceItem.plan",
             "djstripe.InvoiceItem.price",
         }
+        expected_blank_fks.difference_update(
+            {
+                "djstripe.PaymentIntent.invoice (related name)",
+                "djstripe.Invoice.payment_intent",
+            }
+        )
 
         self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
 
@@ -274,7 +282,6 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -300,6 +307,9 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
@@ -329,6 +339,12 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.InvoiceItem.plan",
             "djstripe.InvoiceItem.price",
         }
+        expected_blank_fks.difference_update(
+            {
+                "djstripe.PaymentIntent.invoice (related name)",
+                "djstripe.Invoice.payment_intent",
+            }
+        )
 
         self.assert_fks(invoiceitem, expected_blank_fks=expected_blank_fks)
 
@@ -362,7 +378,6 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -390,6 +405,9 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
@@ -418,10 +436,19 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         self.assertEqual(FAKE_PLAN_II["id"], invoiceitem.plan.id)
         self.assertEqual(FAKE_PRICE_II["id"], invoiceitem.price.id)
 
+        expected_blank_fks = self.default_expected_blank_fks | {
+            "djstripe.InvoiceItem.subscription"
+        }
+        expected_blank_fks.difference_update(
+            {
+                "djstripe.PaymentIntent.invoice (related name)",
+                "djstripe.Invoice.payment_intent",
+            }
+        )
+
         self.assert_fks(
             invoiceitem,
-            expected_blank_fks=self.default_expected_blank_fks
-            | {"djstripe.InvoiceItem.subscription"},
+            expected_blank_fks=expected_blank_fks,
         )
 
     @patch(
@@ -511,7 +538,6 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -529,6 +555,9 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -13,10 +13,15 @@ from djstripe.models import Account, Customer, PaymentIntent
 
 from . import (
     FAKE_ACCOUNT,
+    FAKE_BALANCE_TRANSACTION,
+    FAKE_CHARGE,
     FAKE_CUSTOMER,
+    FAKE_INVOICE,
     FAKE_PAYMENT_INTENT_DESTINATION_CHARGE,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PAYMENT_METHOD_I,
+    FAKE_PRODUCT,
+    FAKE_SUBSCRIPTION,
     AssertStripeFksMixin,
 )
 
@@ -49,26 +54,64 @@ class TestStrPaymentIntent:
             (get_fake_payment_intent_i_no_customer(), False, False),
         ],
     )
+    # flake8: noqa (C901)
     def test___str__(self, fake_intent_data, has_account, has_customer, monkeypatch):
         def mock_customer_get(*args, **kwargs):
+            """Monkeypatched stripe.Customer.retrieve"""
             return deepcopy(FAKE_CUSTOMER)
 
         def mock_account_get(*args, **kwargs):
+            """Monkeypatched stripe.Account.retrieve"""
             data = deepcopy(FAKE_ACCOUNT)
             # Otherwise Account.api_retrieve will invoke File.api_retrieve...
             data["settings"]["branding"] = {}
             return data
 
         def mock_payment_method_get(*args, **kwargs):
+            """Monkeypatched stripe.PaymentMethod.retrieve"""
             return deepcopy(FAKE_PAYMENT_METHOD_I)
 
-        # monkeypatch stripe.Product.retrieve, stripe.Price.retrieve, and  stripe.PaymentMethod.retrieve calls to return
+        def mock_invoice_get(*args, **kwargs):
+            """Monkeypatched stripe.Invoice.retrieve"""
+            return deepcopy(FAKE_INVOICE)
+
+        def mock_subscription_get(*args, **kwargs):
+            """Monkeypatched stripe.Subscription.retrieve"""
+            return deepcopy(FAKE_SUBSCRIPTION)
+
+        def mock_balance_transaction_get(*args, **kwargs):
+            """Monkeypatched stripe.BalanceTransaction.retrieve"""
+            return deepcopy(FAKE_BALANCE_TRANSACTION)
+
+        def mock_product_get(*args, **kwargs):
+            """Monkeypatched stripe.Product.retrieve"""
+            return deepcopy(FAKE_PRODUCT)
+
+        def mock_charge_get(*args, **kwargs):
+            """Monkeypatched stripe.Charge.retrieve"""
+            return deepcopy(FAKE_CHARGE)
+
+        # monkeypatch stripe.Product.retrieve, stripe.Price.retrieve, stripe.PaymentMethod.retrieve, and stripe.PaymentIntent.retrieve calls to return
         # the desired json response.
         monkeypatch.setattr(stripe.Account, "retrieve", mock_account_get)
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
 
+        # because of Reverse o2o field sync due to PaymentIntent.sync_from_stripe_data..
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
         pi = PaymentIntent.sync_from_stripe_data(fake_intent_data)
+
+        # due to reverse o2o sync invoice should also get created
+        if fake_intent_data.get("invoice"):
+            assert pi.invoice is not None
+
         account = Account.objects.filter(id=fake_intent_data["on_behalf_of"]).first()
         customer = Customer.objects.filter(id=fake_intent_data["customer"]).first()
 
@@ -99,33 +142,106 @@ class TestStrPaymentIntent:
 
 class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_sync_from_stripe_data(self, customer_retrieve_mock):
-        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    def test_sync_from_stripe_data(
+        self,
+        invoice_retrieve_mock,
+        customer_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
+    ):
 
-        payment_intent = PaymentIntent.sync_from_stripe_data(fake_payment_intent)
+        payment_intent = PaymentIntent.sync_from_stripe_data(
+            deepcopy(FAKE_PAYMENT_INTENT_I)
+        )
 
         self.assert_fks(
             payment_intent,
             expected_blank_fks={
+                "djstripe.Charge.latest_upcominginvoice (related name)",
+                "djstripe.Charge.application_fee",
+                "djstripe.Charge.dispute",
+                "djstripe.Charge.on_behalf_of",
+                "djstripe.Charge.source_transfer",
+                "djstripe.Charge.transfer",
                 "djstripe.Customer.coupon",
                 "djstripe.Customer.default_payment_method",
                 "djstripe.Customer.subscriber",
-                "djstripe.PaymentIntent.invoice (related name)",
+                "djstripe.Invoice.default_payment_method",
+                "djstripe.Invoice.default_source",
                 "djstripe.PaymentIntent.on_behalf_of",
                 "djstripe.PaymentIntent.payment_method",
                 "djstripe.PaymentIntent.upcominginvoice (related name)",
+                "djstripe.Subscription.default_payment_method",
+                "djstripe.Subscription.default_source",
+                "djstripe.Subscription.pending_setup_intent",
+                "djstripe.Subscription.schedule",
             },
         )
 
-        # TODO - PaymentIntent should probably sync invoice (reverse OneToOneField)
-        # self.assertIsNotNone(payment_intent.invoice)
+        self.assertIsNotNone(payment_intent.invoice)
 
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_status_enum(self, customer_retrieve_mock):
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    def test_status_enum(
+        self,
+        invoice_retrieve_mock,
+        customer_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
+    ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
 
         for status in (
@@ -144,9 +260,40 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
             payment_intent.full_clean()
 
     @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
-    def test_canceled_intent(self, customer_retrieve_mock):
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
+    def test_canceled_intent(
+        self,
+        invoice_retrieve_mock,
+        customer_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
+    ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
 
         fake_payment_intent["status"] = "canceled"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,9 +11,15 @@ from django.test import TestCase
 from djstripe.models import Session
 from djstripe.settings import djstripe_settings
 from tests import (
+    FAKE_BALANCE_TRANSACTION,
+    FAKE_CHARGE,
     FAKE_CUSTOMER,
+    FAKE_INVOICE,
     FAKE_PAYMENT_INTENT_I,
+    FAKE_PAYMENT_METHOD_I,
+    FAKE_PRODUCT,
     FAKE_SESSION_I,
+    FAKE_SUBSCRIPTION,
     AssertStripeFksMixin,
 )
 
@@ -21,6 +27,28 @@ pytestmark = pytest.mark.django_db
 
 
 class SessionTest(AssertStripeFksMixin, TestCase):
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
@@ -30,26 +58,66 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     def test_sync_from_stripe_data(
-        self, payment_intent_retrieve_mock, customer_retrieve_mock
+        self,
+        payment_intent_retrieve_mock,
+        customer_retrieve_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
     ):
-        fake_payment_intent = deepcopy(FAKE_SESSION_I)
 
-        session = Session.sync_from_stripe_data(fake_payment_intent)
+        session = Session.sync_from_stripe_data(deepcopy(FAKE_SESSION_I))
 
         self.assert_fks(
             session,
             expected_blank_fks={
+                "djstripe.Charge.latest_upcominginvoice (related name)",
+                "djstripe.Charge.application_fee",
+                "djstripe.Charge.dispute",
+                "djstripe.Charge.on_behalf_of",
+                "djstripe.Charge.source_transfer",
+                "djstripe.Charge.transfer",
                 "djstripe.Customer.coupon",
                 "djstripe.Customer.default_payment_method",
                 "djstripe.Customer.subscriber",
-                "djstripe.PaymentIntent.invoice (related name)",
+                "djstripe.Invoice.default_payment_method",
+                "djstripe.Invoice.default_source",
                 "djstripe.PaymentIntent.on_behalf_of",
                 "djstripe.PaymentIntent.payment_method",
                 "djstripe.PaymentIntent.upcominginvoice (related name)",
+                "djstripe.Subscription.default_payment_method",
+                "djstripe.Subscription.default_source",
+                "djstripe.Subscription.pending_setup_intent",
+                "djstripe.Subscription.schedule",
                 "djstripe.Session.subscription",
             },
         )
 
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
@@ -58,26 +126,21 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
-    def test___str__(self, payment_intent_retrieve_mock, customer_retrieve_mock):
-        fake_payment_intent = deepcopy(FAKE_SESSION_I)
+    def test___str__(
+        self,
+        payment_intent_retrieve_mock,
+        customer_retrieve_mock,
+        invoice_retrieve_mock,
+        product_retrieve_mock,
+        paymentmethod_card_retrieve_mock,
+        charge_retrieve_mock,
+        subscription_retrieve_mock,
+        balance_transaction_retrieve_mock,
+    ):
 
-        session = Session.sync_from_stripe_data(fake_payment_intent)
+        session = Session.sync_from_stripe_data(deepcopy(FAKE_SESSION_I))
 
         self.assertEqual(f"<id={FAKE_SESSION_I['id']}>", str(session))
-
-        self.assert_fks(
-            session,
-            expected_blank_fks={
-                "djstripe.Customer.coupon",
-                "djstripe.Customer.default_payment_method",
-                "djstripe.Customer.subscriber",
-                "djstripe.PaymentIntent.invoice (related name)",
-                "djstripe.PaymentIntent.on_behalf_of",
-                "djstripe.PaymentIntent.payment_method",
-                "djstripe.PaymentIntent.upcominginvoice (related name)",
-                "djstripe.Session.subscription",
-            },
-        )
 
 
 class TestSession:
@@ -91,6 +154,7 @@ class TestSession:
             {"key1": "val1", key: "random"},
         ],
     )
+    # flake8: noqa (C901)
     def test__attach_objects_post_save_hook(
         self, monkeypatch, fake_user, fake_customer, metadata
     ):
@@ -111,26 +175,61 @@ class TestSession:
         fake_stripe_session = deepcopy(FAKE_SESSION_I)
         fake_stripe_session["metadata"] = metadata
 
-        def patched_checkout_session(*args, **kwargs):
+        def mock_checkout_session_get(*args, **kwargs):
             """Monkeypatched stripe.Session.retrieve"""
             return fake_stripe_session
 
-        def patched_customer(*args, **kwargs):
+        def mock_customer_get(*args, **kwargs):
             """Monkeypatched stripe.Customer.retrieve"""
             fake_customer = deepcopy(FAKE_CUSTOMER)
             return fake_customer
 
-        def patched_payment_intent(*args, **kwargs):
+        def mock_payment_intent_get(*args, **kwargs):
             """Monkeypatched stripe.PaymentIntent.retrieve"""
             fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
             return fake_payment_intent
 
+        def mock_invoice_get(*args, **kwargs):
+            """Monkeypatched stripe.Invoice.retrieve"""
+            return deepcopy(FAKE_INVOICE)
+
+        def mock_payment_method_get(*args, **kwargs):
+            """Monkeypatched stripe.PaymentMethod.retrieve"""
+            fake_payment_intent = deepcopy(FAKE_PAYMENT_METHOD_I)
+            return fake_payment_intent
+
+        def mock_subscription_get(*args, **kwargs):
+            """Monkeypatched stripe.Subscription.retrieve"""
+            return deepcopy(FAKE_SUBSCRIPTION)
+
+        def mock_balance_transaction_get(*args, **kwargs):
+            """Monkeypatched stripe.BalanceTransaction.retrieve"""
+            return deepcopy(FAKE_BALANCE_TRANSACTION)
+
+        def mock_product_get(*args, **kwargs):
+            """Monkeypatched stripe.Product.retrieve"""
+            return deepcopy(FAKE_PRODUCT)
+
+        def mock_charge_get(*args, **kwargs):
+            """Monkeypatched stripe.Charge.retrieve"""
+            return deepcopy(FAKE_CHARGE)
+
         # monkeypatch stripe.checkout.Session.retrieve, stripe.Customer.retrieve, stripe.PaymentIntent.retrieve
         monkeypatch.setattr(
-            stripe.checkout.Session, "retrieve", patched_checkout_session
+            stripe.checkout.Session, "retrieve", mock_checkout_session_get
         )
-        monkeypatch.setattr(stripe.Customer, "modify", patched_customer)
-        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", patched_payment_intent)
+        monkeypatch.setattr(stripe.Customer, "modify", mock_customer_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+
+        # because of Reverse o2o field sync due to PaymentIntent.sync_from_stripe_data..
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
 
         # Invoke the sync to invoke _attach_objects_post_save_hook()
         session = Session.sync_from_stripe_data(fake_stripe_session)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -979,7 +979,6 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        return_value=deepcopy(FAKE_PAYMENT_INTENT_II),
         autospec=True,
     )
     @patch(
@@ -1012,6 +1011,10 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
     ):
         # delete pydanny customer as that causes issues with Invoice and Latest_invoice FKs
         self.customer.delete()
+
+        fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_II)
+        fake_payment_intent["invoice"] = FAKE_INVOICE_II["id"]
+        paymentintent_retrieve_mock.return_value = fake_payment_intent
 
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION_MULTI_PLAN)
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
@@ -1048,8 +1051,6 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
             | {
                 "djstripe.Customer.subscriber",
                 "djstripe.Subscription.plan",
-                "djstripe.PaymentIntent.invoice (related name)",
-                "djstripe.Invoice.payment_intent",
             },
         )
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -580,11 +580,7 @@ class TestGetRemoteIp:
         request = self.RequestClass(data)
 
         # ensure warning is raised
-        with pytest.warns(None) as recorded_warning:
+        with pytest.warns(
+            None, match=r"Could not determine remote IP \(missing REMOTE_ADDR\)\."
+        ):
             assert get_remote_ip(request) == "0.0.0.0"
-
-        assert len(recorded_warning) == 1
-        assert (
-            "Could not determine remote IP (missing REMOTE_ADDR)."
-            in recorded_warning[0].message.args[0]
-        )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Adds sync support for syncing of `Reverse One to One` fields.
2. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #970
Close: #969
Now `o2o` fields not directly on the model being synced will also get synced. Eg Syncing `PaymentIntent` will also sync the associated `Invoice` (if any).