### PR TITLE
Update 2_6_0 release history

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1757,6 +1757,8 @@ class SubscriptionItem(StripeModel):
         )
 
 
+# TODO Add missing fields and then add to SubscriptionAdmin (as inline)
+# https://stripe.com/docs/api/subscription_schedules/object?lang=python
 class SubscriptionSchedule(StripeModel):
     """
     Subscription schedules allow you to create and manage the lifecycle

--- a/docs/history/2_6_0.md
+++ b/docs/history/2_6_0.md
@@ -34,6 +34,7 @@
     order to support a pre-existing database. A migration path will later be provided
     for this use case.
 -   The undocumented `get_stripe_api_version()` helper function has been removed.
+-   The undocumented method `str_parts()` has been removed.
 -   Settings for dj-stripe are now in `djstripe.settings.djstripe_settings` (as opposed
     to top-level in `djstripe.settings`)
 -   `Customer.subscribe()` method no longer accepts positional arguments, only keywords.

--- a/docs/history/2_6_0.md
+++ b/docs/history/2_6_0.md
@@ -35,6 +35,7 @@
     for this use case.
 -   The undocumented `get_stripe_api_version()` helper function has been removed.
 -   The undocumented method `str_parts()` has been removed.
+-   The undocumented `StripeModel` classmethod, `_id_from_data()`, has been removed and replaced with [`get_id_from_stripe_data()`](../../djstripe/utils.py#get_id_from_stripe_data)
 -   Settings for dj-stripe are now in `djstripe.settings.djstripe_settings` (as opposed
     to top-level in `djstripe.settings`)
 -   `Customer.subscribe()` method no longer accepts positional arguments, only keywords.

--- a/docs/history/2_6_0.md
+++ b/docs/history/2_6_0.md
@@ -51,3 +51,4 @@
     `InvalidStripeAPIKey` if the API key looks completely incorrect.
 -   `Customers` can now be subscribed to multiple prices by passing the `items` argument
     to `Customer.subscribe()`.
+-   `Checkout Session` metadata can be used to `create/link` djstripe `Customer` to the instance specified by the `djstripe_settings.SUBSCRIBER_CUSTOMER_KEY`. Check Example [here](../usage/using_stripe_checkout.md)


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated the `2.6.0 release notes` regarding how one can now link `Checkout` created `Customers` to `Subscribers`.
2. Updated the `2.6.0 release notes` regarding the now removed `str_parts()` method.
3. Updated the `2.6.0 release notes` regarding  the now removed `StripeModel._id_from_data()` classmethod and how thay has been replaced by the helper function, `get_id_from_stripe_data()`, from the `utils` module.
4. Added `TODOs`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

