### PR TITLE
Swapped dict with typing.Dict across all app modules

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -2,7 +2,7 @@
 Django Administration interface definitions
 """
 import json
-from typing import Optional
+from typing import Dict, Optional
 from urllib.parse import urljoin
 
 from django import forms
@@ -860,7 +860,7 @@ class WebhookEndpointAdmin(admin.ModelAdmin):
             ),
         ]
 
-    def get_changeform_initial_data(self, request) -> dict[str, str]:
+    def get_changeform_initial_data(self, request) -> Dict[str, str]:
         ret = super().get_changeform_initial_data(request)
         base_url = f"{request.scheme}://{request.get_host()}"
         ret.setdefault("base_url", base_url)

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import timedelta
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from django.apps import apps
 from django.db import IntegrityError, models, transaction
@@ -299,7 +299,7 @@ class StripeModel(StripeBaseModel):
         pending_relations: list = None,
         stripe_account: str = None,
         api_key=djstripe_settings.STRIPE_SECRET_KEY,
-    ) -> dict:
+    ) -> Dict:
         """
         This takes an object, as it is formatted in Stripe's current API for our object
         type. In return, it provides a dict. The dict can be used to create a record or

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ import sys
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -143,7 +143,7 @@ class StripeItem(dict):
         base = self.class_url()
         return "%s/%s" % (base, id)
 
-    def request(self, method, url, params) -> dict:
+    def request(self, method, url, params) -> Dict:
         """Superficial mock that emulates request method."""
         assert method == "post"
         for key, value in params.items():


### PR DESCRIPTION
This was done to ensure type compatability across all python versions from 3.7 to 3.10. Otherwise one would need to use the __future__ module to delay run-time type annotation in the admin module in 3.7 and 3.8

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.


Checklist:

- [ ] I've updated the `tests` or confirm that my change doesn't require any updates.
- [ ] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [ ] I confirm that my change doesn't drop code coverage below the current level.
- [ ] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
