### PR TITLE
Dropped Support for testing against django main branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ The full documentation is available [on Read the Docs](https://dj-stripe.github.
 
 ## Requirements
 
--   Django 3.2.5+
+-   Django 3.2.5+. *dj-stripe is not tested with the `main` branch of `Django` and hence compatibility cannot be guaranteed.*
 -   Python 3.7+
 -   PostgreSQL engine (recommended) 9.6+
 -   MySQL engine: MariaDB 10.2+ or MySQL 5.7+

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 isolated_build = True
 envlist =
-    docs-django{32,40,main}-{postgres,mysql,sqlite}{,-nativejson}
+    docs-django{32,40}-{postgres,mysql,sqlite}{,-nativejson}
     pre-commit
     py37-django{32}-{postgres,postgres-nativejson,mysql,sqlite}
-    py{38,39}-django{32,40,main}-{postgres,mysql,sqlite}{,-nativejson}
-    py310-django{32,40,main}-{postgres,mysql,sqlite}{,-nativejson}
+    py{38,39,310}-django{32,40}-{postgres,mysql,sqlite}{,-nativejson}
 
 skip_missing_interpreters = True
 
@@ -33,7 +32,6 @@ deps =
 
     django32: Django==3.2,<3.3
     django40: Django==4.0,<4.1
-    djangomain: https://github.com/django/django/archive/main.tar.gz
     pytest-django
     pytest-cov
 
@@ -44,7 +42,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 
 ; Need to mention the env because we use tests.settings
-[testenv:docs-django{32,40,main}-{postgres,mysql,sqlite}{,-nativejson}]
+[testenv:docs-django{32,40}-{postgres,mysql,sqlite}{,-nativejson}]
 extras = docs
 commands =
     mkdocs build --clean


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Dropped testing against `djangomain`. `djangomain` is fairly unstable and doesn't add any real value to testing against it.
2. Updated `docs` regarding no support for `djangomain`.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`Django Main` is fairly unstable and prone to a lot of development and hence breaks easily making all the tests also fail as a result which defeats the purpose as `dj-stripe` is fairly stable and compatible with all of `Django's` released versions.