### PR TITLE
Allow passing kwargs when calling to Subscription.cancel() to cancel immediately

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1555,18 +1555,21 @@ class Subscription(StripeModel):
 
         return self.update(proration_behavior="none", trial_end=period_end)
 
-    def cancel(self, at_period_end: bool = False):
+    def cancel(self, at_period_end: bool = False, **kwargs):
         """
         Cancels this subscription. If you set the at_period_end parameter to true,
         the subscription will remain active until the end of the period, at which point
         it will be canceled and not renewed. By default, the subscription is terminated
         immediately. In either case, the customer will not be charged again for
-        the subscription. Note, however, that any pending invoice items that you've
-        created will still be charged for at the end of the period unless manually
-        deleted. If you've set the subscription to cancel at period end,
-        any pending prorations will also be left in place and collected at the end of
-        the period, but if the subscription is set to cancel immediately,
-        pending prorations will be removed.
+        the subscription. Note, however, that any pending invoice items or metered
+        usage will still be charged at the end of the period unless manually
+        deleted.
+
+        Depending on how `proration_behavior` is set, any pending prorations will
+        also be left in place and collected at the end of the period.
+        However, if the subscription is set to cancel immediately, you can pass the
+        `prorate` and `invoice_now` flags in `kwargs` to configure how the pending
+        metered usage is invoiced and how proration must work.
 
         By default, all unpaid invoices for the customer will be closed upon
         subscription cancellation. We do this in order to prevent unexpected payment
@@ -1595,7 +1598,7 @@ class Subscription(StripeModel):
             stripe_subscription = self._api_update(cancel_at_period_end=True)
         else:
             try:
-                stripe_subscription = self._api_delete()
+                stripe_subscription = self._api_delete(**kwargs)
             except InvalidRequestError as exc:
                 if "No such subscription:" in str(exc):
                     # cancel() works by deleting the subscription. The object still


### PR DESCRIPTION
## Description

If a customer immediately cancels his subscription, he is not charged for pending charges such as metered usage during the current billing cycle.

Actually Stripe supports two parameters when deleting a subscription:

![image](https://user-images.githubusercontent.com/73274/152807775-d56b2124-559b-49a0-9d4d-619f817b55da.png)

But you cannot specify any of those by calling `Subscription.cancel()`

This PR contains the following changes:

1. Allow passing extra arguments to `Subscription.cancel()` in kwargs

Checklist:

- [ ] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [ ] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale


Reference:

* https://stripe.com/docs/api/subscriptions/cancel

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

* https://stripe.com/docs/billing/subscriptions/cancel#canceling

> By default, the cancellation takes effect immediately. As soon as a customer’s subscription is canceled, no further invoices are generated for that subscription. You can configure the cancellation to prorate if the cancellation is part of the way through a paid billing period, and optionally invoice for any outstanding prorations and metered usage. Otherwise, all metered usage is discarded and the customer will not be credited for any potential prorations.

* https://stripe.com/docs/billing/subscriptions/examples#usage-based-pricing

> With the usage-based model, you charge your customers based on how much of your service they use during the billing cycle, instead of explicitly setting quantities, as in the per-seat and flat rate pricing models. (Another difference is that in the per-seat and flat-rate models, you could optionally collect payment for the billing cycle up front. With metered billing, you have to collect payment in arrears.)