### PR TITLE
Add missing admin tests

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -273,6 +273,7 @@ class APIKeyAdminCreateForm(forms.ModelForm):
         model = models.APIKey
         fields = ["name", "secret"]
 
+    # todo add test
     def _post_clean(self):
         super()._post_clean()
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -313,13 +313,13 @@ class TestAdminCustomActions(TestCase):
         patched__api_delete.assert_called_once_with()
 
 
-class TestAdminRegisteredModels(TestCase):
+class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
     def setUp(self):
         self.admin = get_user_model().objects.create_superuser(
             username="admin", email="admin@djstripe.com", password="xxx"
         )
         self.factory = RequestFactory()
-        # the 2 models that do not inherit from StripeModel and hence
+        # the 4 models that do not inherit from StripeModel and hence
         # do not inherit from StripeModelAdmin
         self.ignore_models = [
             "WebhookEventTrigger",
@@ -683,6 +683,358 @@ class TestAdminRegisteredModels(TestCase):
                 # for models inheriting from StripeModelAdmin verify:
                 if model.__name__ not in self.ignore_models:
                     self.assertTrue("id" in search_fields)
+
+
+class TestAdminRegisteredModelsNotChildrenOfStripeModel(TestCase):
+    def setUp(self):
+        self.admin = get_user_model().objects.create_superuser(
+            username="admin", email="admin@djstripe.com", password="xxx"
+        )
+        self.factory = RequestFactory()
+
+    def test_get_list_display_links(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+                list_display = model_admin.get_changelist_instance(request).list_display
+
+                # get_changelist_instance to get an instance of the ChangelistView for logged in admin user
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    list(response.context_data["cl"].list_display_links),
+                    list(
+                        model_admin.get_changelist_instance(request).list_display_links
+                    ),
+                )
+
+                # ensure all the fields in list_display_links are valid
+                for field in model_admin.get_list_display_links(request, list_display):
+                    model_admin.get_changelist_instance(request).get_ordering_field(
+                        field
+                    )
+
+    def test_get_list_display(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+
+                # get_changelist_instance to get an instance of the ChangelistView for logged in admin user
+                list_display = model_admin.get_changelist_instance(request).list_display
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    list(response.context_data["cl"].list_display),
+                    list(list_display),
+                )
+
+                # ensure all the fields in list_display are valid
+                for field in model_admin.get_list_display(request):
+                    model_admin.get_changelist_instance(request).get_ordering_field(
+                        field
+                    )
+
+                self.assertTrue(
+                    all(
+                        [
+                            1
+                            for i in [
+                                "__str__",
+                                "id",
+                                "djstripe_owner_account",
+                                "created",
+                                "livemode",
+                            ]
+                            if i in list_display
+                        ]
+                    )
+                )
+
+    def test_get_list_filter(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+
+                # get_changelist_instance to get an instance of the ChangelistView for logged in admin user
+                list_filter = model_admin.get_changelist_instance(request).list_filter
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    list(response.context_data["cl"].list_filter),
+                    list(list_filter),
+                )
+
+                # ensure all the filters get formed correctly
+                chl = model_admin.get_changelist_instance(request)
+                chl.get_filters(request)
+                chl.get_queryset(request)
+
+                self.assertTrue(
+                    all([1 for i in ["created", "livemode"] if i in list_filter])
+                )
+
+    def test_get_readonly_fields(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+
+                # get_changelist_instance to get an instance of the ChangelistView for logged in admin user
+                readonly_fields = model_admin.get_changelist_instance(
+                    request
+                ).model_admin.readonly_fields
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context_data["cl"].model_admin.readonly_fields,
+                    readonly_fields,
+                )
+
+                # ensure all the fields in readonly_fields are valid
+                for field in model_admin.get_readonly_fields(request):
+                    # ensure the given field is on model, or model_admin or modelform
+                    model_admin.get_changelist_instance(request).get_ordering_field(
+                        field
+                    )
+
+                self.assertTrue(
+                    all(
+                        [
+                            1
+                            for i in ["created", "djstripe_owner_account", "id"]
+                            if i in readonly_fields
+                        ]
+                    )
+                )
+
+    def test_get_list_select_related(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+
+                # get_changelist_instance to get an instance of the ChangelistView for logged in admin user
+                list_select_related = model_admin.get_changelist_instance(
+                    request
+                ).list_select_related
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context_data["cl"].list_select_related,
+                    list_select_related,
+                )
+
+                # ensure all the fields in list_select_related are valid
+                list_select_related_fields = model_admin.get_list_select_related(
+                    request
+                )
+                if isinstance(list_select_related_fields, Sequence):
+                    # need to force the returned queryset to get evaluated
+                    list(model.objects.select_related(*list_select_related_fields))
+
+    # todo complete after djstripe has integrated ModelFactory
+    # def test_get_fieldsets_change(self):
+    #     pass
+
+    def test_get_fieldsets_add(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard add url
+                add_url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_add"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(add_url)
+                request.user = self.admin
+
+                # skip model if model doesn't have "has_add_permission"
+                if not model_admin.has_add_permission(request):
+                    continue
+
+                response = model_admin.add_view(request)
+
+                fieldsets = model_admin.get_fieldsets(request)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context_data["adminform"].fieldsets,
+                    [*fieldsets],
+                )
+
+                self.assertTrue(
+                    all(
+                        [
+                            1
+                            for i in [
+                                "created",
+                                "livemode",
+                                "djstripe_owner_account",
+                                "id",
+                            ]
+                            if i in fieldsets
+                        ]
+                    )
+                )
+
+    # todo complete after djstripe has integrated ModelFactory
+    # def test_get_fields_change(self):
+    #     pass
+
+    def test_get_fields_add(self):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard add url
+                add_url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_add"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(add_url)
+                request.user = self.admin
+
+                # skip model if model doesn't have "has_add_permission"
+                if not model_admin.has_add_permission(request):
+                    continue
+
+                response = model_admin.add_view(request)
+
+                fields = model_admin.get_fields(request)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context_data["adminform"].model_admin.get_fields(request),
+                    list(fields),
+                )
+
+                # ensure all the fields in model_admin are valid
+                for field in model_admin.get_fields(request):
+                    # as these fields are form field and not modelform fields
+                    if model_admin.model is models.WebhookEndpoint and field in (
+                        "base_url",
+                        "enabled",
+                        "connect",
+                    ):
+                        continue
+                    model_admin.get_changelist_instance(request).get_ordering_field(
+                        field
+                    )
+
+    def test_get_search_fields(self):
+        """
+        Ensure all fields in model_admin.get_search_fields exist on the model or the related model
+        """
+
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+                # get the standard changelist_view url and make a sample query to trigger search
+                url = (
+                    reverse(
+                        f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                    )
+                    + "?q=bar"
+                )
+
+                # add the admin user to the mocked request
+                request = self.factory.get(url)
+                request.user = self.admin
+
+                response = model_admin.changelist_view(request)
+
+                search_fields = model_admin.get_changelist_instance(
+                    request
+                ).search_fields
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.context_data["cl"].search_fields,
+                    search_fields,
+                )
+
+                try:
+                    # ensure all the fields in search_fields are valid
+                    # need to force the returned queryset to get evaluated
+                    list(model.objects.select_related(*search_fields))
+                except FieldError as error:
+                    if "Non-relational field given in select_related" not in str(error):
+                        self.fail(error)
 
 
 class TestAdminInlineModels(TestCase):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added missing Admin tests for all models that did not inherit from `StripeModelAdmin`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will Improve test coverage.