### PR TITLE
Reduce DB queries in SourceTransactionAdmin

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -727,6 +727,26 @@ class SourceAdmin(StripeModelAdmin):
         )
 
 
+@admin.register(models.SourceTransaction)
+class SourceTransactionAdmin(StripeModelAdmin):
+    list_display = ("status", "amount", "currency")
+    list_filter = (
+        "status",
+        "source__id",
+        "source__customer",
+        "source__customer__subscriber",
+    )
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if "_resync_instances" in actions:
+            del actions["_resync_instances"]
+        return actions
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("source")
+
+
 @admin.register(models.PaymentMethod)
 class PaymentMethodAdmin(StripeModelAdmin):
     list_display = ("customer", "type", "billing_details")
@@ -803,7 +823,6 @@ class SubscriptionAdmin(StripeModelAdmin):
                 )
             except InvalidRequestError as error:
                 self.message_user(request, str(error), level=messages.WARNING)
-
 
     def get_queryset(self, request):
         return (

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -679,7 +679,7 @@ class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
 
                 # sub-classes of StripeModel
                 if model.__name__ not in self.ignore_models:
-                    if model.__name__ == "UsageRecordSummary":
+                    if model.__name__ in ("UsageRecordSummary", "SourceTransaction"):
                         assert "_resync_instances" not in actions
                         assert "_sync_all_instances" in actions
                     elif model.__name__ == "Subscription":


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge the following PRs before merging this PR:

1. #1616 
2. #1542 

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Removed `_resync_instances` custom action for `SourceTransaction` as Stripe doesn't allow to `retrieve` those objects. One can only `list` them.
2. Added `get_queryset` to `SourceTransactionAdmin` to reduce the number of `DB` queries.
3. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`SourceTransaction` models can now be synced directly from the `admin`.