### PR TITLE
Fix fields.E010

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1415,7 +1415,7 @@ class Dispute(StripeModel):
         "account balance.",
     )
     balance_transactions = JSONField(
-        default="[]",
+        default=list,
         help_text="List of 0, 1 or 2 Balance Transactions that show funds withdrawn and reinstated to your Stripe account as a result of this dispute.",
     )
     # charge is nullable to avoid infinite sync as Charge model has a dispute field as well


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Make Dispute.balance_transactions use a callable as a default to avoid using the same default everywhere.

Also, avoid a warning to the console when system checking the app.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates. (This is handled by Django system checks)
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [ ] I've updated `migrations` or confirm that my change doesn't make changes to any model (Can't do it on GitHub, feel free to push).

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

It avoids a system check and avoid saving bad data in the database.