### PR TITLE
Removed unnecessary TaxRate.refresh_from_db() as cached percentage values are removed in sync_from_stripe_data()

### DIFF
--- a/tests/test_tax_rates.py
+++ b/tests/test_tax_rates.py
@@ -16,8 +16,6 @@ pytestmark = pytest.mark.django_db
 class TaxRateTest(AssertStripeFksMixin, TestCase):
     def test___str__(self):
         tax_rate = TaxRate.sync_from_stripe_data(deepcopy(FAKE_TAX_RATE_EXAMPLE_1_VAT))
-        # need to refresh to load percentage as decimal
-        tax_rate.refresh_from_db()
 
         self.assertEqual(
             f"{FAKE_TAX_RATE_EXAMPLE_1_VAT['display_name']} – {FAKE_TAX_RATE_EXAMPLE_1_VAT['jurisdiction']} at {FAKE_TAX_RATE_EXAMPLE_1_VAT['percentage']:.2f}%",


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `test_tax_rates` module to remove the unnecessary `TaxRate.refresh_from_db()` as `cached` percentage values are removed from `sync_from_stripe_data()`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Tests should run slightly faster as this does away with a few unnecessary `db` calls.