### PR TITLE
Management Command will sync all data for all api_keys 

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -52,8 +52,11 @@ class Command(BaseCommand):
         else:
             model_list = app_config.get_models()
 
+        # get all APIKey objects in the db
+        api_qs = models.APIKey.objects.all()
         for model in model_list:
-            self.sync_model(model)
+            for api_key in api_qs:
+                self.sync_model(model, api_key=api_key)
 
     def _should_sync_model(self, model):
         if not issubclass(model, StripeBaseModel):

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -115,17 +115,15 @@ class Account(StripeModel):
         return ""
 
     @classmethod
-    def get_default_account(cls):
+    def get_default_account(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY):
         # As of API version 2020-03-02, there is no permission that can allow
         # restricted keys to call GET /v1/account
         if djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_"):
             return None
 
-        account_data = cls.stripe_class.retrieve(
-            api_key=djstripe_settings.STRIPE_SECRET_KEY
-        )
+        account_data = cls.stripe_class.retrieve(api_key=api_key)
 
-        return cls._get_or_create_from_stripe_object(account_data)[0]
+        return cls._get_or_create_from_stripe_object(account_data, api_key=api_key)[0]
 
     @classmethod
     def get_or_retrieve_for_api_key(cls, api_key: str):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge #1586 before merging this PR.

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Updated `Account.get_default_account()` to allow passing `api_key` kwarg.
2.  Management command will sync data for **all APIKey objects in the DB**. Data for `Platform` as well as its `connected accounts` for **each api_key in the DB** will be retrieved and synced.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`dj-stripe` will now be able to `retrieve`, `sync`, and `store` data for `Multiple Independent Platform Accounts` as well as their associated `Connected Accounts`!