### PR TITLE
Updated StripeModel._create_from_stripe_object() classmethod

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -574,24 +574,35 @@ class StripeModel(StripeBaseModel):
         """
         if api_key is None:
             api_key = djstripe_settings.STRIPE_SECRET_KEY
-        # TODO dictionary unpacking will not work if cls has any ManyToManyField
-        instance = cls(
-            **cls._stripe_object_to_record(
-                data,
-                current_ids=current_ids,
-                pending_relations=pending_relations,
-                stripe_account=stripe_account,
-                api_key=api_key,
+
+        stripe_data = cls._stripe_object_to_record(
+            data,
+            current_ids=current_ids,
+            pending_relations=pending_relations,
+            stripe_account=stripe_account,
+            api_key=api_key,
+        )
+        try:
+            id_ = get_id_from_stripe_data(stripe_data)
+            if id_ is not None:
+                instance = cls.stripe_objects.get(id=id_)
+            else:
+                # Raise error on purpose to resume the _create_from_stripe_object flow
+                raise cls.DoesNotExist
+
+        except cls.DoesNotExist:
+            # try to create iff instance doesn't already exist in the DB
+            # TODO dictionary unpacking will not work if cls has any ManyToManyField
+            instance = cls(**stripe_data)
+
+            instance._attach_objects_hook(cls, data, current_ids=current_ids)
+
+            if save:
+                instance.save(force_insert=True)
+
+            instance._attach_objects_post_save_hook(
+                cls, data, pending_relations=pending_relations
             )
-        )
-        instance._attach_objects_hook(cls, data, current_ids=current_ids)
-
-        if save:
-            instance.save(force_insert=True)
-
-        instance._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
-        )
 
         return instance
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -598,7 +598,7 @@ class StripeModel(StripeBaseModel):
             instance._attach_objects_hook(cls, data, current_ids=current_ids)
 
             if save:
-                instance.save(force_insert=True)
+                instance.save()
 
             instance._attach_objects_post_save_hook(
                 cls, data, pending_relations=pending_relations

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -76,7 +76,7 @@ class EventTest(TestCase):
         mock_objects.filter.assert_called_once_with(id=mock_data["id"])
         mock_objects.filter.return_value.exists.assert_called_once_with()
         mock_atomic.return_value.__enter__.assert_called_once_with()
-        mock__create_from_stripe_object.assert_called_once_with(mock_data)
+        mock__create_from_stripe_object.assert_called_once_with(mock_data, api_key=None)
         (
             mock__create_from_stripe_object.return_value.invoke_webhook_handlers
         ).assert_called_once_with()
@@ -138,7 +138,7 @@ class EventTest(TestCase):
         ) as create_from_stripe_object_mock:
             Event.process(data=event_data)
 
-        create_from_stripe_object_mock.assert_called_once_with(event_data)
+        create_from_stripe_object_mock.assert_called_once_with(event_data, api_key=None)
         self.assertFalse(
             Event.objects.filter(id=FAKE_EVENT_TRANSFER_CREATED["id"]).exists()
         )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

Updated `StripeModel._create_from_stripe_object()` classmethod to only run when instance doesn't exist. This was done because of the following reason:

This was done because in cases where the "sync chain" is like so (`with repeated links`):
```
            A --> B --> C --> D --> B --> ...
```

In words: Syncing A starts syncing for `RelatedObject` B, which in turn starts the sync process for `RelatedObject` C and so on and so forth. And any one or more links of the chain references an already `sync started` RelatedObject, when time comes to finish the sync process for the earlier `sync started` RelatedObject, an `IntegrityError` would be thrown as the **ALREADY** invoked classmethod `StripeModel._create_from_stripe_object()` would try to `create` the object (**that already exists in the transaction**) ultimately resulting in  `Object matching query does not exist` Exception. This is because trying to create an already created object would throw an `IntegrityError`, which would cause all the `created` objects in the transaction `to get rolled back`!



Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1560
Fix: #1552

In general any "sync chains" with repeated links will face this issue and this PR will be a generic fix for such issues.
