### PR TITLE
Fix typo in link formatting

### DIFF
--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -14,7 +14,7 @@ dj-stripe provides the following settings to tune how your webhooks work:
 
 dj-stripe comes with native support for webhooks as event listeners.
 
-Events allow you to do things like [sending an email to a customer when
+Events allow you to do things like sending an email to a customer when
 his payment has
 [failed](https://stripe.com/docs/receipts#failed-payment-alerts)
 or trial period is ending.


### PR DESCRIPTION
There was an extra `[`

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fix a typo


Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale
The typo looks bad
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
