### PR TITLE
Updated Tests to ensure Warnings get raised

### DIFF
--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -704,10 +704,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             self.customer.invoice_settings["default_payment_method"],
         )
 
-        self.assertTrue(
-            self.customer.can_charge(),
-            "Expect to be able to charge since we've set a default_payment_method",
-        )
+        with pytest.warns(DeprecationWarning):
+            self.assertTrue(
+                self.customer.can_charge(),
+                "Expect to be able to charge since we've set a default_payment_method",
+            )
 
         self.assert_fks(
             self.customer,
@@ -749,12 +750,12 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
             ).count(),
             1,
         )
-
-        self.assertFalse(
-            self.customer.can_charge(),
-            "Expect not to be able to charge since we've not set a "
-            "default_payment_method",
-        )
+        with pytest.warns(DeprecationWarning):
+            self.assertFalse(
+                self.customer.can_charge(),
+                "Expect not to be able to charge since we've not set a "
+                "default_payment_method",
+            )
 
         self.assert_fks(
             self.customer,
@@ -770,7 +771,8 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     )
     def test_cannot_charge(self, customer_retrieve_fake):
         self.customer.date_purged = timezone.now()
-        self.assertFalse(self.customer.can_charge())
+        with pytest.warns(DeprecationWarning):
+            self.assertFalse(self.customer.can_charge())
 
     def test_charge_accepts_only_decimals(self):
         with self.assertRaises(ValueError):

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from decimal import Decimal
 from unittest.mock import ANY, call, patch
 
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from stripe.error import InvalidRequestError
@@ -1207,7 +1208,8 @@ class TestCustomerEvents(EventTestCase):
         )
         self.customer.save()
         self.assertIsNotNone(self.customer.default_source)
-        self.assertTrue(self.customer.has_valid_source())
+        with pytest.warns(DeprecationWarning):
+            self.assertTrue(self.customer.has_valid_source())
 
         event = self._create_event(FAKE_EVENT_CUSTOMER_SOURCE_DELETED)
         event.invoke_webhook_handlers()
@@ -1216,7 +1218,8 @@ class TestCustomerEvents(EventTestCase):
         # deleted
         customer = Customer.objects.get(id=FAKE_CUSTOMER["id"])
         self.assertIsNone(customer.default_source)
-        self.assertFalse(customer.has_valid_source())
+        with pytest.warns(DeprecationWarning):
+            self.assertFalse(customer.has_valid_source())
 
     @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
     def test_customer_source_double_delete(self, customer_retrieve_mock):
@@ -1230,7 +1233,8 @@ class TestCustomerEvents(EventTestCase):
         # deleted
         customer = Customer.objects.get(id=FAKE_CUSTOMER["id"])
         self.assertIsNone(customer.default_source)
-        self.assertFalse(customer.has_valid_source())
+        with pytest.warns(DeprecationWarning):
+            self.assertFalse(customer.has_valid_source())
 
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
     @patch("stripe.Subscription.retrieve", autospec=True)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -337,7 +337,8 @@ class TestWebhookEventTrigger(TestCase):
     ):
         fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
         event_retrieve_mock.return_value = fake_event
-        resp = self._send_event(fake_event)
+        with pytest.warns(None):
+            resp = self._send_event(fake_event)
         self.assertEqual(resp.status_code, 200)
         webhook_event_trigger = WebhookEventTrigger.objects.get()
         webhook_event_callback_mock.called_once_with(webhook_event_trigger)
@@ -364,14 +365,16 @@ class TestWebhookEventTrigger(TestCase):
     ):
         fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
         event_retrieve_mock.return_value = fake_event
+        with pytest.warns(None):
+            resp = self._send_event(fake_event)
 
-        resp = self._send_event(fake_event)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(Event.objects.filter(type="transfer.created").exists())
         self.assertEqual(1, Event.objects.filter(type="transfer.created").count())
 
         # Duplication
-        resp = self._send_event(fake_event)
+        with pytest.warns(None):
+            resp = self._send_event(fake_event)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(1, Event.objects.filter(type="transfer.created").count())
 
@@ -397,7 +400,8 @@ class TestWebhookEventTrigger(TestCase):
     ):
         fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
         event_retrieve_mock.return_value = fake_event
-        resp = self._send_event(fake_event)
+        with pytest.warns(None):
+            resp = self._send_event(fake_event)
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(Event.objects.count(), 1)
@@ -432,7 +436,8 @@ class TestWebhookEventTrigger(TestCase):
         fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
         fake_event["account"] = FAKE_CUSTOM_ACCOUNT["id"]
         event_retrieve_mock.return_value = fake_event
-        resp = self._send_event(fake_event)
+        with pytest.warns(None):
+            resp = self._send_event(fake_event)
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(Event.objects.count(), 1)
@@ -466,7 +471,8 @@ class TestWebhookEventTrigger(TestCase):
         fake_event = deepcopy(FAKE_EVENT_TRANSFER_CREATED)
         event_retrieve_mock.return_value = fake_event
         with self.assertRaises(KeyError):
-            self._send_event(fake_event)
+            with pytest.warns(None):
+                self._send_event(fake_event)
 
         self.assertEqual(Event.objects.count(), 0)
         self.assertEqual(WebhookEventTrigger.objects.count(), 1)


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated tests to ensure `DeprecationWarning` is raised on invoking `customer.can_charge()`.
2. Updated tests to ensure `DeprecationWarning` is raised whenever `Webhook Validation` is disabled.
3. Updated tests to ensure `DeprecationWarning` is raised on invoking `customer.has_valid_source()`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Improved Project reliability.