### PR TITLE
Added add _sync_all_instances Django Action

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -635,7 +635,9 @@ class SubscriptionAdmin(StripeModelAdmin):
     list_select_related = ("customer", "customer__subscriber")
 
     inlines = (SubscriptionItemInline,)
+    actions = ("_cancel", "_resync_instances", "_sync_all_instances")
 
+    @admin.action(description="Cancel selected subscriptions")
     def _cancel(self, request, queryset):
         """Cancel a subscription."""
         for subscription in queryset:
@@ -648,10 +650,6 @@ class SubscriptionAdmin(StripeModelAdmin):
                 )
             except InvalidRequestError as error:
                 self.message_user(request, str(error), level=messages.WARNING)
-
-    _cancel.short_description = "Cancel selected subscriptions"  # type: ignore # noqa
-
-    actions = (_cancel, "_resync_instances")
 
 
 @admin.register(models.TaxRate)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -64,6 +64,14 @@ def test_get_forward_relation_fields_for_model(output, input):
 
 
 class TestAdminCustomActions:
+    # the 4 models that do not inherit from StripeModel and hence
+    # do not inherit from StripeModelAdmin
+    ignore_models = [
+        "WebhookEventTrigger",
+        "WebhookEndpoint",
+        "IdempotencyKey",
+        "APIKey",
+    ]
     kwargs_called_with = {}
 
     # to get around Session/MessageMiddleware Deprecation Warnings
@@ -71,33 +79,41 @@ class TestAdminCustomActions:
         return None
 
     @pytest.mark.parametrize("fake_selected_pks", [None, [1, 2]])
-    def test__resync_all_usage_record_summaries(self, admin_client, fake_selected_pks):
+    def test__sync_all_instances(self, admin_client, fake_selected_pks):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
 
-        model = models.UsageRecordSummary
+        for model in all_models_lst:
+            if model in site._registry.keys() and (
+                model.__name__ == "WebhookEndpoint"
+                or model.__name__ not in self.ignore_models
+            ):
 
-        # get the standard changelist_view url
-        change_url = reverse(
-            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
-        )
+                # get the standard changelist_view url
+                change_url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
 
-        data = {"action": "_resync_all_usage_record_summaries"}
+                data = {"action": "_sync_all_instances"}
 
-        if fake_selected_pks is not None:
-            data[helpers.ACTION_CHECKBOX_NAME] = fake_selected_pks
+                if fake_selected_pks is not None:
+                    data[helpers.ACTION_CHECKBOX_NAME] = fake_selected_pks
 
-        response = admin_client.post(change_url, data, follow=True)
-        assert response.status_code == 200
+                response = admin_client.post(change_url, data, follow=True)
+                assert response.status_code == 200
 
-        # assert correct Success messages are emmitted
-        messages_sent_dictionary = {
-            m.message: m.level_tag for m in messages.get_messages(response.wsgi_request)
-        }
+                # assert correct Success messages are emmitted
+                messages_sent_dictionary = {
+                    m.message: m.level_tag
+                    for m in messages.get_messages(response.wsgi_request)
+                }
 
-        # assert correct success message was emmitted
-        assert (
-            messages_sent_dictionary.get("Successfully Synced ALL Instances")
-            == "success"
-        )
+                # assert correct success message was emmitted
+                assert (
+                    messages_sent_dictionary.get("Successfully Synced All Instances")
+                    == "success"
+                )
 
     @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
     def test__resync_instances(
@@ -665,19 +681,24 @@ class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
                 if model.__name__ not in self.ignore_models:
                     if model.__name__ == "UsageRecordSummary":
                         assert "_resync_instances" not in actions
+                        assert "_sync_all_instances" in actions
                     elif model.__name__ == "Subscription":
                         assert "_resync_instances" in actions
+                        assert "_sync_all_instances" in actions
                         assert "_cancel" in actions
                     else:
                         assert "_resync_instances" in actions
+                        assert "_sync_all_instances" in actions
 
                 # not sub-classes of StripeModel
                 else:
                     if model.__name__ == "WebhookEndpoint":
                         assert "delete_selected" not in actions
                         assert "_resync_instances" in actions
+                        assert "_sync_all_instances" in actions
                     else:
                         assert "_resync_instances" not in actions
+                        assert "_sync_all_instances" not in actions
 
 
 class TestAdminRegisteredModelsNotChildrenOfStripeModel(TestCase):
@@ -1116,34 +1137,52 @@ class TestAdminSite(TestCase):
                 )
 
 
-class TestUsageRecordSummaryAdmin:
+class TestCustomActionMixin:
+    # the 4 models that do not inherit from StripeModel and hence
+    # do not inherit from StripeModelAdmin
+    ignore_models = [
+        "WebhookEventTrigger",
+        "WebhookEndpoint",
+        "IdempotencyKey",
+        "APIKey",
+    ]
+
     @pytest.mark.parametrize("fake_selected_pks", [None, [1, 2]])
     def test_changelist_view(self, admin_client, admin_user, fake_selected_pks):
 
-        model = models.UsageRecordSummary
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
 
-        # get the standard changelist_view url
-        change_url = reverse(
-            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
-        )
+        for model in all_models_lst:
+            if model in site._registry.keys() and (
+                model.__name__ == "WebhookEndpoint"
+                or model.__name__ not in self.ignore_models
+            ):
 
-        data = {"action": "_resync_all_usage_record_summaries"}
+                # get the standard changelist_view url
+                change_url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
 
-        if fake_selected_pks is not None:
-            # add key helpers.ACTION_CHECKBOX_NAME when it is not None
-            data[helpers.ACTION_CHECKBOX_NAME] = fake_selected_pks
+                data = {"action": "_sync_all_instances"}
 
-        # get the response. This will invoke the changelist_view
-        response = admin_client.post(change_url, data=data, follow=True)
+                if fake_selected_pks is not None:
+                    # add key helpers.ACTION_CHECKBOX_NAME when it is not None
+                    data[helpers.ACTION_CHECKBOX_NAME] = fake_selected_pks
 
-        assert response.status_code == 200
+                # get the response. This will invoke the changelist_view
+                response = admin_client.post(change_url, data=data, follow=True)
 
-        # assert correct Success messages are emmitted
-        messages_sent_dictionary = {
-            m.message: m.level_tag for m in messages.get_messages(response.wsgi_request)
-        }
-        # assert correct success message was emmitted
-        assert (
-            messages_sent_dictionary.get("Successfully Synced ALL Instances")
-            == "success"
-        )
+                assert response.status_code == 200
+
+                # assert correct Success messages are emmitted
+                messages_sent_dictionary = {
+                    m.message: m.level_tag
+                    for m in messages.get_messages(response.wsgi_request)
+                }
+                # assert correct success message was emmitted
+                assert (
+                    messages_sent_dictionary.get("Successfully Synced All Instances")
+                    == "success"
+                )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -661,12 +661,17 @@ class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
 
                 actions = model_admin.get_actions(request)
 
+                # sub-classes of StripeModel
                 if model.__name__ not in self.ignore_models:
                     if model.__name__ == "UsageRecordSummary":
                         assert "_resync_instances" not in actions
-                        assert "_resync_all_usage_record_summaries" in actions
+                    elif model.__name__ == "Subscription":
+                        assert "_resync_instances" in actions
+                        assert "_cancel" in actions
                     else:
                         assert "_resync_instances" in actions
+
+                # not sub-classes of StripeModel
                 else:
                     if model.__name__ == "WebhookEndpoint":
                         assert "delete_selected" not in actions


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Converted `_resync_instances` into a `CustomActionMixin` Method for re-usability.
2.  Removed `_resync_all_usage_record_summaries` django action from `UsageRecordSummaryAdmin`.
3. Added `sync_all_instances` custom django action to `CustomActionMixin` to easily sync all Model instances
4. Refactored `SubscriptionAdmin`'s  `_cancel` action.
5. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

The User will be able to easily sync all instances from the admin.
