### PR TITLE
Pass api key throughout the sync infrastructure

### DIFF
--- a/djstripe/event_handlers.py
+++ b/djstripe/event_handlers.py
@@ -407,6 +407,6 @@ def _handle_crud_like_event(
             stripe_account=stripe_account, api_key=event.default_api_key
         )
         # create or update the object from the retrieved Stripe Data
-        obj = target_cls.sync_from_stripe_data(data)
+        obj = target_cls.sync_from_stripe_data(data, api_key=event.default_api_key)
 
     return obj

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -193,11 +193,17 @@ class Account(StripeModel):
         id = self.settings.get("branding", {}).get("logo")
         return File.objects.filter(id=id).first() if id else None
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        pending_relations=None,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+    ):
         from ..models.core import File
 
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, pending_relations=pending_relations, api_key=api_key
         )
 
         # Retrieve and save the Files in the settings.branding object.

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -214,7 +214,10 @@ class Account(StripeModel):
             if file_upload_id:
                 try:
                     File.sync_from_stripe_data(
-                        File(id=file_upload_id).api_retrieve(stripe_account=self.id)
+                        File(id=file_upload_id).api_retrieve(
+                            stripe_account=self.id, api_key=api_key
+                        ),
+                        api_key=api_key,
                     )
                 except stripe.error.PermissionError:
                     # No permission to retrieve the data with the key

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -509,7 +509,13 @@ class StripeModel(StripeBaseModel):
 
         pass
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         """
         Gets called by this object's create and sync methods just after save.
         Use this to populate fields after the model is saved.
@@ -605,7 +611,7 @@ class StripeModel(StripeBaseModel):
                 instance.save()
 
             instance._attach_objects_post_save_hook(
-                cls, data, pending_relations=pending_relations
+                cls, data, api_key=api_key, pending_relations=pending_relations
             )
 
         return instance
@@ -969,7 +975,7 @@ class StripeModel(StripeBaseModel):
                 cls, data, api_key=api_key, current_ids=current_ids
             )
             instance.save()
-            instance._attach_objects_post_save_hook(cls, data)
+            instance._attach_objects_post_save_hook(cls, data, api_key=api_key)
 
         for field in instance._meta.concrete_fields:
             if isinstance(field, (StripePercentField, models.UUIDField)):

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -360,6 +360,7 @@ class StripeModel(StripeBaseModel):
                     current_ids=current_ids,
                     pending_relations=pending_relations,
                     stripe_account=stripe_account,
+                    api_key=api_key,
                 )
 
                 if skip and not is_nulled:
@@ -396,6 +397,7 @@ class StripeModel(StripeBaseModel):
         current_ids=None,
         pending_relations=None,
         stripe_account=None,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
     ):
         """
         This converts a stripe API field to the dj stripe object it references,
@@ -474,6 +476,7 @@ class StripeModel(StripeBaseModel):
                     current_ids=current_ids,
                     pending_relations=pending_relations,
                     stripe_account=stripe_account,
+                    api_key=api_key,
                 )
 
                 # Remove the id of the current object from the list
@@ -561,7 +564,7 @@ class StripeModel(StripeBaseModel):
         pending_relations=None,
         save=True,
         stripe_account=None,
-        api_key: str = None,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
     ):
         """
         Instantiates a model instance using the provided data object received
@@ -580,9 +583,6 @@ class StripeModel(StripeBaseModel):
         :type stripe_account: string
         :returns: The instantiated object.
         """
-        if api_key is None:
-            api_key = djstripe_settings.STRIPE_SECRET_KEY
-
         stripe_data = cls._stripe_object_to_record(
             data,
             current_ids=current_ids,
@@ -1007,7 +1007,7 @@ class StripeModel(StripeBaseModel):
             djstripe_settings.get_default_api_key(livemode=kwargs.get("livemode")),
         )
         data = cls.stripe_class.retrieve(id=id, **kwargs)
-        instance = cls.sync_from_stripe_data(data)
+        instance = cls.sync_from_stripe_data(data, api_key=kwargs.get("api_key"))
         return instance
 
     def __str__(self):

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -738,7 +738,13 @@ class StripeModel(StripeBaseModel):
             return cls.stripe_objects.get(id=id_), False
 
     @classmethod
-    def _stripe_object_to_customer(cls, target_cls, data, current_ids=None):
+    def _stripe_object_to_customer(
+        cls,
+        target_cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        current_ids=None,
+    ):
         """
         Search the given manager for the Customer matching this object's
         ``customer`` field.
@@ -752,7 +758,7 @@ class StripeModel(StripeBaseModel):
 
         if "customer" in data and data["customer"]:
             return target_cls._get_or_create_from_stripe_object(
-                data, "customer", current_ids=current_ids
+                data, "customer", current_ids=current_ids, api_key=api_key
             )[0]
 
     @classmethod

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -936,7 +936,9 @@ class StripeModel(StripeBaseModel):
         return subscriptionitems
 
     @classmethod
-    def _stripe_object_to_refunds(cls, target_cls, data, charge):
+    def _stripe_object_to_refunds(
+        cls, target_cls, data, charge, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Retrieves Refunds for a charge
         :param target_cls: The target class to instantiate per refund
@@ -955,7 +957,9 @@ class StripeModel(StripeBaseModel):
         refund_objs = []
         for refund_data in refunds.auto_paging_iter():
             item, _ = target_cls._get_or_create_from_stripe_object(
-                refund_data, refetch=False
+                refund_data,
+                refetch=False,
+                api_key=api_key,
             )
             refund_objs.append(item)
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -493,7 +493,9 @@ class StripeModel(StripeBaseModel):
         """
         return "object" in data and data["object"] == cls.stripe_class.OBJECT_NAME
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
+    ):
         """
         Gets called by this object's create and sync methods just before save.
         Use this to populate fields before the model is saved.
@@ -595,7 +597,9 @@ class StripeModel(StripeBaseModel):
             # TODO dictionary unpacking will not work if cls has any ManyToManyField
             instance = cls(**stripe_data)
 
-            instance._attach_objects_hook(cls, data, current_ids=current_ids)
+            instance._attach_objects_hook(
+                cls, data, api_key=api_key, current_ids=current_ids
+            )
 
             if save:
                 instance.save()
@@ -961,7 +965,9 @@ class StripeModel(StripeBaseModel):
             record_data = cls._stripe_object_to_record(data, api_key=api_key)
             for attr, value in record_data.items():
                 setattr(instance, attr, value)
-            instance._attach_objects_hook(cls, data, current_ids=current_ids)
+            instance._attach_objects_hook(
+                cls, data, api_key=api_key, current_ids=current_ids
+            )
             instance.save()
             instance._attach_objects_post_save_hook(cls, data)
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -784,7 +784,9 @@ class StripeModel(StripeBaseModel):
         return tax_rates
 
     @classmethod
-    def _stripe_object_to_tax_rates(cls, target_cls, data):
+    def _stripe_object_to_tax_rates(
+        cls, target_cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Retrieves TaxRates for a SubscriptionItem or InvoiceItem
         :param target_cls:
@@ -795,7 +797,7 @@ class StripeModel(StripeBaseModel):
 
         for tax_rate_data in data.get("tax_rates", []):
             tax_rate, _ = target_cls._get_or_create_from_stripe_object(
-                tax_rate_data, refetch=False
+                tax_rate_data, refetch=False, api_key=api_key
             )
             tax_rates.append(tax_rate)
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -844,7 +844,9 @@ class StripeModel(StripeBaseModel):
         instance.total_tax_amounts.exclude(pk__in=pks).delete()
 
     @classmethod
-    def _stripe_object_to_invoice_items(cls, target_cls, data, invoice):
+    def _stripe_object_to_invoice_items(
+        cls, target_cls, data, invoice, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Retrieves InvoiceItems for an invoice.
 
@@ -889,7 +891,7 @@ class StripeModel(StripeBaseModel):
             line.setdefault("date", int(dateformat.format(invoice.created, "U")))
 
             item, _ = target_cls._get_or_create_from_stripe_object(
-                line, refetch=False, save=save
+                line, refetch=False, save=save, api_key=api_key
             )
             invoiceitems.append(item)
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -762,7 +762,9 @@ class StripeModel(StripeBaseModel):
             )[0]
 
     @classmethod
-    def _stripe_object_to_default_tax_rates(cls, target_cls, data):
+    def _stripe_object_to_default_tax_rates(
+        cls, target_cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Retrieves TaxRates for a Subscription or Invoice
         :param target_cls:
@@ -775,7 +777,7 @@ class StripeModel(StripeBaseModel):
 
         for tax_rate_data in data.get("default_tax_rates", []):
             tax_rate, _ = target_cls._get_or_create_from_stripe_object(
-                tax_rate_data, refetch=False
+                tax_rate_data, refetch=False, api_key=api_key
             )
             tax_rates.append(tax_rate)
 

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -683,7 +683,9 @@ class StripeModel(StripeBaseModel):
                 # If field_name="default_source", we get_or_create the card instead.
                 cls_instance = cls(id=id_)
                 try:
-                    data = cls_instance.api_retrieve(stripe_account=stripe_account)
+                    data = cls_instance.api_retrieve(
+                        stripe_account=stripe_account, api_key=api_key
+                    )
                 except InvalidRequestError as e:
                     if "a similar object exists in" in str(e):
                         # HACK around a Stripe bug.

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -804,7 +804,9 @@ class StripeModel(StripeBaseModel):
         return tax_rates
 
     @classmethod
-    def _stripe_object_set_total_tax_amounts(cls, target_cls, data, instance):
+    def _stripe_object_set_total_tax_amounts(
+        cls, target_cls, data, instance, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Set total tax amounts on Invoice instance
         :param target_cls:
@@ -823,7 +825,10 @@ class StripeModel(StripeBaseModel):
                 tax_rate_data = {"tax_rate": tax_rate_data}
 
             tax_rate, _ = TaxRate._get_or_create_from_stripe_object(
-                tax_rate_data, field_name="tax_rate", refetch=True
+                tax_rate_data,
+                field_name="tax_rate",
+                refetch=True,
+                api_key=api_key,
             )
             tax_amount, _ = target_cls.objects.update_or_create(
                 invoice=instance,

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -898,7 +898,9 @@ class StripeModel(StripeBaseModel):
         return invoiceitems
 
     @classmethod
-    def _stripe_object_to_subscription_items(cls, target_cls, data, subscription):
+    def _stripe_object_to_subscription_items(
+        cls, target_cls, data, subscription, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Retrieves SubscriptionItems for a subscription.
 
@@ -921,7 +923,7 @@ class StripeModel(StripeBaseModel):
         subscriptionitems = []
         for item_data in items.auto_paging_iter():
             item, _ = target_cls._get_or_create_from_stripe_object(
-                item_data, refetch=False
+                item_data, refetch=False, api_key=api_key
             )
 
             # sync the SubscriptionItem

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -844,7 +844,7 @@ class UpcomingInvoice(BaseInvoice):
             if not isinstance(tax_rate_id, str):
                 tax_rate_id = tax_rate_id["tax_rate"]
 
-            tax_rate = TaxRate._get_or_retrieve(id=tax_rate_id)
+            tax_rate = TaxRate._get_or_retrieve(id=tax_rate_id, api_key=api_key)
 
             tax_amount = DjstripeUpcomingInvoiceTotalTaxAmount(
                 invoice=self,

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1725,7 +1725,7 @@ class Subscription(StripeModel):
         )
 
         cls._stripe_object_to_subscription_items(
-            target_cls=SubscriptionItem, data=data, subscription=self
+            target_cls=SubscriptionItem, data=data, subscription=self, api_key=api_key
         )
 
         self.default_tax_rates.set(

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1024,7 +1024,9 @@ class InvoiceItem(StripeModel):
         if self.pk:
             # only call .set() on saved instance (ie don't on items of UpcomingInvoice)
             self.tax_rates.set(
-                cls._stripe_object_to_tax_rates(target_cls=TaxRate, data=data)
+                cls._stripe_object_to_tax_rates(
+                    target_cls=TaxRate, data=data, api_key=api_key
+                )
             )
 
     def __str__(self):
@@ -1797,7 +1799,9 @@ class SubscriptionItem(StripeModel):
         )
 
         self.tax_rates.set(
-            cls._stripe_object_to_tax_rates(target_cls=TaxRate, data=data)
+            cls._stripe_object_to_tax_rates(
+                target_cls=TaxRate, data=data, api_key=api_key
+            )
         )
 
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -795,8 +795,12 @@ class UpcomingInvoice(BaseInvoice):
     def get_stripe_dashboard_url(self):
         return ""
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
-        super()._attach_objects_hook(cls, data, current_ids=current_ids)
+    def _attach_objects_hook(
+        self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
+    ):
+        super()._attach_objects_hook(
+            cls, data, api_key=api_key, current_ids=current_ids
+        )
         self._invoiceitems = cls._stripe_object_to_invoice_items(
             target_cls=InvoiceItem, data=data, invoice=self
         )

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -678,7 +678,7 @@ class BaseInvoice(StripeModel):
         # InvoiceItems need a saved invoice because they're associated via a
         # RelatedManager, so this must be done as part of the post save hook.
         cls._stripe_object_to_invoice_items(
-            target_cls=InvoiceItem, data=data, invoice=self
+            target_cls=InvoiceItem, data=data, invoice=self, api_key=api_key
         )
 
     @property
@@ -819,7 +819,7 @@ class UpcomingInvoice(BaseInvoice):
             cls, data, api_key=api_key, current_ids=current_ids
         )
         self._invoiceitems = cls._stripe_object_to_invoice_items(
-            target_cls=InvoiceItem, data=data, invoice=self
+            target_cls=InvoiceItem, data=data, invoice=self, api_key=api_key
         )
 
     def _attach_objects_post_save_hook(

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -776,7 +776,10 @@ class Invoice(BaseInvoice):
         )
 
         cls._stripe_object_set_total_tax_amounts(
-            target_cls=DjstripeInvoiceTotalTaxAmount, data=data, instance=self
+            target_cls=DjstripeInvoiceTotalTaxAmount,
+            data=data,
+            instance=self,
+            api_key=api_key,
         )
 
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -770,7 +770,9 @@ class Invoice(BaseInvoice):
         )
 
         self.default_tax_rates.set(
-            cls._stripe_object_to_default_tax_rates(target_cls=TaxRate, data=data)
+            cls._stripe_object_to_default_tax_rates(
+                target_cls=TaxRate, data=data, api_key=api_key
+            )
         )
 
         cls._stripe_object_set_total_tax_amounts(
@@ -829,7 +831,7 @@ class UpcomingInvoice(BaseInvoice):
         )
 
         self._default_tax_rates = cls._stripe_object_to_default_tax_rates(
-            target_cls=TaxRate, data=data
+            target_cls=TaxRate, data=data, api_key=api_key
         )
 
         total_tax_amounts = []
@@ -1722,7 +1724,9 @@ class Subscription(StripeModel):
         )
 
         self.default_tax_rates.set(
-            cls._stripe_object_to_default_tax_rates(target_cls=TaxRate, data=data)
+            cls._stripe_object_to_default_tax_rates(
+                target_cls=TaxRate, data=data, api_key=api_key
+            )
         )
 
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -664,9 +664,15 @@ class BaseInvoice(StripeModel):
     def get_stripe_dashboard_url(self):
         return self.customer.get_stripe_dashboard_url()
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         # InvoiceItems need a saved invoice because they're associated via a
@@ -752,9 +758,15 @@ class Invoice(BaseInvoice):
         help_text="The tax rates applied to this invoice, if any.",
     )
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         self.default_tax_rates.set(
@@ -805,9 +817,15 @@ class UpcomingInvoice(BaseInvoice):
             target_cls=InvoiceItem, data=data, invoice=self
         )
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         self._default_tax_rates = cls._stripe_object_to_default_tax_rates(
@@ -990,9 +1008,15 @@ class InvoiceItem(StripeModel):
 
         return data
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         if self.pk:
@@ -1682,9 +1706,15 @@ class Subscription(StripeModel):
 
         return True
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         cls._stripe_object_to_subscription_items(
@@ -1751,9 +1781,15 @@ class SubscriptionItem(StripeModel):
         "subscription_item.",
     )
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         self.tax_rates.set(

--- a/djstripe/models/checkout.py
+++ b/djstripe/models/checkout.py
@@ -104,11 +104,17 @@ class Session(StripeModel):
         ),
     )
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         from ..event_handlers import update_customer_helper
 
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         # only update if customer and metadata exist

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -249,14 +249,20 @@ class Transfer(StripeModel):
         # No Reversal
         return f"{self.human_readable_amount}"
 
-    def _attach_objects_post_save_hook(self, cls, data, pending_relations=None):
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
         """
         Iterate over reversals on the Transfer object to create and/or sync
         TransferReversal objects
         """
 
         super()._attach_objects_post_save_hook(
-            cls, data, pending_relations=pending_relations
+            cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
         # Transfer Reversals exist as a list on the Transfer Object

--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -267,7 +267,7 @@ class Transfer(StripeModel):
 
         # Transfer Reversals exist as a list on the Transfer Object
         for reversals_data in data.get("reversals").auto_paging_iter():
-            TransferReversal.sync_from_stripe_data(reversals_data)
+            TransferReversal.sync_from_stripe_data(reversals_data, api_key=api_key)
 
 
 # TODO Add Tests

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1460,7 +1460,10 @@ class Dispute(StripeModel):
             file_upload_id = self.evidence.get(field, None)
             if file_upload_id:
                 try:
-                    File.sync_from_stripe_data(File(id=file_upload_id).api_retrieve())
+                    File.sync_from_stripe_data(
+                        File(id=file_upload_id).api_retrieve(api_key=api_key),
+                        api_key=api_key,
+                    )
                 except stripe.error.PermissionError:
                     # No permission to retrieve the data with the key
                     # Log a warning message
@@ -1472,7 +1475,9 @@ class Dispute(StripeModel):
 
         # iterate and sync every balance transaction
         for stripe_balance_transaction in self.balance_transactions:
-            BalanceTransaction.sync_from_stripe_data(stripe_balance_transaction)
+            BalanceTransaction.sync_from_stripe_data(
+                stripe_balance_transaction, api_key=api_key
+            )
 
 
 class Event(StripeModel):

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1304,7 +1304,9 @@ class Customer(StripeModel):
         if save:
             self.save()
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         # When we save a customer to Stripe, we add a reference to its Django PK
         # in the `django_account` key. If we find that, we re-attach that PK.
         subscriber_key = djstripe_settings.SUBSCRIBER_CUSTOMER_KEY
@@ -1493,7 +1495,9 @@ class Event(StripeModel):
     def __str__(self):
         return f"type={self.type}, id={self.id}"
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         if self.api_version is None:
             # as of api version 2017-02-14, the account.application.deauthorized
             # event sends None as api_version.

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1295,7 +1295,7 @@ class Customer(StripeModel):
             # by id when we look at the default_source (we need the source type).
             for source in customer_sources["data"]:
                 obj, _ = DjstripePaymentMethod._get_or_create_source(
-                    source, source["object"]
+                    source, source["object"], api_key=api_key
                 )
                 sources[source["id"]] = obj
 
@@ -1531,7 +1531,7 @@ class Event(StripeModel):
             self.request_id = request_obj or ""
 
     @classmethod
-    def process(cls, data, api_key: str = None):
+    def process(cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY):
         qs = cls.objects.filter(id=data["id"])
         if qs.exists():
             return qs.first()

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -441,7 +441,9 @@ class Charge(StripeModel):
             cls, data, pending_relations=pending_relations, api_key=api_key
         )
 
-        cls._stripe_object_to_refunds(target_cls=Refund, data=data, charge=self)
+        cls._stripe_object_to_refunds(
+            target_cls=Refund, data=data, charge=self, api_key=api_key
+        )
 
 
 # TODO Add Tests

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -694,7 +694,9 @@ class Source(StripeModel):
         data["source_data"] = data[data["type"]]
         return data
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
+    ):
         customer = None
         # "customer" key could be like "cus_6lsBvm5rJ0zyHc" or {"id": "cus_6lsBvm5rJ0zyHc"}
         customer_id = get_id_from_stripe_data(data.get("customer"))
@@ -869,7 +871,9 @@ class PaymentMethod(StripeModel):
             return f"{enums.PaymentMethodType.humanize(self.type)} for {self.customer}"
         return f"{enums.PaymentMethodType.humanize(self.type)} is not associated with any customer"
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
+    ):
         customer = None
         # "customer" key could be like "cus_6lsBvm5rJ0zyHc" or {"id": "cus_6lsBvm5rJ0zyHc"}
         customer_id = get_id_from_stripe_data(data.get("customer"))

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -47,7 +47,9 @@ class DjstripePaymentMethod(models.Model):
         return instance
 
     @classmethod
-    def _get_or_create_source(cls, data, source_type=None):
+    def _get_or_create_source(
+        cls, data, source_type=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
 
         # prefer passed in source_type
         if not source_type:
@@ -55,7 +57,7 @@ class DjstripePaymentMethod(models.Model):
 
         try:
             model = cls._model_for_type(source_type)
-            model._get_or_create_from_stripe_object(data)
+            model._get_or_create_from_stripe_object(data, api_key=api_key)
         except ValueError as e:
             # This may happen if we have source types we don't know about.
             # Let's not make dj-stripe entirely unusable if that happens.
@@ -93,6 +95,7 @@ class DjstripePaymentMethod(models.Model):
         pending_relations=None,
         save=True,
         stripe_account=None,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
     ):
 
         raw_field_data = data.get(field_name)
@@ -127,6 +130,7 @@ class DjstripePaymentMethod(models.Model):
             current_ids=current_ids,
             pending_relations=pending_relations,
             stripe_account=stripe_account,
+            api_key=api_key,
         )
 
         return cls.objects.get_or_create(id=id_, defaults={"type": source_type})

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -707,7 +707,7 @@ class Source(StripeModel):
 
         if current_ids is None or customer_id not in current_ids:
             customer = cls._stripe_object_to_customer(
-                target_cls=Customer, data=data, current_ids=current_ids
+                target_cls=Customer, data=data, current_ids=current_ids, api_key=api_key
             )
 
         if customer:
@@ -884,7 +884,7 @@ class PaymentMethod(StripeModel):
 
         if current_ids is None or customer_id not in current_ids:
             customer = cls._stripe_object_to_customer(
-                target_cls=Customer, data=data, current_ids=current_ids
+                target_cls=Customer, data=data, current_ids=current_ids, api_key=api_key
             )
 
         if customer:

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -64,12 +64,16 @@ class WebhookEndpoint(StripeModel):
     def __str__(self):
         return self.url or str(self.djstripe_uuid)
 
-    def _attach_objects_hook(self, cls, data, current_ids=None):
+    def _attach_objects_hook(
+        self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
+    ):
         """
         Gets called by this object's create and sync methods just before save.
         Use this to populate fields before the model is saved.
         """
-        super()._attach_objects_hook(cls, data, current_ids=current_ids)
+        super()._attach_objects_hook(
+            cls, data, current_ids=current_ids, api_key=api_key
+        )
 
         self.djstripe_uuid = data.get("metadata", {}).get("djstripe_uuid")
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -10,6 +10,7 @@ from stripe.error import StripeError
 
 from djstripe import webhooks
 from djstripe.models import Event, Transfer
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_CUSTOMER,
@@ -76,7 +77,9 @@ class EventTest(TestCase):
         mock_objects.filter.assert_called_once_with(id=mock_data["id"])
         mock_objects.filter.return_value.exists.assert_called_once_with()
         mock_atomic.return_value.__enter__.assert_called_once_with()
-        mock__create_from_stripe_object.assert_called_once_with(mock_data, api_key=None)
+        mock__create_from_stripe_object.assert_called_once_with(
+            mock_data, api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )
         (
             mock__create_from_stripe_object.return_value.invoke_webhook_handlers
         ).assert_called_once_with()
@@ -138,7 +141,9 @@ class EventTest(TestCase):
         ) as create_from_stripe_object_mock:
             Event.process(data=event_data)
 
-        create_from_stripe_object_mock.assert_called_once_with(event_data, api_key=None)
+        create_from_stripe_object_mock.assert_called_once_with(
+            event_data, api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )
         self.assertFalse(
             Event.objects.filter(id=FAKE_EVENT_TRANSFER_CREATED["id"]).exists()
         )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Passed `api_key` throughout the `sync infrastructure` so that the objects get `synced` and/or `retrieved` using the correct `api_key`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1584
`event_handlers` should now retrieve and sync Stripe objects with the appropriate `api_key`. 
