### PR TITLE
Updated test_webhook_no_validation_pass to not pollute the console with expected warning

### DIFF
--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -227,7 +227,9 @@ class TestWebhookEventTrigger(TestCase):
         invalid_event["id"] = "evt_invalid"
         invalid_event["data"]["valid"] = "not really"
 
-        resp = self._send_event(invalid_event)
+        # ensure warning is raised
+        with pytest.warns(None, match=r"WEBHOOK VALIDATION is disabled."):
+            resp = self._send_event(invalid_event)
 
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(Event.objects.filter(id="evt_invalid").exists())


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `test_webhook_no_validation_pass` to not only check that the `expected warning` got raised but to also prevent it from polluting the `console` with `expected warning.`


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.