### PR TITLE
Explicitly passed api_key kwarg in sync_from_stripe_data() throughout the application code

### DIFF
--- a/djstripe/models/api.py
+++ b/djstripe/models/api.py
@@ -97,7 +97,7 @@ class APIKey(StripeModel):
         )
         if created:
             # If it's just been created, now we can sync the account.
-            Account.sync_from_stripe_data(account_data)
+            Account.sync_from_stripe_data(account_data, api_key=self.secret)
         self.djstripe_owner_account = account
         if commit:
             self.save()

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -927,7 +927,7 @@ class StripeModel(StripeBaseModel):
             )
 
             # sync the SubscriptionItem
-            target_cls.sync_from_stripe_data(item_data)
+            target_cls.sync_from_stripe_data(item_data, api_key=api_key)
 
             pks.append(item.pk)
             subscriptionitems.append(item)

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -657,7 +657,9 @@ class BaseInvoice(StripeModel):
             updated_stripe_invoice = (
                 stripe_invoice.pay()
             )  # pay() throws an exception if the charge is not successful.
-            type(self).sync_from_stripe_data(updated_stripe_invoice)
+            type(self).sync_from_stripe_data(
+                updated_stripe_invoice, api_key=self.default_api_key
+            )
             return True
         return False
 
@@ -1209,7 +1211,8 @@ class Plan(StripeModel):
             api_kwargs["product"] = api_kwargs["product"].id
 
         stripe_plan = cls._api_create(**api_kwargs)
-        plan = cls.sync_from_stripe_data(stripe_plan)
+        api_key = api_kwargs.get("api_key") or djstripe_settings.STRIPE_SECRET_KEY
+        plan = cls.sync_from_stripe_data(stripe_plan, api_key=api_key)
 
         return plan
 
@@ -1568,7 +1571,8 @@ class Subscription(StripeModel):
 
         stripe_subscription = self._api_update(plan=plan, **kwargs)
 
-        return Subscription.sync_from_stripe_data(stripe_subscription)
+        api_key = kwargs.get("api_key") or self.default_api_key
+        return Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
 
     def extend(self, delta):
         """
@@ -1643,7 +1647,9 @@ class Subscription(StripeModel):
                 else:
                     raise
 
-        return Subscription.sync_from_stripe_data(stripe_subscription)
+        return Subscription.sync_from_stripe_data(
+            stripe_subscription, api_key=self.default_api_key
+        )
 
     def reactivate(self):
         """
@@ -2081,7 +2087,7 @@ class UsageRecord(StripeModel):
 
         # ! Hack: there is no way to retrieve a UsageRecord object from Stripe,
         # ! which is why we create and sync it right here
-        cls.sync_from_stripe_data(usage_stripe_data)
+        cls.sync_from_stripe_data(usage_stripe_data, api_key=api_key)
 
         return usage_stripe_data
 

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -416,7 +416,9 @@ class Charge(StripeModel):
         charge_obj = self.api_retrieve().refund(
             amount=self._calculate_refund_amount(amount=amount), reason=reason
         )
-        return self.__class__.sync_from_stripe_data(charge_obj)
+        return self.__class__.sync_from_stripe_data(
+            charge_obj, api_key=self.default_api_key
+        )
 
     def capture(self, **kwargs) -> "Charge":
         """
@@ -428,7 +430,9 @@ class Charge(StripeModel):
         """
 
         captured_charge = self.api_retrieve().capture(**kwargs)
-        return self.__class__.sync_from_stripe_data(captured_charge)
+        return self.__class__.sync_from_stripe_data(
+            captured_charge, api_key=self.default_api_key
+        )
 
     def _attach_objects_post_save_hook(
         self,
@@ -896,7 +900,8 @@ class Customer(StripeModel):
             items=_items, customer=self.id, **kwargs
         )
 
-        Subscription.sync_from_stripe_data(stripe_subscription)
+        api_key = kwargs.get("api_key") or self.default_api_key
+        Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
 
     def charge(
         self,
@@ -935,7 +940,8 @@ class Customer(StripeModel):
             **kwargs,
         )
 
-        return Charge.sync_from_stripe_data(stripe_charge)
+        api_key = kwargs.get("api_key") or self.default_api_key
+        return Charge.sync_from_stripe_data(stripe_charge, api_key=api_key)
 
     def add_invoice_item(
         self,
@@ -1010,7 +1016,9 @@ class Customer(StripeModel):
             subscription=subscription,
         )
 
-        return InvoiceItem.sync_from_stripe_data(stripe_invoiceitem)
+        return InvoiceItem.sync_from_stripe_data(
+            stripe_invoiceitem, api_key=self.default_api_key
+        )
 
     def add_card(self, source, set_default=True):
         """
@@ -1070,7 +1078,7 @@ class Customer(StripeModel):
             # 1) sets self.default_payment_method (we rely on logic in
             # Customer._manipulate_stripe_object_hook to do this)
             # 2) updates self.invoice_settings.default_payment_methods
-            self.sync_from_stripe_data(stripe_customer)
+            self.sync_from_stripe_data(stripe_customer, api_key=self.default_api_key)
             self.refresh_from_db()
 
         return payment_method
@@ -1258,7 +1266,9 @@ class Customer(StripeModel):
         stripe_customer = self.api_retrieve()
         stripe_customer["coupon"] = coupon
         stripe_customer.save(idempotency_key=idempotency_key)
-        return self.__class__.sync_from_stripe_data(stripe_customer)
+        return self.__class__.sync_from_stripe_data(
+            stripe_customer, api_key=self.default_api_key
+        )
 
     def upcoming_invoice(self, **kwargs):
         """Gets the upcoming preview invoice (singular) for this customer.
@@ -1346,26 +1356,30 @@ class Customer(StripeModel):
     def _sync_invoices(self, **kwargs):
         from .billing import Invoice
 
+        api_key = kwargs.get("api_key") or self.default_api_key
         for stripe_invoice in Invoice.api_list(customer=self.id, **kwargs):
-            Invoice.sync_from_stripe_data(stripe_invoice)
+            Invoice.sync_from_stripe_data(stripe_invoice, api_key=api_key)
 
     def _sync_charges(self, **kwargs):
+        api_key = kwargs.get("api_key") or self.default_api_key
         for stripe_charge in Charge.api_list(customer=self.id, **kwargs):
-            Charge.sync_from_stripe_data(stripe_charge)
+            Charge.sync_from_stripe_data(stripe_charge, api_key=api_key)
 
     def _sync_cards(self, **kwargs):
         from .payment_methods import Card
 
+        api_key = kwargs.get("api_key") or self.default_api_key
         for stripe_card in Card.api_list(customer=self, **kwargs):
-            Card.sync_from_stripe_data(stripe_card)
+            Card.sync_from_stripe_data(stripe_card, api_key=api_key)
 
     def _sync_subscriptions(self, **kwargs):
         from .billing import Subscription
 
+        api_key = kwargs.get("api_key") or self.default_api_key
         for stripe_subscription in Subscription.api_list(
             customer=self.id, status="all", **kwargs
         ):
-            Subscription.sync_from_stripe_data(stripe_subscription)
+            Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
 
 
 # TODO Add Tests
@@ -2259,7 +2273,9 @@ class Price(StripeModel):
             api_kwargs["product"] = api_kwargs["product"].id
 
         stripe_price = cls._api_create(**api_kwargs)
-        price = cls.sync_from_stripe_data(stripe_price)
+
+        api_key = api_kwargs.get("api_key") or djstripe_settings.STRIPE_SECRET_KEY
+        price = cls.sync_from_stripe_data(stripe_price, api_key=api_key)
 
         return price
 

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -924,7 +924,7 @@ class PaymentMethod(StripeModel):
         stripe_payment_method = stripe.PaymentMethod.attach(
             payment_method, customer=customer, **extra_kwargs
         )
-        return cls.sync_from_stripe_data(stripe_payment_method)
+        return cls.sync_from_stripe_data(stripe_payment_method, api_key=api_key)
 
     def detach(self):
         """

--- a/tests/test_usage_record.py
+++ b/tests/test_usage_record.py
@@ -171,4 +171,6 @@ class TestUsageRecord(AssertStripeFksMixin, TestCase):
         )
 
         # assert usage_record_creation_mock was called as expected
-        sync_from_stripe_data_mock.assert_called_once_with(fake_usage_data)
+        sync_from_stripe_data_mock.assert_called_once_with(
+            fake_usage_data, api_key=djstripe_settings.STRIPE_SECRET_KEY
+        )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Explicitly passed `api_key` kwarg in `sync_from_stripe_data()` throughout the application code.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Passing `api_key` in `sync_from_stripe_data()` will ensure Stripe objects get retrieved and synced from the correct `Platform` Account.