### PR TITLE
Made get_remote_ip func swappable by exposing a new setting

### DIFF
--- a/djstripe/apps.py
+++ b/djstripe/apps.py
@@ -2,6 +2,7 @@
 dj-stripe - Django + Stripe Made Easy
 """
 from importlib.metadata import version
+
 from django.apps import AppConfig
 
 __version__ = version("dj-stripe")

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -169,7 +169,7 @@ class WebhookEventTrigger(models.Model):
         except Exception:
             body = "(error decoding body)"
 
-        ip = get_remote_ip(request)
+        ip = djstripe_settings.GET_REMOTE_IP(request)
 
         try:
             data = json.loads(body)

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -91,32 +91,6 @@ def _get_version():
     return __version__
 
 
-def get_remote_ip(request):
-    """Given the HTTPRequest object return the IP Address of the client
-
-    :param request: client request
-    :type request: HTTPRequest
-
-    :Returns: the client ip address
-    """
-
-    # x-forwarded-for is relevant for django running behind a proxy
-    x_forwarded_for = request.headers.get("x-forwarded-for")
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(",")[0]
-    else:
-        ip = request.META.get("REMOTE_ADDR")
-
-    if not ip:
-        warnings.warn(
-            "Could not determine remote IP (missing REMOTE_ADDR). "
-            "This is likely an issue with your wsgi/server setup."
-        )
-        ip = "0.0.0.0"
-
-    return ip
-
-
 class WebhookEventTrigger(models.Model):
     """
     An instance of a request that reached the server endpoint for Stripe webhooks.

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
+from .utils import _get_remote_ip
+
 
 class DjstripeSettings:
     """Container for Dj-stripe settings
@@ -61,6 +63,20 @@ class DjstripeSettings:
         return self.get_callback_function(
             "DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK", self._get_idempotency_key
         )
+
+    @property
+    def GET_REMOTE_IP(self):
+        return self.get_callback_function(
+            "DJSTRIPE_GET_REMOTE_IP", default=_get_remote_ip
+        )
+
+    @property
+    def USE_NATIVE_JSONFIELD(self):
+        return getattr(settings, "DJSTRIPE_USE_NATIVE_JSONFIELD", True)
+
+    @property
+    def PRORATION_POLICY(self):
+        return getattr(settings, "DJSTRIPE_PRORATION_POLICY", None)
 
     @property
     def DJSTRIPE_WEBHOOK_URL(self):

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -2,6 +2,7 @@
 Utility functions related to the djstripe app.
 """
 import datetime
+import warnings
 from typing import Optional
 
 import stripe
@@ -122,3 +123,28 @@ def get_timezone_utc():
         return datetime.timezone.utc
     except AttributeError:
         return timezone.utc
+
+def _get_remote_ip(request):
+    """Given the HTTPRequest object return the IP Address of the client
+
+    :param request: client request
+    :type request: HTTPRequest
+
+    :Returns: the client ip address
+    """
+
+    # HTTP_X_FORWARDED_FOR is relevant for django running behind a proxy
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(",")[0]
+    else:
+        ip = request.META.get("REMOTE_ADDR")
+
+    if not ip:
+        warnings.warn(
+            "Could not determine remote IP (missing REMOTE_ADDR). "
+            "This is likely an issue with your wsgi/server setup."
+        )
+        ip = "0.0.0.0"
+
+    return ip

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -124,6 +124,7 @@ def get_timezone_utc():
     except AttributeError:
         return timezone.utc
 
+
 def _get_remote_ip(request):
     """Given the HTTPRequest object return the IP Address of the client
 
@@ -134,7 +135,7 @@ def _get_remote_ip(request):
     """
 
     # HTTP_X_FORWARDED_FOR is relevant for django running behind a proxy
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    x_forwarded_for = request.headers.get("x-forwarded-for")
     if x_forwarded_for:
         ip = x_forwarded_for.split(",")[0]
     else:

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,6 +51,25 @@ switch an older installation to "id", the easiest way is to wipe the djstripe db
 sync again from scratch. This is obviously not ideal, and we will design a proper
 migration path before 3.0.
 
+## DJSTRIPE_GET_REMOTE_IP (=djstripe.settings.djstripe_settings.GET_REMOTE_IP)
+
+_(Introduced in 2.6.0)_
+
+`DJSTRIPE_GET_REMOTE_IP` is a setting introduced in dj-stripe version 2.6.0. You are `not` required to set it unless you require more advanced strategies and/or filters to record the `client remote ip`. The [`default function`][djstripe.utils._get_remote_ip] can handle common django setups behind a proxy and relies on the HTTP header `HTTP_X_FORWARDED_FOR`. 
+
+`DJSTRIPE_GET_REMOTE_IP` should return a function with the following signature:
+
+```py
+def GET_REMOTE_IP(request: HTTPRequest):
+    # do your magic
+    return "<IP_ADDRESS>"
+```
+
+The function MUST return a string suitably random for the object_type/action pair, and
+usable in the Stripe `Idempotency-Key` HTTP header. For more information, see the
+[stripe documentation](https://stripe.com/docs/upgrades).
+
+
 ## DJSTRIPE_IDEMPOTENCY_KEY_CALLBACK (=djstripe.settings.djstripe_settings.\_get_idempotency_key)
 
 A function which will return an idempotency key for a particular object_type and action

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -55,7 +55,7 @@ migration path before 3.0.
 
 _(Introduced in 2.6.0)_
 
-`DJSTRIPE_GET_REMOTE_IP` is a setting introduced in dj-stripe version 2.6.0. You are `not` required to set it unless you require more advanced strategies and/or filters to record the `client remote ip`. The [`default function`][djstripe.utils._get_remote_ip] can handle common django setups behind a proxy and relies on the HTTP header `HTTP_X_FORWARDED_FOR`. 
+`DJSTRIPE_GET_REMOTE_IP` is a setting introduced in dj-stripe version 2.6.0. You are `not` required to set it unless you require more advanced strategies and/or filters to record the `client remote ip`. The [`default function`][djstripe.utils._get_remote_ip] can handle common django setups behind a proxy and relies on the HTTP header `HTTP_X_FORWARDED_FOR`.
 
 `DJSTRIPE_GET_REMOTE_IP` should return a function with the following signature:
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -15,9 +15,9 @@ from django.test.client import Client
 from django.urls import reverse
 
 from djstripe import webhooks
-from djstripe.models import Event, Transfer, WebhookEventTrigger
-from djstripe.models.webhooks import WebhookEndpoint, get_remote_ip
+from djstripe.models import Event, Transfer, WebhookEndpoint, WebhookEventTrigger
 from djstripe.settings import djstripe_settings
+from djstripe.utils import _get_remote_ip
 from djstripe.webhooks import TEST_EVENT_ID, call_handlers, handler, handler_all
 
 from . import (
@@ -653,9 +653,9 @@ class TestGetRemoteIp:
             },
         ],
     )
-    def test_get_remote_ip(self, data):
+    def test__get_remote_ip(self, data):
         request = self.RequestClass(data)
-        assert get_remote_ip(request) == "127.0.0.1"
+        assert _get_remote_ip(request) == "127.0.0.1"
 
     @pytest.mark.parametrize(
         "data",
@@ -668,14 +668,14 @@ class TestGetRemoteIp:
             },
         ],
     )
-    def test_get_remote_ip_remote_addr_is_none(self, data):
+    def test__get_remote_ip_remote_addr_is_none(self, data):
         request = self.RequestClass(data)
 
         # ensure warning is raised
         with pytest.warns(
             None, match=r"Could not determine remote IP \(missing REMOTE_ADDR\)\."
         ):
-            assert get_remote_ip(request) == "0.0.0.0"
+            assert _get_remote_ip(request) == "0.0.0.0"
 
 
 class TestWebhookEndpoint(CreateAccountMixin):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge PR #1531 before merging this

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Exposed a new setting `DJSTRIPE_GET_REMOTE_IP` to allow the user to write their own function to extract the `remote_ip` from the `request`.
2. Updated Application Code to accomodate the change
3. Updated Corresponding Tests
4. Updated docs with the new setting name.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1057
Fix: #1843
User would now be able to override `_get_remote_ip` with their own function for more advanced setups and perhaps even use libraries like [django-ipware](https://github.com/un33k/django-ipware)