### PR TITLE
Add admin action intermediate pages

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -10,7 +10,6 @@ from django.contrib import admin, messages
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import display_for_field, display_for_value, quote
 from django.contrib.contenttypes.models import ContentType
-from django.core.management import call_command
 from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -110,10 +109,10 @@ class CustomActionMixin:
     @admin.action(description="Sync All Instances for all API Keys")
     def _sync_all_instances(self, request, queryset):
         """Admin Action to Sync All Instances"""
-        call_command("djstripe_sync_models", self.model.__name__)
-        self.message_user(
-            request, "Successfully Synced All Instances", level=messages.SUCCESS
+        context = self.get_admin_action_context(
+            queryset, "_sync_all_instances", CustomActionForm
         )
+        return render(request, "djstripe/admin/confirm_action.html", context)
 
     def changelist_view(self, request, extra_context=None):
         # we fool it into thinking we have selected some query

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -6,12 +6,10 @@ from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 from django import forms
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import display_for_field, display_for_value, quote
-from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, transaction
-from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.html import format_html
@@ -828,16 +826,8 @@ class SubscriptionAdmin(StripeModelAdmin):
     @admin.action(description="Cancel selected subscriptions")
     def _cancel(self, request, queryset):
         """Cancel a subscription."""
-        for subscription in queryset:
-            try:
-                instance = subscription.cancel()
-                self.message_user(
-                    request,
-                    f"Successfully Canceled: {instance}",
-                    level=messages.SUCCESS,
-                )
-            except InvalidRequestError as error:
-                self.message_user(request, str(error), level=messages.WARNING)
+        context = self.get_admin_action_context(queryset, "_cancel", CustomActionForm)
+        return render(request, "djstripe/admin/confirm_action.html", context)
 
     def get_queryset(self, request):
         return (

--- a/djstripe/forms.py
+++ b/djstripe/forms.py
@@ -1,0 +1,40 @@
+"""
+Module for all dj-stripe app forms
+"""
+from django import forms
+from django.contrib.admin import helpers
+
+from djstripe import utils
+
+
+class CustomActionForm(forms.Form):
+    """Form for Custom Django Admin Actions"""
+
+    def __init__(self, *args, **kwargs):
+
+        # remove model_name kwarg
+        model_name = kwargs.pop("model_name")
+
+        # remove action_name kwarg
+        action_name = kwargs.pop("action_name")
+
+        super().__init__(*args, **kwargs)
+
+        model = utils.get_model(model_name)
+        # set choices attribute
+        # form field to keep track of all selected instances
+        # for the Custom Django Admin Action
+
+        if action_name == "_sync_all_instances":
+            self.fields[helpers.ACTION_CHECKBOX_NAME] = forms.MultipleChoiceField(
+                widget=forms.MultipleHiddenInput,
+                choices=[(action_name, action_name)],
+            )
+        else:
+            self.fields[helpers.ACTION_CHECKBOX_NAME] = forms.MultipleChoiceField(
+                widget=forms.MultipleHiddenInput,
+                choices=zip(
+                    model.objects.values_list("pk", flat=True),
+                    model.objects.values_list("pk", flat=True),
+                ),
+            )

--- a/djstripe/templates/djstripe/admin/confirm_action.html
+++ b/djstripe/templates/djstripe/admin/confirm_action.html
@@ -5,6 +5,9 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media.js }}
+    {% comment %} Load Jquery shipped with Django {% endcomment %}
+    <script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}" ></script>
+    <script src="{% static 'admin/js/jquery.init.js' %}" ></script>
 
     <script src="{% static 'admin/js/cancel.js' %}" async></script>
 {% endblock %}
@@ -25,6 +28,15 @@
 
 {% block content %}
     {{ block.super }}
+
+    {% comment %} Page Loader Icon {% endcomment %}
+    <div id="div_spinner" style="display: none;">
+        <div style="min-height: 100vh; display: flex; align-items: center; justify-content: center;">
+            <div id="spinner" role="status">
+                    <span>Loading...</span>
+            </div>
+        </div>
+    </div>
 
 
     <div id="main_content">

--- a/djstripe/templates/djstripe/admin/confirm_action.html
+++ b/djstripe/templates/djstripe/admin/confirm_action.html
@@ -1,0 +1,61 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static l10n admin_urls %}
+
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media.js }}
+
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+    .stripe-confirmation-warning {
+        padding: 1rem;
+        background: var(--message-warning-bg);
+    }
+</style>
+{% endblock extrastyle %}
+
+
+{% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
+
+
+{% block content %}
+    {{ block.super }}
+
+
+    <div id="main_content">
+
+        <h1>Are you Sure? </h1>
+
+        {% if action_name == "_resync_instances" %}
+            <p class="stripe-confirmation-warning">Are you sure you want to sync the selected instances? All of the following objects and their related items will be synced.</p>
+        {% elif action_name == "_sync_all_instances" %}
+            <p class="stripe-confirmation-warning">Are you sure you want to sync all instances? Please note this will be a best effort sync and we will silence any errors encountered.</p>
+            {% if info %}<p>All of the following objects and their related items will be synced:</p>{% endif %}
+        {% elif action_name == "_cancel" %}
+            <p class="stripe-confirmation-warning">Are you sure you want to cancel the selected subscriptions? The following subscriptions will be cancelled.</p>
+        {% endif %}
+
+        <ul>
+            {% for instance in info %}
+            <li>{{instance}}</li>
+            {% endfor %}
+        </ul>
+
+        <form id="form_custom_action" method="post" onsubmit="django.jQuery('#main_content').hide(); django.jQuery('.messagelist').hide(); django.jQuery('#div_spinner').show();" action="{% url 'djstripe:djstripe_custom_action' action_name=action_name model_name=model_name %}">
+            {% csrf_token %}
+            {{form}}
+
+            <div>
+                <input type="submit" value="{% translate 'Yes, I’m sure' %}">
+                <a href="{{changelist_url}}" class="button cancel-link" onclick="django.jQuery('#main_content').hide(); django.jQuery('#div_spinner').show()">{% translate "No, take me back" %}</a>
+            </div>
+        </form>
+    </div>
+
+
+{% endblock content %}

--- a/djstripe/urls.py
+++ b/djstripe/urls.py
@@ -26,4 +26,9 @@ urlpatterns = [
         views.ProcessWebhookView.as_view(),
         name="djstripe_webhook_by_uuid",
     ),
+    path(
+        "action/<str:action_name>/<str:model_name>/",
+        views.ConfirmCustomAction.as_view(),
+        name="djstripe_custom_action",
+    ),
 ]

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -5,6 +5,7 @@ import datetime
 from typing import Optional
 
 import stripe
+from django.apps import apps
 from django.conf import settings
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -95,3 +96,10 @@ def get_id_from_stripe_data(data):
         return data.get("id")
     else:
         return None
+
+
+def get_model(model_name):
+    app_label = "djstripe"
+    app_config = apps.get_app_config(app_label)
+    model = app_config.get_model(model_name)
+    return model

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -103,3 +103,8 @@ def get_model(model_name):
     app_config = apps.get_app_config(app_label)
     model = app_config.get_model(model_name)
     return model
+
+
+def get_queryset(pks, model_name):
+    model = get_model(model_name)
+    return model.objects.filter(pk__in=pks)

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -6,6 +6,7 @@ import logging
 import stripe
 from django.contrib import messages
 from django.contrib.admin import helpers, site
+from django.core.management import call_command
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -146,3 +147,8 @@ class ConfirmCustomAction(FormView):
                 messages.warning(request, error)
             except stripe.error.InvalidRequestError:
                 raise
+
+    def _sync_all_instances(self, request, queryset):
+        """Admin Action to Sync All Instances"""
+        call_command("djstripe_sync_models", queryset.model.__name__)
+        messages.success(request, "Successfully Synced All Instances")

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -152,3 +152,12 @@ class ConfirmCustomAction(FormView):
         """Admin Action to Sync All Instances"""
         call_command("djstripe_sync_models", queryset.model.__name__)
         messages.success(request, "Successfully Synced All Instances")
+
+    def _cancel(self, request, queryset):
+        """Cancel a subscription."""
+        for subscription in queryset:
+            try:
+                instance = subscription.cancel()
+                messages.success(request, f"Successfully Canceled: {instance}")
+            except stripe.error.InvalidRequestError as error:
+                messages.warning(request, error)

--- a/tests/fields/admin.py
+++ b/tests/fields/admin.py
@@ -7,4 +7,10 @@ from .models import TestCustomActionModel
 
 @admin.register(TestCustomActionModel)
 class TestCustomActionModelAdmin(StripeModelAdmin):
-    pass
+
+    # For Subscription model's custom action, _cancel
+    def get_actions(self, request):
+        # get all actions
+        actions = super().get_actions(request)
+        actions["_cancel"] = self.get_action("_cancel")
+        return actions

--- a/tests/fields/admin.py
+++ b/tests/fields/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
+from django.shortcuts import render
 
 from djstripe.admin import StripeModelAdmin
+from djstripe.forms import CustomActionForm
 
 from .models import TestCustomActionModel
 
@@ -14,3 +16,9 @@ class TestCustomActionModelAdmin(StripeModelAdmin):
         actions = super().get_actions(request)
         actions["_cancel"] = self.get_action("_cancel")
         return actions
+
+    @admin.action(description="Cancel selected subscriptions")
+    def _cancel(self, request, queryset):
+        """Cancel a subscription."""
+        context = self.get_admin_action_context(queryset, "_cancel", CustomActionForm)
+        return render(request, "djstripe/admin/confirm_action.html", context)

--- a/tests/fields/models.py
+++ b/tests/fields/models.py
@@ -14,3 +14,7 @@ class TestCustomActionModel(StripeModel):
     # for some reason having a FK here throws relation doesn't exist even though
     # djstripe is also one of the installed apps in tests.settings
     djstripe_owner_account = None
+
+    # For Subscription model's custom action, _cancel
+    def cancel(self, at_period_end: bool = False, **kwargs):
+        pass

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -4,13 +4,10 @@ dj-stripe Admin Tests.
 from typing import Sequence
 
 import pytest
-import stripe
 from django.apps import apps
 from django.contrib import messages
 from django.contrib.admin import helpers, site
 from django.contrib.auth import get_user_model
-from django.contrib.messages.middleware import MessageMiddleware
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import FieldError
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -116,175 +113,6 @@ class TestAdminCustomActions:
                     messages_sent_dictionary.get("Successfully Synced All Instances")
                     == "success"
                 )
-
-    @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
-    def test__resync_instances(
-        self, admin_user, djstripe_owner_account_exists, monkeypatch
-    ):
-
-        # create instance to be used in the Django Admin Action
-        instance = TestCustomActionModel.objects.create(id="test")
-
-        if djstripe_owner_account_exists:
-            account_instance = Account.objects.first()
-            instance.djstripe_owner_account = account_instance
-            instance.save()
-
-        model = TestCustomActionModel
-        model_admin = site._registry.get(model)
-
-        data = {
-            "action": "_resync_instances",
-            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
-        }
-
-        # monkeypatch instance.api_retrieve and instance.__class__.sync_from_stripe_data
-        def mock_instance_api_retrieve(*args, **kwargs):
-            self.kwargs_called_with = kwargs
-
-        def mock_instance_sync_from_stripe_data(*args, **kwargs):
-            pass
-
-        monkeypatch.setattr(instance, "api_retrieve", mock_instance_api_retrieve)
-
-        monkeypatch.setattr(
-            TestCustomActionModel,
-            "sync_from_stripe_data",
-            mock_instance_sync_from_stripe_data,
-        )
-
-        # get the standard changelist_view url
-        change_url = reverse(
-            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
-        )
-
-        # add the admin user to the mocked request and disable CSRF checks
-        factory = RequestFactory()
-        request = factory.post(change_url, data=data, follow=True)
-        request.user = admin_user
-        request._dont_enforce_csrf_checks = True
-
-        # Add the session/message middleware to the request
-        SessionMiddleware(self.dummy_get_response).process_request(request)
-        MessageMiddleware(self.dummy_get_response).process_request(request)
-
-        # get the _resync_instances custom Django Admin Action
-        action_fn = model_admin.get_actions(request)[data.get("action")][0]
-
-        # invoke the _resync_instances action
-        action_fn(model_admin, request, [instance])
-
-        # assert correct Success messages are emmitted
-        messages_sent_dictionary = {
-            m.message: m.level_tag for m in messages.get_messages(request)
-        }
-
-        # assert correct success message was emmitted
-        assert (
-            messages_sent_dictionary.get(f"Successfully Synced: {instance}")
-            == "success"
-        )
-
-        if djstripe_owner_account_exists:
-            # assert in case djstripe_owner_account exists that kwargs are not empty
-            assert self.kwargs_called_with == {
-                "stripe_account": instance.djstripe_owner_account.id,
-                "api_key": instance.default_api_key,
-            }
-        else:
-            # assert in case djstripe_owner_account does not exist that kwargs are empty
-            assert self.kwargs_called_with == {}
-
-    def test__resync_instances_stripe_permission_error(self, admin_user, monkeypatch):
-        # create instance to be used in the Django Admin Action
-        instance = TestCustomActionModel.objects.create(id="test")
-
-        model = TestCustomActionModel
-        model_admin = site._registry.get(model)
-
-        data = {
-            "action": "_resync_instances",
-            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
-        }
-
-        # monkeypatch instance.api_retrieve
-        def mock_instance_api_retrieve(*args, **kwargs):
-            raise stripe.error.PermissionError("some random error message")
-
-        monkeypatch.setattr(instance, "api_retrieve", mock_instance_api_retrieve)
-
-        # get the standard changelist_view url
-        change_url = reverse(
-            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
-        )
-
-        # add the admin user to the mocked request and disable CSRF checks
-        factory = RequestFactory()
-        request = factory.post(change_url, data=data, follow=True)
-        request.user = admin_user
-        request._dont_enforce_csrf_checks = True
-
-        # Add the session/message middleware to the request
-        SessionMiddleware(self.dummy_get_response).process_request(request)
-        MessageMiddleware(self.dummy_get_response).process_request(request)
-
-        # get the _resync_instances custom Django Admin Action
-        action_fn = model_admin.get_actions(request)[data.get("action")][0]
-
-        # invoke the _resync_instances action
-        action_fn(model_admin, request, [instance])
-
-        # assert correct Success messages are emmitted
-        messages_sent_dictionary = {
-            m.message.user_message: m.level_tag for m in messages.get_messages(request)
-        }
-
-        # assert correct success message was emmitted
-        assert messages_sent_dictionary.get("some random error message") == "warning"
-
-    def test__resync_instances_stripe_invalid_request_error(
-        self, admin_user, monkeypatch
-    ):
-        # create instance to be used in the Django Admin Action
-        instance = TestCustomActionModel.objects.create(id="test")
-
-        model = TestCustomActionModel
-        model_admin = site._registry.get(model)
-
-        data = {
-            "action": "_resync_instances",
-            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
-        }
-
-        # monkeypatch instance.api_retrieve
-        def mock_instance_api_retrieve(*args, **kwargs):
-            raise stripe.error.InvalidRequestError({}, "some random error message")
-
-        monkeypatch.setattr(instance, "api_retrieve", mock_instance_api_retrieve)
-
-        # get the standard changelist_view url
-        change_url = reverse(
-            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
-        )
-
-        # add the admin user to the mocked request and disable CSRF checks
-        factory = RequestFactory()
-        request = factory.post(change_url, data=data, follow=True)
-        request.user = admin_user
-        request._dont_enforce_csrf_checks = True
-
-        # Add the session/message middleware to the request
-        SessionMiddleware(self.dummy_get_response).process_request(request)
-        MessageMiddleware(self.dummy_get_response).process_request(request)
-
-        # get the _resync_instances custom Django Admin Action
-        action_fn = model_admin.get_actions(request)[data.get("action")][0]
-
-        with pytest.raises(stripe.error.InvalidRequestError) as exc_info:
-            # invoke the _resync_instances action
-            action_fn(model_admin, request, [instance])
-
-        assert str(exc_info.value.param) == "some random error message"
 
 
 class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
@@ -1241,13 +1069,48 @@ class TestCustomActionMixin:
 
                 assert response.status_code == 200
 
-                # assert correct Success messages are emmitted
-                messages_sent_dictionary = {
-                    m.message: m.level_tag
-                    for m in messages.get_messages(response.wsgi_request)
-                }
-                # assert correct success message was emmitted
-                assert (
-                    messages_sent_dictionary.get("Successfully Synced All Instances")
-                    == "success"
-                )
+    @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
+    def test__resync_instances(
+        self, djstripe_owner_account_exists, admin_client, monkeypatch
+    ):
+        model = TestCustomActionModel
+        model_admin = site._registry.get(model)
+
+        # monkeypatch utils.get_model
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        # monkeypatch modeladmin.get_admin_action_context
+        def mock_get_admin_action_context(*args, **kwargs):
+            return {
+                "action_name": "_resync_instances",
+                "model_name": "testcustomactionmodel",
+            }
+
+        monkeypatch.setattr(
+            model_admin, "get_admin_action_context", mock_get_admin_action_context
+        )
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        if djstripe_owner_account_exists:
+            account_instance = Account.objects.first()
+            instance.djstripe_owner_account = account_instance
+            instance.save()
+
+        data = {
+            "action": "_resync_instances",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        # get the standard changelist_view url
+        change_url = reverse(
+            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+        )
+
+        response = admin_client.post(change_url, data)
+
+        # assert user got 200 status code
+        assert response.status_code == 200

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,9 +1,11 @@
 """
 dj-stripe Admin Tests.
 """
+from copy import deepcopy
 from typing import Sequence
 
 import pytest
+import stripe
 from django.apps import apps
 from django.contrib.admin import helpers, site
 from django.contrib.auth import get_user_model
@@ -18,6 +20,17 @@ from djstripe import admin as djstripe_admin
 from djstripe import models, utils
 from djstripe.forms import CustomActionForm
 from djstripe.models.account import Account
+from tests import (
+    FAKE_BALANCE_TRANSACTION,
+    FAKE_CARD_AS_PAYMENT_METHOD,
+    FAKE_CHARGE,
+    FAKE_CUSTOMER,
+    FAKE_INVOICE,
+    FAKE_PAYMENT_INTENT_I,
+    FAKE_PLAN,
+    FAKE_PRODUCT,
+    FAKE_SUBSCRIPTION,
+)
 
 from .fields.models import TestCustomActionModel
 
@@ -1087,3 +1100,70 @@ class TestCustomActionMixin:
 
                 # assert user got 200 status code
                 assert response.status_code == 200
+
+
+class TestSubscriptionAdminCustomAction:
+    def test__cancel_subscription_instances(
+        self,
+        admin_client,
+        monkeypatch,
+    ):
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # Create Latest Invoice
+        models.Invoice.sync_from_stripe_data(FAKE_INVOICE)
+
+        model = models.Subscription
+        subscription_fake = deepcopy(FAKE_SUBSCRIPTION)
+        instance = model.sync_from_stripe_data(subscription_fake)
+
+        # get the standard changelist_view url
+        change_url = reverse(
+            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+        )
+
+        data = {"action": "_cancel", helpers.ACTION_CHECKBOX_NAME: [instance.pk]}
+
+        response = admin_client.post(change_url, data)
+
+        # assert user got 200 status code
+        assert response.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,237 @@
+"""
+dj-stripe Views Tests.
+"""
+
+import pytest
+from django.contrib.admin import helpers
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test.client import RequestFactory
+from django.urls import reverse
+from pytest_django.asserts import assertContains
+
+from djstripe import models, utils
+from djstripe.views import ConfirmCustomAction
+
+from .fields.models import TestCustomActionModel
+
+pytestmark = pytest.mark.django_db
+
+
+class TestConfirmCustomActionView:
+    # to get around Session/MessageMiddleware Deprecation Warnings
+    def dummy_get_response(self, request):
+        return None
+
+    @pytest.mark.parametrize(
+        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+    )
+    def test_get_form_kwargs(self, action_name, admin_user, monkeypatch):
+
+        model = TestCustomActionModel
+
+        # monkeypatch utils.get_model
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": action_name,
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().get(change_url)
+        # add the admin user to the mocked request
+        request.user = admin_user
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the get_form_kwargs method
+        form_kwargs = view.get_form_kwargs()
+        assert form_kwargs.get("model_name") == model.__name__.lower()
+        assert form_kwargs.get("action_name") == action_name
+
+    @pytest.mark.parametrize(
+        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+    )
+    @pytest.mark.parametrize("is_admin_user", [True, False])
+    def test_dispatch(self, is_admin_user, action_name, admin_user, monkeypatch):
+
+        model = TestCustomActionModel
+
+        # monkeypatch utils.get_model
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": action_name,
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().get(change_url)
+
+        if is_admin_user:
+            # add the admin user to the mocked request
+            request.user = admin_user
+        else:
+            # add the AnonymousUser to the mocked request
+            request.user = AnonymousUser()
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the dispatch method
+        response = view.dispatch(request)
+
+        if is_admin_user:
+            assert response.status_code == 200
+        else:
+            assert response.status_code == 302
+            assert (
+                response.url
+                == f"/admin/login/?next=/djstripe/action/{action_name}/testcustomactionmodel/"
+            )
+
+    @pytest.mark.parametrize(
+        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+    )
+    @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
+    def test_form_valid(self, djstripe_owner_account_exists, action_name, monkeypatch):
+        model = TestCustomActionModel
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        if djstripe_owner_account_exists:
+            account_instance = models.Account.objects.first()
+            instance.djstripe_owner_account = account_instance
+            instance.save()
+
+        data = {
+            "action": action_name,
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        if action_name == "_sync_all_instances":
+            data[helpers.ACTION_CHECKBOX_NAME] = ["_sync_all_instances"]
+
+        # monkeypatch utils.get_model and
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": action_name,
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # monkeypatch Request Handler
+        def mock_request_handler(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(view, action_name, mock_request_handler)
+
+        # get the form
+        form = view.get_form()
+
+        # Ensure form is valid
+        assert form.is_valid()
+
+        # Invoke form_valid()
+        response = view.form_valid(form)
+
+        # assert user redirected to the correct url
+        assert response.status_code == 302
+        assert response.url == "/admin/fields/testcustomactionmodel/"
+
+    @pytest.mark.parametrize(
+        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+    )
+    @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
+    def test_form_invalid(
+        self, djstripe_owner_account_exists, action_name, monkeypatch
+    ):
+        model = TestCustomActionModel
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        if djstripe_owner_account_exists:
+            account_instance = models.Account.objects.first()
+            instance.djstripe_owner_account = account_instance
+            instance.save()
+
+        data = {
+            "action": action_name,
+        }
+
+        # monkeypatch utils.get_model and
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": action_name,
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # get the form
+        form = view.get_form()
+
+        # Ensure form is not valid
+        assert not form.is_valid()
+
+        # Invoke form_invalid()
+        response = view.form_invalid(form)
+
+        # assert user got redirected to the action page with the error rendered
+        assertContains(
+            response,
+            '<ul class="messagelist">\n              <li class="error">* This field is required.</li>\n            </ul>',
+            html=True,
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,8 @@ dj-stripe Views Tests.
 """
 
 import pytest
+import stripe
+from django.contrib import messages
 from django.contrib.admin import helpers
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
@@ -20,6 +22,8 @@ pytestmark = pytest.mark.django_db
 
 
 class TestConfirmCustomActionView:
+    kwargs_called_with = {}
+
     # to get around Session/MessageMiddleware Deprecation Warnings
     def dummy_get_response(self, request):
         return None
@@ -235,3 +239,175 @@ class TestConfirmCustomActionView:
             '<ul class="messagelist">\n              <li class="error">* This field is required.</li>\n            </ul>',
             html=True,
         )
+
+    @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
+    def test__resync_instances(self, djstripe_owner_account_exists, monkeypatch):
+        model = TestCustomActionModel
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        if djstripe_owner_account_exists:
+            account_instance = models.Account.objects.first()
+            instance.djstripe_owner_account = account_instance
+            instance.save()
+
+        data = {
+            "action": "_resync_instances",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        # monkeypatch instance.api_retrieve, instance.__class__.sync_from_stripe_data, and app_config.get_model
+        def mock_instance_api_retrieve(*args, **keywargs):
+            self.kwargs_called_with = keywargs
+
+        def mock_instance_sync_from_stripe_data(*args, **kwargs):
+            pass
+
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(model, "api_retrieve", mock_instance_api_retrieve)
+
+        monkeypatch.setattr(
+            model,
+            "sync_from_stripe_data",
+            mock_instance_sync_from_stripe_data,
+        )
+
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": "_resync_instances",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the Custom Actions
+        view._resync_instances(request, [instance])
+
+        # assert correct Success messages are emmitted
+        messages_sent_dictionary = {
+            m.message: m.level_tag for m in messages.get_messages(request)
+        }
+
+        # assert correct success message was emmitted
+        assert (
+            messages_sent_dictionary.get(f"Successfully Synced: {instance}")
+            == "success"
+        )
+
+        if djstripe_owner_account_exists:
+            # assert in case djstripe_owner_account exists that kwargs are not empty
+            assert self.kwargs_called_with == {
+                "stripe_account": instance.djstripe_owner_account.id,
+                "api_key": instance.default_api_key,
+            }
+        else:
+            # assert in case djstripe_owner_account does not exist that kwargs are empty
+            assert self.kwargs_called_with == {}
+
+    def test__resync_instances_stripe_permission_error(self, monkeypatch):
+
+        model = TestCustomActionModel
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        data = {
+            "action": "_resync_instances",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        # monkeypatch instance.api_retrieve and app_config.get_model
+        def mock_instance_api_retrieve(*args, **kwargs):
+            raise stripe.error.PermissionError("some random error message")
+
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(instance, "api_retrieve", mock_instance_api_retrieve)
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": "_resync_instances",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the Custom Actions
+        view._resync_instances(request, [instance])
+
+        # assert correct Success messages are emmitted
+        messages_sent_dictionary = {
+            m.message.user_message: m.level_tag for m in messages.get_messages(request)
+        }
+
+        # assert correct success message was emmitted
+        assert messages_sent_dictionary.get("some random error message") == "warning"
+
+    def test__resync_instances_stripe_invalid_request_error(self, monkeypatch):
+        model = TestCustomActionModel
+
+        # create instance to be used in the Django Admin Action
+        instance = model.objects.create(id="test")
+
+        data = {
+            "action": "_resync_instances",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        # monkeypatch instance.api_retrieve and app_config.get_model
+        def mock_instance_api_retrieve(*args, **kwargs):
+            raise stripe.error.InvalidRequestError({}, "some random error message")
+
+        def mock_get_model(*args, **kwargs):
+            return model
+
+        monkeypatch.setattr(instance, "api_retrieve", mock_instance_api_retrieve)
+        monkeypatch.setattr(utils, "get_model", mock_get_model)
+
+        kwargs = {
+            "action_name": "_resync_instances",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        with pytest.raises(stripe.error.InvalidRequestError) as exc_info:
+            # Invoke the Custom Actions
+            view._resync_instances(request, [instance])
+
+        assert str(exc_info.value.param) == "some random error message"


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added a template for custom Django actions.
2. Added a `Loading...` text to let the user know that their request is being processed for all custom django actions
3. Added a `ConfirmCustomAction` View to handle all Custom Django Admin Actions
4. Added a `cancel()` method to `TestCustomActionModel` model. This was done in order to be able to test out the `_cancel` django action for `Subscription` Model

5. Refactored `_resync_instances` Custom `DjangoAdmin` Action into its own viewThis was done in order to show the user a Confirmation Page.

6. Refactored `_sync_all_instances` Custom DjangoAdmin Action into its own view This was done in order to show the user a Confirmation Page.

7. Refactored `_cancel` Custom DjangoAdmin Action into its own view. This was done in order to show the user a Confirmation Page.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `UX` will be much better for the user especially for users who want to use `dj-stripe` from the admin mostly.