### PR TITLE
Cleaned up the utils module

### DIFF
--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -1,10 +1,10 @@
 """
 Utility functions related to the djstripe app.
 """
-
 import datetime
 from typing import Optional
 
+import stripe
 from django.conf import settings
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -18,14 +18,10 @@ def get_supported_currency_choices(api_key):
     :param api_key: The api key associated with the account from which to pull data.
     :type api_key: str
     """
-    import stripe
-
-    stripe.api_key = api_key
-
-    account = stripe.Account.retrieve()
-    supported_payment_currencies = stripe.CountrySpec.retrieve(account["country"])[
-        "supported_payment_currencies"
-    ]
+    account = stripe.Account.retrieve(api_key=api_key)
+    supported_payment_currencies = stripe.CountrySpec.retrieve(
+        account["country"], api_key=api_key
+    )["supported_payment_currencies"]
 
     return [(currency, currency.upper()) for currency in supported_payment_currencies]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,8 +53,8 @@ class TestGetSupportedCurrencyChoices(TestCase):
         # Simple test to test sure that at least one currency choice tuple is returned.
 
         currency_choices = get_supported_currency_choices(None)
-        stripe_account_retrieve_mock.assert_called_once_with()
-        stripe_countryspec_retrieve_mock.assert_called_once_with("US")
+        stripe_account_retrieve_mock.assert_called_once_with(api_key=None)
+        stripe_countryspec_retrieve_mock.assert_called_once_with("US", api_key=None)
         self.assertGreaterEqual(
             len(currency_choices), 1, "Currency choices pull returned an empty list."
         )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Moved stripe import at the top of the module
2. Removed setting the `api_key` parameter globally as that can cause issues with the stripe library especially in case of multiple platform accounts as the stripe library defaults to using the global api_key.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.
