### PR TITLE
Added get_actions () to Admin CustomActionMixin class

### DIFF
--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -78,6 +78,7 @@ class ApplicationFeeRefund(StripeModel):
     """
 
     description = None
+    stripe_class = stripe.ApplicationFeeRefund
 
     amount = StripeQuantumCurrencyAmountField(help_text="Amount refunded, in cents.")
     balance_transaction = StripeForeignKey(

--- a/tests/fields/models.py
+++ b/tests/fields/models.py
@@ -10,10 +10,16 @@ class ExampleDecimalModel(models.Model):
     noval = StripePercentField()
 
 
+class MockStripeClass:
+    def retrieve(self):
+        return self
+
+
 class TestCustomActionModel(StripeModel):
     # for some reason having a FK here throws relation doesn't exist even though
     # djstripe is also one of the installed apps in tests.settings
     djstripe_owner_account = None
+    stripe_class = MockStripeClass
 
     # For Subscription model's custom action, _cancel
     def cancel(self, at_period_end: bool = False, **kwargs):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -999,6 +999,36 @@ class TestCustomActionMixin:
                 )
             )
 
+    def test_get_actions(self, admin_user):
+        app_label = "djstripe"
+        app_config = apps.get_app_config(app_label)
+        all_models_lst = app_config.get_models()
+
+        for model in all_models_lst:
+            if model in site._registry.keys():
+                model_admin = site._registry.get(model)
+
+                # get the standard changelist_view url
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+                )
+
+                # add the admin user to the mocked request
+                request = RequestFactory().get(url)
+                request.user = admin_user
+
+                actions = model_admin.get_actions(request)
+
+                # sub-classes of StripeModel
+                if model.__name__ not in self.ignore_models:
+
+                    if getattr(model.stripe_class, "retrieve", None):
+                        # assert "_resync_instances" action is present
+                        assert "_resync_instances" in actions
+                    else:
+                        # assert "_resync_instances" action is not present
+                        assert "_resync_instances" not in actions
+
     @pytest.mark.parametrize("fake_selected_pks", [None, [1, 2]])
     def test_changelist_view(self, admin_client, fake_selected_pks):
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `CustomActionMixin.get_actions()` to ensure the custom django admin action, `_resync_instances` get returned only for models that have the `retrieve` method implemented for the corresponding `Stripe` classes.
2. Added Corresponding Tests


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Makes the project more maintainable by having 1 place (`CustomActionMixin`) as the only place to manage all Custom Actions.