### PR TITLE
Improve PlanAdmin db queries

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -555,6 +555,14 @@ class PlanAdmin(StripeModelAdmin):
 
         return readonly_fields
 
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("product")
+            .prefetch_related("subscriptions")
+        )
+
 
 @admin.register(models.Price)
 class PriceAdmin(StripeModelAdmin):

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1216,12 +1216,10 @@ class Plan(StripeModel):
         return plan
 
     def __str__(self):
-        from .billing import Subscription
-
-        subscriptions = Subscription.objects.filter(plan__id=self.id).count()
+        subscriptions_cnt = self.subscriptions.count()
         if self.product and self.product.name:
-            return f"{self.human_readable_price} for {self.product.name} ({subscriptions} subscriptions)"
-        return f"{self.human_readable_price} ({subscriptions} subscriptions)"
+            return f"{self.human_readable_price} for {self.product.name} ({subscriptions_cnt} subscriptions)"
+        return f"{self.human_readable_price} ({subscriptions_cnt} subscriptions)"
 
     @property
     def amount_in_cents(self):


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Used `select_related` to fetch `Product` FK along with `Plan` queryset.
2. Used `prefetch_related` to get the  `subscriptions`, `Many to One` relation.
3. Overrode `Plan.__str__` to take advantage of the `subscriptions`, `Many to One` relation to get all the associated `Subscription` instances.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `Changelist View` will now load a lot faster for most models due to a significant reduction in the number of `Database` Queries.