### PR TITLE
Added no-op AlterField migrations for Django 4.0

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -2714,7 +2714,7 @@ class Migration(migrations.Migration):
                         help_text="The latest charge generated for this invoice, if any.",
                         null=True,
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="latest_upcominginvoice",
+                        related_name="latest_%(class)s",
                         to="djstripe.charge",
                     ),
                 ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -1621,7 +1621,7 @@ class Migration(migrations.Migration):
                     djstripe.fields.StripeForeignKey(
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
-                        related_name="invoices",
+                        related_name="%(class)ss",
                         to="djstripe.subscription",
                         to_field=settings.DJSTRIPE_FOREIGN_KEY_TO_FIELD,
                     ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -3822,7 +3822,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         db_table="djstripe_djstripesubscriptionitemtaxrate",
                         help_text="The tax rates which apply to this subscription_item. When set, the default_tax_rates on the subscription do not apply to this subscription_item.",
-                        related_name="_subscriptionitem_tax_rates_+",
+                        related_name="+",
                         to="djstripe.TaxRate",
                     ),
                 ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -1603,7 +1603,7 @@ class Migration(migrations.Migration):
                         help_text="The latest charge generated for this invoice, if any.",
                         null=True,
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="latest_invoice",
+                        related_name="latest_%(class)s",
                         to="djstripe.charge",
                     ),
                 ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -1611,7 +1611,7 @@ class Migration(migrations.Migration):
                     "customer",
                     djstripe.fields.StripeForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="invoices",
+                        related_name="%(class)ss",
                         to="djstripe.customer",
                         to_field=settings.DJSTRIPE_FOREIGN_KEY_TO_FIELD,
                     ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -2891,7 +2891,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 db_table="djstripe_djstripesubscriptiondefaulttaxrate",
                 help_text="The tax rates that will apply to any subscription item that does not have tax_rates set. Invoices created will have their default_tax_rates populated from the subscription.",
-                related_name="_subscription_default_tax_rates_+",
+                related_name="+",
                 to="djstripe.TaxRate",
             ),
         ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -2880,7 +2880,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 db_table="djstripe_djstripeinvoicedefaulttaxrate",
                 help_text="The tax rates applied to this invoice, if any.",
-                related_name="_invoice_default_tax_rates_+",
+                related_name="+",
                 to="djstripe.TaxRate",
             ),
         ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -2722,7 +2722,7 @@ class Migration(migrations.Migration):
                     "customer",
                     djstripe.fields.StripeForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="upcominginvoices",
+                        related_name="%(class)ss",
                         to="djstripe.customer",
                         to_field=settings.DJSTRIPE_FOREIGN_KEY_TO_FIELD,
                     ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -4272,7 +4272,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         db_table="djstripe_djstripeinvoiceitemtaxrate",
                         help_text="The tax rates which apply to this invoice item. When set, the default_tax_rates on the invoice do not apply to this invoice item.",
-                        related_name="_invoiceitem_tax_rates_+",
+                        related_name="+",
                         to="djstripe.TaxRate",
                     ),
                 ),

--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -2752,7 +2752,7 @@ class Migration(migrations.Migration):
                     djstripe.fields.StripeForeignKey(
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
-                        related_name="upcominginvoices",
+                        related_name="%(class)ss",
                         to="djstripe.subscription",
                         to_field=settings.DJSTRIPE_FOREIGN_KEY_TO_FIELD,
                     ),


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Generated and Added `no-op AlterField` migrations for `m2m` and `fk` fields as mentioned [here](https://docs.djangoproject.com/en/4.0/releases/4.0/#migrations-autodetector-changes). This was done because Django 4.0 generates migrations for ManyToManyField and ForeignKey fields.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix #1592