### PR TITLE
Fixed Incorrect output of human_readable_amount for Various Models

### DIFF
--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -1,6 +1,8 @@
 import stripe
 from django.db import models
 
+from djstripe.utils import get_friendly_currency_amount
+
 from .. import enums
 from ..fields import (
     JSONField,
@@ -248,6 +250,10 @@ class Transfer(StripeModel):
             return f"{self.human_readable_amount} Partially Reversed"
         # No Reversal
         return f"{self.human_readable_amount}"
+
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount / 100, self.currency)
 
     def _attach_objects_post_save_hook(
         self,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2419,3 +2419,7 @@ class Refund(StripeModel):
         return (
             f"{self.human_readable_amount} ({enums.RefundStatus.humanize(self.status)})"
         )
+
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount / 100, self.currency)

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1503,6 +1503,10 @@ class Dispute(StripeModel):
                 stripe_balance_transaction, api_key=api_key
             )
 
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount / 100, self.currency)
+
 
 class Event(StripeModel):
     """

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -106,6 +106,10 @@ class BalanceTransaction(StripeModel):
     def get_stripe_dashboard_url(self):
         return self.get_source_instance().get_stripe_dashboard_url()
 
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount / 100, self.currency)
+
 
 class Charge(StripeModel):
     """

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1906,6 +1906,10 @@ class PaymentIntent(StripeModel):
 
         return self.api_retrieve(api_key=api_key).confirm(**kwargs)
 
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount / 100, self.currency)
+
 
 class SetupIntent(StripeModel):
     """

--- a/tests/test_balance_transaction.py
+++ b/tests/test_balance_transaction.py
@@ -9,7 +9,6 @@ from django.test.testcases import TestCase
 
 from djstripe import models
 from djstripe.enums import BalanceTransactionStatus
-from djstripe.utils import get_friendly_currency_amount
 
 from . import (
     FAKE_BALANCE_TRANSACTION,
@@ -37,9 +36,9 @@ class TestBalanceTransactionStr:
             modified_balance_transaction
         )
         assert (
-            f"{get_friendly_currency_amount(modified_balance_transaction['amount'], modified_balance_transaction['currency'])}"
-            f" ({BalanceTransactionStatus.humanize(modified_balance_transaction['status'])})"
-        ) == str(balance_transaction)
+            str(balance_transaction)
+            == f"$20.00 USD ({BalanceTransactionStatus.humanize(modified_balance_transaction['status'])})"
+        )
 
 
 class TestBalanceTransactionSourceClass:

--- a/tests/test_dispute.py
+++ b/tests/test_dispute.py
@@ -8,7 +8,6 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test.testcases import TestCase
 
-from djstripe import enums
 from djstripe.models import Dispute
 from djstripe.settings import djstripe_settings
 
@@ -72,10 +71,7 @@ class TestDispute(TestCase):
     ):
 
         dispute = Dispute.sync_from_stripe_data(FAKE_DISPUTE_I)
-        self.assertEqual(
-            str(dispute),
-            f"{dispute.human_readable_amount} ({enums.DisputeStatus.humanize(FAKE_DISPUTE_I['status'])}) ",
-        )
+        self.assertEqual(str(dispute), "$1000.00 USD (Needs response) ")
 
     @patch(
         "stripe.PaymentMethod.retrieve",

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 
 from djstripe.enums import PaymentIntentStatus
 from djstripe.models import Account, Customer, PaymentIntent
+from djstripe.utils import get_friendly_currency_amount
 
 from . import (
     FAKE_ACCOUNT,
@@ -112,32 +113,27 @@ class TestStrPaymentIntent:
         if fake_intent_data.get("invoice"):
             assert pi.invoice is not None
 
-        account = Account.objects.filter(id=fake_intent_data["on_behalf_of"]).first()
-        customer = Customer.objects.filter(id=fake_intent_data["customer"]).first()
-
         if has_account and has_customer:
 
             assert (
-                f"{pi.human_readable_amount} ({PaymentIntentStatus.humanize(fake_intent_data['status'])}) "
-                f"for {account} "
-                f"by {customer}"
-            ) == str(pi)
+                str(pi)
+                == "$1902.00 USD (The funds are in your account.) for dj-stripe by Michael Smith"
+            )
 
         elif has_account and not has_customer:
 
             assert (
-                f"{pi.human_readable_amount} for {account}. {PaymentIntentStatus.humanize(fake_intent_data['status'])}"
-            ) == str(pi)
+                str(pi)
+            ) == "$1902.00 USD for dj-stripe. The funds are in your account."
 
         elif has_customer and not has_account:
 
             assert (
-                f"{pi.human_readable_amount} by {customer}. {PaymentIntentStatus.humanize(fake_intent_data['status'])}"
-            ) == str(pi)
+                str(pi)
+            ) == "$20.00 USD by Michael Smith. The funds are in your account."
         elif not has_customer and not has_account:
-            f"{pi.human_readable_amount} ({PaymentIntentStatus.humanize(fake_intent_data['status'])})" == str(
-                pi
-            )
+
+            assert str(pi) == "$20.00 USD (The funds are in your account.)"
 
 
 class PaymentIntentTest(AssertStripeFksMixin, TestCase):

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -164,10 +164,7 @@ class RefundTest(AssertStripeFksMixin, TestCase):
 
         refund = Refund.sync_from_stripe_data(fake_refund)
 
-        self.assertEqual(
-            f"{refund.human_readable_amount} ({enums.RefundStatus.humanize(fake_refund['status'])})",
-            str(refund),
-        )
+        self.assertEqual(str(refund), "$20.00 USD (Succeeded)")
 
         self.assert_fks(refund, expected_blank_fks=self.default_expected_blank_fks)
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -66,15 +66,13 @@ class TestTransferStr:
         transfer = Transfer.sync_from_stripe_data(fake_transfer_data)
 
         if fake_transfer_data["reversed"]:
-            assert f"{transfer.human_readable_amount} Reversed" == str(transfer)
+            assert "$0.01 USD Reversed" == str(transfer)
 
         elif fake_transfer_data["amount_reversed"]:
-            assert f"{transfer.human_readable_amount} Partially Reversed" == str(
-                transfer
-            )
+            assert "$0.01 USD Partially Reversed" == str(transfer)
 
         else:
-            assert f"{transfer.human_readable_amount}" == str(transfer)
+            assert "$0.01 USD" == str(transfer)
 
 
 class TestTransfer(AssertStripeFksMixin, TestCase):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Overrode `PaymentIntent.human_readable_amount`. This was done so that `amount/100` instead of `amount` could be passed to it.
2. Overrode `BalanceTransaction.human_readable_amount`. This was done so that `amount/100` instead of `amount` could be passed to it.
3. Overrode `Transfer.human_readable_amount`. This was done so that `amount/100` instead of `amount` could be passed to it.
4. Overrode `Dispute.human_readable_amount`. This was done so that `amount/100` instead of `amount` could be passed to it.
5. Overrode `Refund.human_readable_amount`. This was done so that `amount/100` instead of `amount` could be passed to it.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix #1604