### PR TITLE
Fix Customer Subscribe issue in 2.6.0rc1

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -879,7 +879,10 @@ class Customer(StripeModel):
                 price = item.get("price", "")
                 plan = item.get("plan", "")
                 price, kwargs = _sanitise_price(price, plan, **kwargs)
-                _items.append(item)
+                if "price" in item:
+                    _items.append({"price": price})
+                if "plan" in item:
+                    _items.append({"plan": price})
 
         stripe_subscription = Subscription._api_create(
             items=_items, customer=self.id, **kwargs

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -872,7 +872,7 @@ class Customer(StripeModel):
             raise TypeError("Please define only one of items, price or plan arguments.")
 
         if items is None:
-            items = [{"price": price}]
+            _items = [{"price": price}]
         else:
             _items = []
             for item in items:
@@ -882,7 +882,7 @@ class Customer(StripeModel):
                 _items.append(item)
 
         stripe_subscription = Subscription._api_create(
-            items=items, customer=self.id, **kwargs
+            items=_items, customer=self.id, **kwargs
         )
 
         Subscription.sync_from_stripe_data(stripe_subscription)

--- a/docs/history/2_6_0.md
+++ b/docs/history/2_6_0.md
@@ -54,7 +54,7 @@
 -   Migrations have been optimized and should be faster.
 -   dj-stripe now checks the apparent validity of API keys used and will raise
     `InvalidStripeAPIKey` if the API key looks completely incorrect.
--   `Customers` can now be subscribed to multiple prices by passing the `items` argument
+-   `Customers` can now be subscribed to multiple prices and/or plans by passing the `items` argument
     to `Customer.subscribe()`.
 -   Checkout Session metadata can be used to create/link a Stripe `Customer` to the
     `Customer` instance specified by the `djstripe_settings.SUBSCRIBER_CUSTOMER_KEY`.


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed the logic of how the `_items` list to be passed to `Subscription._api_create()` is constructed taking into account the original keys passed into the `items` parameter. The user can choose to pass in a mixed list consisting of `Price`s and `Plan`s.
2. Updated Corresponding Tests.
3. Updated docs.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1552
`Customers` can now be subscribed to multiple `Plan`s and `Price`s at the same time!