### PR TITLE
Fix regression in djstripe_sync_models, not expanding fields (version 2.5)

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -129,7 +129,7 @@ class Command(BaseCommand):
         """
         all_list_kwargs = (
             [{"expand": [f"data.{k}" for k in model.expand_fields]}]
-            if getattr(models, "expand_fields", [])
+            if getattr(model, "expand_fields", [])
             else []
         )
         if model is models.PaymentMethod:


### PR DESCRIPTION
Due to a typo in previous commit 163b85ba5, the command did not expand the fields.

## Description

After upgrading from 2.4 to 2.5, I noticed that the `tiers` attribute in my `Price` objects had been set to null.

<!-- What are you proposing? -->

This PR contains a quick fix to make it work again. The version of the modified file available in the master branch has diverged too much so I think we can just make it work and not cherry-pick all changes.

Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

Regression

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
