### PR TITLE
Update Tox env for building docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 
 ; Need to mention the env because we use tests.settings
-[testenv:docs-django{31,32,main}-{postgres,mysql,sqlite}{,-nativejson}]
+[testenv:docs-django{32,40,main}-{postgres,mysql,sqlite}{,-nativejson}]
 extras = docs
 commands =
     mkdocs build --clean

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ skip_missing_interpreters = True
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38, pre-commit, docs
-    3.9: py39
+    3.8: py38
+    3.9: py39, pre-commit, docs
     3.10: py310
 
 [testenv]


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed `django 3.1` from `docs` as it is no longer supported by `dj-stripe` anyway.
2. Moved running `pre-commit` and `docs` from `python 3.8` to `python 3.9` as that is more recent.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improve long term maintainability of the project.