### PR TITLE
Improve ProductAdmin db queries

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -675,6 +675,9 @@ class ProductAdmin(StripeModelAdmin):
     list_filter = ("type", "active", "shippable")
     search_fields = ("name", "statement_descriptor")
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related("prices")
+
 
 @admin.register(models.Refund)
 class RefundAdmin(StripeModelAdmin):

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -599,7 +599,7 @@ class Product(StripeModel):
 
     def __str__(self):
         # 1 product can have 1 or more than 1 related price
-        price_qs = Price.objects.filter(product__id=self.id)
+        price_qs = self.prices.all()
         price_count = price_qs.count()
 
         if price_count > 1:


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Used `prefetch_related` to get the  `prices`, `Many to One` relation.
2. Overrode `Product.__str__` to take advantage of the `prices`, `Many to One` relation to get all the associated `Price` instances.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `Changelist View` will now load a lot faster for most models due to a significant reduction in the number of `Database` Queries.