### PR TITLE
Fixed minor bugs in APIKey Admin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -288,6 +288,11 @@ class APIKeyAdmin(admin.ModelAdmin):
     readonly_fields = ("djstripe_owner_account", "livemode", "type", "secret")
     search_fields = ("name",)
 
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return ["djstripe_owner_account", "livemode", "type"]
+        return super().get_readonly_fields(request, obj=obj)
+
     def get_fields(self, request, obj=None):
         if obj is None:
             return APIKeyAdminCreateForm.Meta.fields

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -272,14 +272,16 @@ class APIKeyAdminCreateForm(forms.ModelForm):
 
     def _post_clean(self):
         super()._post_clean()
-        if (
-            self.instance.type == enums.APIKeyType.secret
-            and self.instance.djstripe_owner_account is None
-        ):
-            try:
-                self.instance.refresh_account()
-            except AuthenticationError as e:
-                self.add_error("secret", str(e))
+
+        if not self.errors:
+            if (
+                self.instance.type == enums.APIKeyType.secret
+                and self.instance.djstripe_owner_account is None
+            ):
+                try:
+                    self.instance.refresh_account()
+                except AuthenticationError as e:
+                    self.add_error("secret", str(e))
 
 
 @admin.register(models.APIKey)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -61,7 +61,7 @@ class TestAdminRegisteredModels(TestCase):
         self.factory = RequestFactory()
         # the 2 models that do not inherit from StripeModel and hence
         # do not inherit from StripeModelAdmin
-        self.ignore_models = ["WebhookEventTrigger", "IdempotencyKey"]
+        self.ignore_models = ["WebhookEventTrigger", "IdempotencyKey", "APIKey"]
 
     def test_get_list_display_links(self):
         app_label = "djstripe"

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -55,7 +55,7 @@ def test_clean_public_apikey():
     assert not key.djstripe_owner_account
 
 
-@pytest.mark.django_db
+
 @patch("stripe.Account.retrieve", return_value=deepcopy(FAKE_PLATFORM_ACCOUNT))
 @patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD_ICON))
 def test_apikey_detect_livemode_and_type(

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -132,7 +132,10 @@ class APIKeyTest(TestCase):
         autospec=True,
     )
     def test_refresh_account(self, fileupload_retrieve_mock, account_retrieve_mock):
+        # remove djstripe_owner_account field
         self.apikey_test.djstripe_owner_account = None
         self.apikey_test.save()
-        self.apikey_test.clean()
+
+        # invoke refresh_Account()
+        self.apikey_test.refresh_account()
         assert self.apikey_test.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
+from djstripe.admin import APIKeyAdminCreateForm
 from djstripe.enums import APIKeyType
 from djstripe.exceptions import InvalidStripeAPIKey
 from djstripe.models import Account, APIKey
@@ -55,7 +56,6 @@ def test_clean_public_apikey():
     assert not key.djstripe_owner_account
 
 
-
 @patch("stripe.Account.retrieve", return_value=deepcopy(FAKE_PLATFORM_ACCOUNT))
 @patch("stripe.File.retrieve", return_value=deepcopy(FAKE_FILEUPLOAD_ICON))
 def test_apikey_detect_livemode_and_type(
@@ -70,10 +70,14 @@ def test_apikey_detect_livemode_and_type(
         (SK_LIVE, True, APIKeyType.secret),
     )
     for secret, livemode, type in keys_and_values:
-        key = APIKey.objects.create(secret=secret)
-        assert key.livemode is livemode
-        assert key.type is type
-        key.clean()
+        # need to use ModelAdmin Form to create the APIKey instance
+        form = APIKeyAdminCreateForm(
+            data={"secret": secret},
+        )
+        form.save()
+
+        key = form.instance
+
         assert key.livemode is livemode
         assert key.type is type
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed `secret` modelfield getting displayed as a `readonly` field to users when `creating/adding` a new `APIKey` instance
2. Handled the scenario that the `secret` of the `APIKey` that is being created already exists and thus raises an `IntegrityError`
3. Updated Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
User will now be able to `create/edit` an `API key` from the `Admin` easily.