### PR TITLE
Update Incorrect Stripe Dashboard URL for various models

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -289,6 +289,8 @@ class APIKeyAdminCreateForm(forms.ModelForm):
 
 @admin.register(models.APIKey)
 class APIKeyAdmin(admin.ModelAdmin):
+    change_form_template = "djstripe/admin/change_form.html"
+
     list_display = ("__str__", "type", "djstripe_owner_account", "livemode")
     readonly_fields = ("djstripe_owner_account", "livemode", "type", "secret")
     search_fields = ("name",)

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -86,6 +86,13 @@ class Account(StripeModel):
         help_text="Details on the acceptance of the Stripe Services Agreement",
     )
 
+    def get_stripe_dashboard_url(self) -> str:
+        """Get the stripe dashboard url for this object."""
+        return (
+            f"https://dashboard.stripe.com/{self.id}/"
+            f"{'test/' if not self.livemode else ''}dashboard"
+        )
+
     @property
     def default_api_key(self) -> str:
         return self.get_default_api_key()

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -661,9 +661,6 @@ class BaseInvoice(StripeModel):
             return True
         return False
 
-    def get_stripe_dashboard_url(self):
-        return self.customer.get_stripe_dashboard_url()
-
     def _attach_objects_post_save_hook(
         self,
         cls,

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -277,6 +277,7 @@ class TransferReversal(StripeModel):
     """
 
     expand_fields = ["balance_transaction", "transfer"]
+    stripe_dashboard_item_name = "transfer_reversals"
 
     # TransferReversal classmethods are derived from
     # and attached to the stripe.Transfer class

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -269,6 +269,12 @@ class Transfer(StripeModel):
         for reversals_data in data.get("reversals").auto_paging_iter():
             TransferReversal.sync_from_stripe_data(reversals_data, api_key=api_key)
 
+    def get_stripe_dashboard_url(self) -> str:
+        return (
+            f"{self._get_base_stripe_dashboard_url()}"
+            f"connect/{self.stripe_dashboard_item_name}/{self.id}"
+        )
+
 
 # TODO Add Tests
 class TransferReversal(StripeModel):

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1368,7 +1368,6 @@ class Customer(StripeModel):
             Subscription.sync_from_stripe_data(stripe_subscription)
 
 
-# TODO Add Tests
 class Dispute(StripeModel):
     """
     A dispute occurs when a customer questions your charge with their
@@ -1379,7 +1378,7 @@ class Dispute(StripeModel):
     """
 
     stripe_class = stripe.Dispute
-    stripe_dashboard_item_name = "disputes"
+    stripe_dashboard_item_name = "payments"
 
     amount = StripeQuantumCurrencyAmountField(
         help_text=(
@@ -1431,6 +1430,13 @@ class Dispute(StripeModel):
 
     def __str__(self):
         return f"{self.human_readable_amount} ({enums.DisputeStatus.humanize(self.status)}) "
+
+    def get_stripe_dashboard_url(self) -> str:
+        """Get the stripe dashboard url for this object."""
+        return (
+            f"{self._get_base_stripe_dashboard_url()}"
+            f"{self.stripe_dashboard_item_name}/{self.payment_intent.id}"
+        )
 
     def _attach_objects_post_save_hook(
         self,

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -264,7 +264,7 @@ class LegacySourceMixin:
         if self.customer:
             return self.customer.get_stripe_dashboard_url()
         elif self.account:
-            return self.account.get_stripe_dashboard_url()
+            return f"https://dashboard.stripe.com/{self.account.id}/settings/payouts"
         else:
             return ""
 

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -880,6 +880,12 @@ class PaymentMethod(StripeModel):
             return f"{enums.PaymentMethodType.humanize(self.type)} for {self.customer}"
         return f"{enums.PaymentMethodType.humanize(self.type)} is not associated with any customer"
 
+
+    def get_stripe_dashboard_url(self) -> str:
+        if self.customer:
+            return self.customer.get_stripe_dashboard_url()
+        return ""
+
     def _attach_objects_hook(
         self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
     ):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -200,6 +200,28 @@ class TestAccount(AssertStripeFksMixin, TestCase):
             },
         )
 
+    @patch(
+        "stripe.Account.retrieve",
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        return_value=deepcopy(FAKE_ACCOUNT),
+    )
+    @patch(
+        "stripe.File.retrieve",
+        side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
+        autospec=True,
+    )
+    def test_get_stripe_dashboard_url(
+        self, fileupload_retrieve_mock, account_retrieve_mock
+    ):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        account = Account.sync_from_stripe_data(fake_account)
+
+        self.assertEqual(
+            account.get_stripe_dashboard_url(),
+            f"https://dashboard.stripe.com/{account.id}/"
+            f"{'test/' if not account.livemode else ''}dashboard",
+        )
+
 
 class TestAccountStr:
     @pytest.mark.parametrize(

--- a/tests/test_bank_account.py
+++ b/tests/test_bank_account.py
@@ -231,7 +231,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
         self.assertEqual(self.standard_account, bank_account.account)
         self.assertEqual(
             bank_account.get_stripe_dashboard_url(),
-            self.standard_account.get_stripe_dashboard_url(),
+            f"https://dashboard.stripe.com/{bank_account.account.id}/settings/payouts",
         )
 
         self.assert_fks(

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -201,7 +201,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
         self.assertEqual(self.standard_account, card.account)
         self.assertEqual(
             card.get_stripe_dashboard_url(),
-            self.standard_account.get_stripe_dashboard_url(),
+            f"https://dashboard.stripe.com/{card.account.id}/settings/payouts",
         )
 
         self.assert_fks(

--- a/tests/test_dispute.py
+++ b/tests/test_dispute.py
@@ -176,3 +176,48 @@ class TestDispute(TestCase):
             expand=[],
             stripe_account=None,
         )
+
+    @patch(
+        "stripe.PaymentMethod.retrieve",
+        return_value=deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
+        autospec=True,
+    )
+    @patch(
+        "stripe.PaymentIntent.retrieve",
+        return_value=deepcopy(FAKE_DISPUTE_PAYMENT_INTENT),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Charge.retrieve",
+        return_value=deepcopy(FAKE_DISPUTE_CHARGE),
+        autospec=True,
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_DISPUTE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_ICON),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Dispute.retrieve", return_value=deepcopy(FAKE_DISPUTE_I), autospec=True
+    )
+    def test_get_stripe_dashboard_url(
+        self,
+        dispute_retrieve_mock,
+        file_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        charge_retrieve_mock,
+        payment_intent_retrieve_mock,
+        payment_method_retrieve_mock,
+    ):
+
+        dispute = Dispute.sync_from_stripe_data(FAKE_DISPUTE_I)
+        self.assertEqual(
+            dispute.get_stripe_dashboard_url(),
+            f"{dispute._get_base_stripe_dashboard_url()}"
+            f"{dispute.stripe_dashboard_item_name}/{dispute.payment_intent.id}",
+        )

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -109,9 +109,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     ):
         default_account_mock.return_value = self.account
         invoice = Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
-        self.assertEqual(
-            invoice.get_stripe_dashboard_url(), self.customer.get_stripe_dashboard_url()
-        )
+
         self.assertEqual(str(invoice), "Invoice #{}".format(FAKE_INVOICE["number"]))
         self.assertGreater(len(invoice.status_transitions.keys()), 1)
         self.assertTrue(bool(invoice.account_country))

--- a/tests/test_payment_method.py
+++ b/tests/test_payment_method.py
@@ -79,6 +79,20 @@ class TestPaymentMethod:
             )
             assert pm.get_stripe_dashboard_url() == customer.get_stripe_dashboard_url()
 
+    @pytest.mark.parametrize("customer_exists", [True, False])
+    def test_sync_from_stripe_data(self, monkeypatch, customer_exists):
+
+        # monkeypatch stripe.Customer.retrieve call to return
+        # the desired json response.
+        monkeypatch.setattr(stripe.Customer, "retrieve", self.mock_customer_get)
+
+        fake_payment_method_data = deepcopy(FAKE_PAYMENT_METHOD_I)
+        if not customer_exists:
+            fake_payment_method_data["customer"] = None
+
+        pm = models.PaymentMethod.sync_from_stripe_data(fake_payment_method_data)
+        assert pm.id == fake_payment_method_data["id"]
+
 
 class PaymentMethodTest(AssertStripeFksMixin, TestCase):
     def setUp(self):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -139,3 +139,32 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
         transfer = Transfer.sync_from_stripe_data(deepcopy(FAKE_TRANSFER))
         assert transfer.fee == FAKE_BALANCE_TRANSACTION_II["fee"]
         assert transfer.fee == transfer.balance_transaction.fee
+
+    @patch.object(Transfer, "_attach_objects_post_save_hook")
+    @patch(
+        "stripe.Account.retrieve",
+        return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
+        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    )
+    @patch(
+        "stripe.BalanceTransaction.retrieve",
+        return_value=deepcopy(FAKE_BALANCE_TRANSACTION_II),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
+    )
+    def test_get_stripe_dashboard_url(
+        self,
+        transfer_retrieve_mock,
+        balance_transaction_retrieve_mock,
+        account_retrieve_mock,
+        transfer__attach_object_post_save_hook_mock,
+    ):
+
+        transfer = Transfer.sync_from_stripe_data(deepcopy(FAKE_TRANSFER))
+
+        assert transfer.get_stripe_dashboard_url() == (
+            f"{transfer._get_base_stripe_dashboard_url()}"
+            f"connect/{transfer.stripe_dashboard_item_name}/{transfer.id}"
+        )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed `get_stripe_dashboard_url()` for `Account`
2. Fixed `get_stripe_dashboard_url()` for `Invoice`
3. Fixed `get_stripe_dashboard_url()` for `Dispute`
4. Fixed `get_stripe_dashboard_url()` for `Transfer`
5. Fixed `get_stripe_dashboard_url()` for `TransferReversal`
6. Fixed `get_stripe_dashboard_url()` for `PaymentMethod`
7. Fixed `get_stripe_dashboard_url()` for `LegacySourceMixin`
8. Added missing `changeform_template` to the `APIKeyAdmin`. Without that it was not possible to see the object on the `Stripe Dashboard`
9. Added missing test for `sync_from_stripe_data` for `PaymentMethod`
10. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The user would now be able to see the correct page for the given `Stripe Object`