### PR TITLE
Add Django Admin Action to Cancel Payouts

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -336,6 +336,20 @@ class PayoutAdmin(StripeModelAdmin):
             .select_related("balance_transaction", "destination")
         )
 
+    @admin.display(description="Cancel selected Payouts")
+    def _cancel_payout(self, request, queryset):
+        """Cancel a Payout."""
+        context = self.get_admin_action_context(
+            queryset, "_cancel_payout", CustomActionForm
+        )
+        return render(request, "djstripe/admin/confirm_action.html", context)
+
+    def get_actions(self, request):
+        # get all actions
+        actions = super().get_actions(request)
+        actions["_cancel_payout"] = self.get_action("_cancel_payout")
+        return actions
+
 
 @admin.register(models.SetupIntent)
 class SetupIntentAdmin(StripeModelAdmin):

--- a/djstripe/admin/views.py
+++ b/djstripe/admin/views.py
@@ -122,3 +122,12 @@ class ConfirmCustomAction(FormView):
                 messages.success(request, f"Successfully Canceled: {instance}")
             except stripe.error.InvalidRequestError as error:
                 messages.warning(request, error)
+
+    def _cancel_payout(self, request, queryset):
+        """Cancel a Payout."""
+        for payout in queryset:
+            try:
+                instance = payout.cancel()
+                messages.success(request, f"Successfully Canceled: {instance}")
+            except stripe.error.InvalidRequestError as error:
+                messages.warning(request, error)

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2140,6 +2140,17 @@ class Payout(StripeModel):
     def __str__(self):
         return f"{self.amount} ({enums.PayoutStatus.humanize(self.status)})"
 
+    def cancel(self, api_key=None, stripe_account=None, **kwargs):
+        api_key = api_key or self.default_api_key
+        # Prefer passed in stripe_account if set.
+        if not stripe_account:
+            stripe_account = self._get_stripe_account_id(api_key)
+
+        stripe_payout = self.stripe_class.cancel(
+            self.id, api_key=api_key, stripe_account=stripe_account, **kwargs
+        )
+        return Payout.sync_from_stripe_data(stripe_payout)
+
 
 class Price(StripeModel):
     """

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -47,3 +47,4 @@
 - `check_stripe_api_key` will raise appropriate warnings on the console directing users to add keys directly from the django admin.
 -  Swapped Critical Error to Info for `_check_webhook_endpoint_validation` check to allow the users to use the django admin.
 - `LineItem` instances can also get synced using the `djstripe_sync_models` management command.
+- Payouts can now be cancelled from the Django admin.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1110,7 +1110,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -1174,7 +1174,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -64,7 +64,6 @@ class TestConfirmCustomActionView:
         ],
     )
     def test_get_form_kwargs(self, action_name, admin_user, monkeypatch):
-
         model = CustomActionModel
 
         # monkeypatch utils.get_model
@@ -247,7 +246,6 @@ class TestConfirmCustomActionView:
                 model.__name__ == "WebhookEndpoint"
                 or model.__name__ not in self.ignore_models
             ):
-
                 # monkeypatch utils.get_model
                 def mock_get_model(*args, **kwargs):
                     return model
@@ -372,7 +370,6 @@ class TestConfirmCustomActionView:
             assert self.kwargs_called_with == {}
 
     def test__resync_instances_stripe_permission_error(self, monkeypatch):
-
         model = CustomActionModel
 
         # create instance to be used in the Django Admin Action
@@ -515,7 +512,7 @@ class TestConfirmCustomActionView:
         monkeypatch.setattr(
             stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
         )
-        # si_HXZCDv9ixoUB5u
+
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
         monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `Payout.cancel()` to `cancel` Payouts.
2. Added a Custom Django Admin action to allow users to cancel `Payouts` like they can cancel `Subscriptions` right from the Django Admin.
3. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

The UX will improve as the `Django Admin` gains more functionality.