### PR TITLE
Allow passing kwargs when calling to Subscription.cancel() to cancel immediately

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -1,9 +1,37 @@
 """
 Django Administration interface definitions
 """
+import json
+
 from django.contrib import admin
+from django.contrib.admin.utils import display_for_field, display_for_value
+from jsonfield import JSONField
 
 from . import models
+
+
+def custom_display_for_JSONfield(value, field, empty_value_display):
+    """
+    Overriding display_for_field to correctly render JSONField READonly fields
+    in django-admin. Relevant when DJSTRIPE_USE_NATIVE_JSONFIELD is False
+    Note: This does not handle invalid JSON. That should be handled by the JSONField itself
+    """
+    # we manually JSON serialise in case field is from jsonfield module
+    if isinstance(field, JSONField) and value:
+        try:
+            return json.dumps(value)
+        except TypeError:
+            return display_for_value(value, empty_value_display)
+    return display_for_field(value, field, empty_value_display)
+
+
+def admin_display_for_field_override():
+    admin.utils.display_for_field = custom_display_for_JSONfield
+    admin.helpers.display_for_field = custom_display_for_JSONfield
+
+
+# execute override
+admin_display_for_field_override()
 
 
 class ReadOnlyMixin:

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -129,7 +129,7 @@ class Command(BaseCommand):
         """
         all_list_kwargs = (
             [{"expand": [f"data.{k}" for k in model.expand_fields]}]
-            if getattr(models, "expand_fields", [])
+            if getattr(model, "expand_fields", [])
             else []
         )
         if model is models.PaymentMethod:

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -816,7 +816,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="djstripe_customers",
-                        to=settings.AUTH_USER_MODEL,
+                        to=DJSTRIPE_SUBSCRIBER_MODEL,
                     ),
                 ),
                 (

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -822,6 +822,10 @@ class StripeModel(StripeBaseModel):
             item, _ = target_cls._get_or_create_from_stripe_object(
                 item_data, refetch=False
             )
+
+            # sync the SubscriptionItem
+            target_cls.sync_from_stripe_data(item_data)
+
             pks.append(item.pk)
             subscriptionitems.append(item)
         subscription.items.exclude(pk__in=pks).delete()

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1530,7 +1530,7 @@ class Subscription(StripeModel):
         the ``at_period_end`` flag will be overridden to False so that the trial ends \
         immediately and the customer's card isn't charged.
 
-        kwargs: invoice_now (bool), prorate (bool)
+        when cancelling immediately: kwargs: invoice_now (bool), prorate (bool)
         """
 
         # If plan has trial days and customer cancels before

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1501,7 +1501,7 @@ class Subscription(StripeModel):
 
         return self.update(proration_behavior="none", trial_end=period_end)
 
-    def cancel(self, at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END):
+    def cancel(self, at_period_end=djstripe_settings.CANCELLATION_AT_PERIOD_END, **kwargs):
         """
         Cancels this subscription. If you set the at_period_end parameter to true,
         the subscription will remain active until the end of the period, at which point
@@ -1529,6 +1529,8 @@ class Subscription(StripeModel):
         .. important:: If a subscription is canceled during a trial period, \
         the ``at_period_end`` flag will be overridden to False so that the trial ends \
         immediately and the customer's card isn't charged.
+
+        kwargs: invoice_now (bool), prorate (bool)
         """
 
         # If plan has trial days and customer cancels before
@@ -1541,7 +1543,7 @@ class Subscription(StripeModel):
             stripe_subscription = self._api_update(cancel_at_period_end=True)
         else:
             try:
-                stripe_subscription = self._api_delete()
+                stripe_subscription = self._api_delete(**kwargs)
             except InvalidRequestError as exc:
                 if "No such subscription:" in str(exc):
                     # cancel() works by deleting the subscription. The object still

--- a/docs/history/2_5_x.md
+++ b/docs/history/2_5_x.md
@@ -1,4 +1,4 @@
-# dj-stripe 2.5.1 (unreleased)
+# dj-stripe 2.5.1 (2021-07-02)
 
 ## Release notes
 

--- a/docs/history/2_5_x.md
+++ b/docs/history/2_5_x.md
@@ -1,0 +1,7 @@
+# dj-stripe 2.5.1 (unreleased)
+
+## Release notes
+
+-   Fixed migration issue for new setups using custom `DJSTRIPE_CUSTOMER_MODEL`.
+-   Display correct JSON for JSONFields in the Django admin.
+-   Fix manual syncing of `SubscriptionItem`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dj-stripe"
-version = "2.5.0"
+version = "2.5.1"
 description = "Django + Stripe made easy"
 license = "MIT"
 authors = [

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,9 +3,15 @@ dj-stripe Admin Tests.
 """
 from django.contrib import admin
 from django.test import TestCase
+from jsonfield import JSONField
+
+from djstripe.admin import custom_display_for_JSONfield
 
 
 class TestAdminSite(TestCase):
+    def setUp(self):
+        self.empty_value = "-empty-"
+
     def test_search_fields(self):
         """
         Search for errors like this:
@@ -22,4 +28,18 @@ class TestAdminSite(TestCase):
                     "Bad search field <{search_field}> for {model_name} model.".format(
                         search_field=search_field, model_name=model_name
                     ),
+                )
+
+    def test_json_display_for_field(self):
+        json_tests = [
+            ({"a": {"b": None}}, '{"a": {"b": null}}'),
+            (["a", False], '["a", false]'),
+            ("a", '"a"'),
+            ({("a", "b"): "c"}, "{('a', 'b'): 'c'}"),  # Invalid JSON.
+        ]
+        for value, display_value in json_tests:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    custom_display_for_JSONfield(value, JSONField(), self.empty_value),
+                    display_value,
                 )


### PR DESCRIPTION
## Description

If a customer immediately cancels his subscription, he is not charged for pending charges such as metered usage during the current billing cycle.

Actually Stripe supports two parameters when deleting a subscription:

![image](https://user-images.githubusercontent.com/73274/152807775-d56b2124-559b-49a0-9d4d-619f817b55da.png)

But you cannot specify any of those by calling `Subscription.cancel()`

This PR contains the following changes:

1. Allow passing extra arguments to `Subscription.cancel()` in kwargs

Checklist:

- [ ] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [ ] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale


Reference:

* https://stripe.com/docs/api/subscriptions/cancel

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

* https://stripe.com/docs/billing/subscriptions/cancel#canceling

> By default, the cancellation takes effect immediately. As soon as a customer’s subscription is canceled, no further invoices are generated for that subscription. You can configure the cancellation to prorate if the cancellation is part of the way through a paid billing period, and optionally invoice for any outstanding prorations and metered usage. Otherwise, all metered usage is discarded and the customer will not be credited for any potential prorations.

* https://stripe.com/docs/billing/subscriptions/examples#usage-based-pricing

> With the usage-based model, you charge your customers based on how much of your service they use during the billing cycle, instead of explicitly setting quantities, as in the per-seat and flat rate pricing models. (Another difference is that in the per-seat and flat-rate models, you could optionally collect payment for the billing cycle up front. With metered billing, you have to collect payment in arrears.)