### PR TITLE
Add djstripe_updated model field to admin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -188,14 +188,19 @@ class StripeModelAdmin(admin.ModelAdmin):
         return (
             ("__str__", "id", "djstripe_owner_account")
             + self.list_display
-            + ("created", "livemode")
+            + ("created", "livemode", "djstripe_updated")
         )
 
     def get_list_filter(self, request):
-        return self.list_filter + ("created", "livemode")
+        return self.list_filter + ("created", "livemode", "djstripe_updated")
 
     def get_readonly_fields(self, request, obj=None):
-        return self.readonly_fields + ("id", "djstripe_owner_account", "created")
+        return self.readonly_fields + (
+            "id",
+            "djstripe_owner_account",
+            "created",
+            "djstripe_updated",
+        )
 
     def get_search_fields(self, request):
         return self.search_fields + ("id",)
@@ -216,7 +221,7 @@ class SubscriptionInline(admin.StackedInline):
 
     model = models.Subscription
     extra = 0
-    readonly_fields = ("id", "created", "djstripe_owner_account")
+    readonly_fields = ("id", "created", "djstripe_owner_account", "djstripe_updated")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -234,6 +239,7 @@ class TaxIdInline(admin.TabularInline):
         "livemode",
         "country",
         "djstripe_owner_account",
+        "djstripe_updated",
     )
     show_change_link = True
 
@@ -243,7 +249,7 @@ class SubscriptionItemInline(admin.StackedInline):
 
     model = models.SubscriptionItem
     extra = 0
-    readonly_fields = ("id", "created", "djstripe_owner_account")
+    readonly_fields = ("id", "created", "djstripe_owner_account", "djstripe_updated")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -253,7 +259,7 @@ class InvoiceItemInline(admin.StackedInline):
 
     model = models.InvoiceItem
     extra = 0
-    readonly_fields = ("id", "created", "djstripe_owner_account")
+    readonly_fields = ("id", "created", "djstripe_owner_account", "djstripe_updated")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
 
@@ -286,8 +292,20 @@ class APIKeyAdminCreateForm(forms.ModelForm):
 
 @admin.register(models.APIKey)
 class APIKeyAdmin(admin.ModelAdmin):
-    list_display = ("__str__", "type", "djstripe_owner_account", "livemode")
-    readonly_fields = ("djstripe_owner_account", "livemode", "type", "secret")
+    list_display = (
+        "__str__",
+        "type",
+        "djstripe_owner_account",
+        "livemode",
+        "djstripe_updated",
+    )
+    readonly_fields = (
+        "djstripe_owner_account",
+        "livemode",
+        "type",
+        "secret",
+        "djstripe_updated",
+    )
     search_fields = ("name",)
 
     def get_readonly_fields(self, request, obj=None):

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -71,8 +71,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("business_profile", djstripe.fields.JSONField(blank=True, null=True)),
                 (
                     "business_type",
@@ -167,8 +166,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -318,8 +316,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("id", djstripe.fields.StripeIdField(max_length=500)),
                 (
                     "amount_off",
@@ -419,8 +416,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("billing_details", djstripe.fields.JSONField()),
                 ("card", djstripe.fields.JSONField()),
                 ("card_present", djstripe.fields.JSONField(blank=True, null=True)),
@@ -462,8 +458,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("balance", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 (
                     "business_vat_id",
@@ -602,8 +597,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField()),
                 ("evidence", djstripe.fields.JSONField()),
@@ -656,8 +650,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "api_version",
                     models.CharField(
@@ -713,8 +706,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "filename",
                     models.CharField(
@@ -787,8 +779,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -915,8 +906,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "name",
                     models.TextField(
@@ -1010,8 +1000,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "application_fee_percent",
                     djstripe.fields.StripePercentField(
@@ -1160,8 +1149,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -1317,8 +1305,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount_due",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -1636,8 +1623,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "account_holder_name",
                     models.TextField(
@@ -1723,8 +1709,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="CountrySpec",
             fields=[
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "id",
                     models.CharField(max_length=2, primary_key=True, serialize=False),
@@ -1768,8 +1753,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
@@ -1832,8 +1816,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("data_load_time", djstripe.fields.StripeDateTimeField()),
                 ("error", djstripe.fields.JSONField(blank=True, null=True)),
                 ("result_available_until", djstripe.fields.StripeDateTimeField()),
@@ -1891,8 +1874,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "quantity",
                     models.PositiveIntegerField(
@@ -1949,8 +1931,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -2003,8 +1984,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "quantity",
                     models.PositiveIntegerField(
@@ -2050,8 +2030,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("amount_refunded", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
@@ -2101,8 +2080,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", djstripe.fields.StripeDateTimeField(blank=True, null=True)),
                 ("metadata", djstripe.fields.JSONField(blank=True, null=True)),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -2173,8 +2151,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "address_city",
                     models.TextField(
@@ -2372,8 +2349,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "application",
                     models.CharField(
@@ -2469,8 +2445,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", djstripe.fields.StripeDateTimeField(blank=True, null=True)),
                 ("metadata", djstripe.fields.JSONField(blank=True, null=True)),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 (
                     "amount_capturable",
@@ -2665,8 +2640,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "billing_address_collection",
                     djstripe.fields.StripeEnumField(
@@ -2922,8 +2896,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -3034,8 +3007,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -3134,8 +3106,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -3229,8 +3200,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "account_country",
                     models.CharField(
@@ -3576,8 +3546,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -3661,8 +3630,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -72,6 +72,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("business_profile", djstripe.fields.JSONField(blank=True, null=True)),
                 (
                     "business_type",
@@ -167,6 +168,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -317,6 +319,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("id", djstripe.fields.StripeIdField(max_length=500)),
                 (
                     "amount_off",
@@ -417,6 +420,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("billing_details", djstripe.fields.JSONField()),
                 ("card", djstripe.fields.JSONField()),
                 ("card_present", djstripe.fields.JSONField(blank=True, null=True)),
@@ -459,6 +463,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("balance", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 (
                     "business_vat_id",
@@ -598,6 +603,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField()),
                 ("evidence", djstripe.fields.JSONField()),
@@ -651,6 +657,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "api_version",
                     models.CharField(
@@ -707,6 +714,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "filename",
                     models.CharField(
@@ -780,6 +788,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -907,6 +916,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "name",
                     models.TextField(
@@ -1001,6 +1011,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "application_fee_percent",
                     djstripe.fields.StripePercentField(
@@ -1150,6 +1161,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -1306,6 +1318,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount_due",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -1624,6 +1637,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "account_holder_name",
                     models.TextField(
@@ -1710,6 +1724,7 @@ class Migration(migrations.Migration):
             name="CountrySpec",
             fields=[
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "id",
                     models.CharField(max_length=2, primary_key=True, serialize=False),
@@ -1754,6 +1769,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeQuantumCurrencyAmountField(
@@ -1817,6 +1833,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("data_load_time", djstripe.fields.StripeDateTimeField()),
                 ("error", djstripe.fields.JSONField(blank=True, null=True)),
                 ("result_available_until", djstripe.fields.StripeDateTimeField()),
@@ -1875,6 +1892,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "quantity",
                     models.PositiveIntegerField(
@@ -1932,6 +1950,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -1985,6 +2004,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "quantity",
                     models.PositiveIntegerField(
@@ -2031,6 +2051,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("amount_refunded", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
@@ -2081,6 +2102,7 @@ class Migration(migrations.Migration):
                 ("created", djstripe.fields.StripeDateTimeField(blank=True, null=True)),
                 ("metadata", djstripe.fields.JSONField(blank=True, null=True)),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -2152,6 +2174,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "address_city",
                     models.TextField(
@@ -2350,6 +2373,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "application",
                     models.CharField(
@@ -2446,6 +2470,7 @@ class Migration(migrations.Migration):
                 ("created", djstripe.fields.StripeDateTimeField(blank=True, null=True)),
                 ("metadata", djstripe.fields.JSONField(blank=True, null=True)),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 (
                     "amount_capturable",
@@ -2641,6 +2666,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "billing_address_collection",
                     djstripe.fields.StripeEnumField(
@@ -2897,6 +2923,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -3008,6 +3035,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(
@@ -3107,6 +3135,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 ("amount", djstripe.fields.StripeQuantumCurrencyAmountField()),
                 ("currency", djstripe.fields.StripeCurrencyCodeField(max_length=3)),
                 (
@@ -3201,6 +3230,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "account_country",
                     models.CharField(
@@ -3547,6 +3577,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -3631,6 +3662,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "amount",
                     djstripe.fields.StripeDecimalCurrencyAmountField(

--- a/djstripe/migrations/0007_2_4.py
+++ b/djstripe/migrations/0007_2_4.py
@@ -541,8 +541,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -714,8 +713,7 @@ class Migration(migrations.Migration):
                         null=True,
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "country",
                     models.CharField(
@@ -853,8 +851,7 @@ class Migration(migrations.Migration):
                         blank=True, help_text="A description of this object.", null=True
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "canceled_at",
                     djstripe.fields.StripeDateTimeField(
@@ -1255,8 +1252,7 @@ class Migration(migrations.Migration):
                         null=True,
                     ),
                 ),
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "id",
                     models.CharField(

--- a/djstripe/migrations/0007_2_4.py
+++ b/djstripe/migrations/0007_2_4.py
@@ -542,6 +542,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "active",
                     models.BooleanField(
@@ -714,6 +715,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "country",
                     models.CharField(
@@ -852,6 +854,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "canceled_at",
                     djstripe.fields.StripeDateTimeField(
@@ -1253,6 +1256,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "id",
                     models.CharField(

--- a/djstripe/migrations/0008_2_5.py
+++ b/djstripe/migrations/0008_2_5.py
@@ -73,6 +73,7 @@ class Migration(migrations.Migration):
             name="FileLink",
             fields=[
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(
@@ -154,6 +155,7 @@ class Migration(migrations.Migration):
             name="Mandate",
             fields=[
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(

--- a/djstripe/migrations/0008_2_5.py
+++ b/djstripe/migrations/0008_2_5.py
@@ -72,8 +72,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="FileLink",
             fields=[
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(
@@ -154,8 +153,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="Mandate",
             fields=[
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(

--- a/djstripe/migrations/0009_2_6.py
+++ b/djstripe/migrations/0009_2_6.py
@@ -21,8 +21,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="WebhookEndpoint",
             fields=[
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(
@@ -119,8 +118,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="UsageRecordSummary",
             fields=[
-                ("djstripe_created", models.DateTimeField(auto_now_add=True)),
-                ("djstripe_updated", models.DateTimeField(auto_now=True)),
+                ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(

--- a/djstripe/migrations/0009_2_6.py
+++ b/djstripe/migrations/0009_2_6.py
@@ -22,6 +22,7 @@ class Migration(migrations.Migration):
             name="WebhookEndpoint",
             fields=[
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(
@@ -119,6 +120,7 @@ class Migration(migrations.Migration):
             name="UsageRecordSummary",
             fields=[
                 ("djstripe_created", models.DateTimeField(auto_now_add=True, help_text="The datetime this object was created in the local database.")),
+                ("djstripe_updated", models.DateTimeField(auto_now=True, help_text="The datetime this object was updated/modified in the local database.")),
                 (
                     "djstripe_id",
                     models.BigAutoField(

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -32,6 +32,11 @@ class StripeBaseModel(models.Model):
         editable=False,
         help_text="The datetime this object was created in the local database.",
     )
+    djstripe_updated = models.DateTimeField(
+        auto_now=True,
+        editable=False,
+        help_text="The datetime this object was updated/modified in the local database.",
+    )
 
     class Meta:
         abstract = True

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -27,8 +27,11 @@ logger = logging.getLogger(__name__)
 class StripeBaseModel(models.Model):
     stripe_class: Optional[APIResource] = None
 
-    djstripe_created = models.DateTimeField(auto_now_add=True, editable=False)
-    djstripe_updated = models.DateTimeField(auto_now=True, editable=False)
+    djstripe_created = models.DateTimeField(
+        auto_now_add=True,
+        editable=False,
+        help_text="The datetime this object was created in the local database.",
+    )
 
     class Meta:
         abstract = True


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `help_text` of `StripeBaseModel.djstripe_created` to ensure one doesn't confuse it with the similar field `StripeModel.created`.
2. Updated `help_text` of `StripeBaseModel.djstripe_updated` and exposed on `Admin` to make it easier and faster for the users to use the  `admin` to sort through the vast amount of synced data. This can be used to select fields that one may want to `sync/update` from upstream, for example.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
This will make it faster for a user to not only sort through older fields that haven't been updated recently but to also easily select the fields to update and invoke `_update_sync_instances` django action for that.