### PR TITLE
Added missing __str__ test for apikey

### DIFF
--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -113,6 +113,16 @@ class APIKeyTest(TestCase):
             "https://dashboard.stripe.com/acct_1Fg9jUA3kq9o1aTc/apikeys",
         )
 
+    def test___str__(self):
+        assert str(self.apikey_live) == "Live Secret Key"
+        assert str(self.apikey_test) == "Test Secret Key"
+
+        # update name of apikey_live to ""
+        self.apikey_live.name = ""
+        self.apikey_live.save()
+
+        assert str(self.apikey_live) == "sk_live_...5678"
+
     def test_secret_redacted(self):
         self.assertEqual(self.apikey_test.secret_redacted, "sk_test_...1234")
         self.assertEqual(self.apikey_live.secret_redacted, "sk_live_...5678")


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added missing test for `APIKey.__str__()`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Overall better test coverage for `APIKey`