### PR TITLE
Add Admin Custom Sync Action

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -5,6 +5,7 @@ import json
 from typing import Dict, Optional
 from urllib.parse import urljoin
 
+import stripe
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin import helpers
@@ -39,6 +40,27 @@ def admin_display_for_field_override():
 
 # execute override
 admin_display_for_field_override()
+
+
+@admin.action(description="Re-Sync Selected Instances")
+def _resync_instances(modeladmin, request, queryset):
+    """Admin Action to resync selected instances"""
+    for instance in queryset:
+        try:
+            if instance.djstripe_owner_account:
+                stripe_data = instance.api_retrieve(
+                    stripe_account=instance.djstripe_owner_account.id
+                )
+            else:
+                stripe_data = instance.api_retrieve()
+            instance.__class__.sync_from_stripe_data(stripe_data)
+            modeladmin.message_user(
+                request, f"Successfully Synced: {instance}", level=messages.SUCCESS
+            )
+        except stripe.error.PermissionError as error:
+            modeladmin.message_user(request, error, level=messages.WARNING)
+        except stripe.error.InvalidRequestError:
+            raise
 
 
 @admin.action(description="Re-Sync ALL Usage Record Summaries")
@@ -192,6 +214,7 @@ class StripeModelAdmin(admin.ModelAdmin):
     """Base class for all StripeModel-based model admins"""
 
     change_form_template = "djstripe/admin/change_form.html"
+    actions = (_resync_instances,)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -622,7 +622,7 @@ class SubscriptionAdmin(StripeModelAdmin):
 
     _cancel.short_description = "Cancel selected subscriptions"  # type: ignore # noqa
 
-    actions = (_cancel,)
+    actions = (_cancel, _resync_instances)
 
 
 @admin.register(models.TaxRate)
@@ -842,7 +842,6 @@ class WebhookEndpointAdminEditForm(WebhookEndpointAdminBaseForm):
         return super()._post_clean()
 
 
-# todo add _resync_instances or similar admin action to webhookendpoint as well
 @admin.register(models.WebhookEndpoint)
 class WebhookEndpointAdmin(admin.ModelAdmin):
     change_form_template = "djstripe/admin/change_form.html"

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -857,11 +857,15 @@ class WebhookEndpointAdmin(admin.ModelAdmin):
         "created",
         "api_version",
     )
+    actions = (_resync_instances,)
 
-    # Disable the mass-delete action for webhook endpoints.
-    # We don't want to enable deleting multiple endpoints on Stripe at once.
     def get_actions(self, request):
-        return {}
+        actions = super().get_actions(request)
+        # Disable the mass-delete action for webhook endpoints.
+        # We don't want to enable deleting multiple endpoints on Stripe at once.
+        if "delete_selected" in actions:
+            del actions["delete_selected"]
+        return actions
 
     def get_form(self, request, obj=None, **kwargs):
         if obj:

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -46,14 +46,15 @@ admin_display_for_field_override()
 def _resync_instances(modeladmin, request, queryset):
     """Admin Action to resync selected instances"""
     for instance in queryset:
+        api_key = instance.default_api_key
         try:
             if instance.djstripe_owner_account:
                 stripe_data = instance.api_retrieve(
-                    stripe_account=instance.djstripe_owner_account.id
+                    stripe_account=instance.djstripe_owner_account.id, api_key=api_key
                 )
             else:
                 stripe_data = instance.api_retrieve()
-            instance.__class__.sync_from_stripe_data(stripe_data)
+            instance.__class__.sync_from_stripe_data(stripe_data, api_key=api_key)
             modeladmin.message_user(
                 request, f"Successfully Synced: {instance}", level=messages.SUCCESS
             )

--- a/tests/fields/admin.py
+++ b/tests/fields/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from djstripe.admin import StripeModelAdmin
+
+from .models import TestCustomActionModel
+
+
+@admin.register(TestCustomActionModel)
+class TestCustomActionModelAdmin(StripeModelAdmin):
+    pass

--- a/tests/fields/models.py
+++ b/tests/fields/models.py
@@ -3,7 +3,14 @@
 from django.db import models
 
 from djstripe.fields import StripePercentField
+from djstripe.models import StripeModel
 
 
 class ExampleDecimalModel(models.Model):
     noval = StripePercentField()
+
+
+class TestCustomActionModel(StripeModel):
+    # for some reason having a FK here throws relation doesn't exist even though
+    # djstripe is also one of the installed apps in tests.settings
+    djstripe_owner_account = None

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -170,7 +170,8 @@ class TestAdminCustomActions:
         if djstripe_owner_account_exists:
             # assert in case djstripe_owner_account exists that kwargs are not empty
             assert self.kwargs_called_with == {
-                "stripe_account": instance.djstripe_owner_account.id
+                "stripe_account": instance.djstripe_owner_account.id,
+                "api_key": instance.default_api_key,
             }
         else:
             # assert in case djstripe_owner_account does not exist that kwargs are empty

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -660,17 +660,19 @@ class TestAdminRegisteredModels(TestCase):
                 request.user = self.admin
 
                 actions = model_admin.get_actions(request)
-                models_to_ignore = self.ignore_models + ["APIKey"]
 
-                if model.__name__ not in models_to_ignore:
+                if model.__name__ not in self.ignore_models:
                     if model.__name__ == "UsageRecordSummary":
                         assert "_resync_instances" not in actions
                         assert "_resync_all_usage_record_summaries" in actions
-
                     else:
                         assert "_resync_instances" in actions
                 else:
-                    assert "_resync_instances" not in actions
+                    if model.__name__ == "WebhookEndpoint":
+                        assert "delete_selected" not in actions
+                        assert "_resync_instances" in actions
+                    else:
+                        assert "_resync_instances" not in actions
 
 
 class TestAdminInlineModels(TestCase):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added a custom admin action to allow users to select 1 or more instances and sync with upstream. This will help in case the user suspects the selected instances were modified locally.
2. Added a custom admin action to allow users to sync all `UsageRecordSummary` objects as Stripe does not allow to retrieve them one by one.
3. Added Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

This will make it slightly easier to `sync` or `update` local `db` instances with `upstream` data.