### PR TITLE
Removed unnecessary flag IS_STATICMETHOD_AUTOSPEC_SUPPORTED

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import logging
 import os
-import sys
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -27,14 +26,6 @@ logger = logging.getLogger(__name__)
 FUTURE_DATE = datetime(2100, 4, 30, tzinfo=timezone.utc)
 
 FIXTURE_DIR_PATH = Path(__file__).parent.joinpath("fixtures")
-
-
-# Flags for various bugs with mock autospec
-# These can be removed once we drop support for the affected python versions
-
-# Don't try and use autospec=True on staticmethods on <py3.7
-# see https://bugs.python.org/issue23078
-IS_STATICMETHOD_AUTOSPEC_SUPPORTED = sys.version_info >= (3, 7, 4)
 
 
 class AssertStripeFksMixin:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -18,7 +18,6 @@ from . import (
     FAKE_FILEUPLOAD_ICON,
     FAKE_FILEUPLOAD_LOGO,
     FAKE_PLATFORM_ACCOUNT,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -26,7 +25,7 @@ pytestmark = pytest.mark.django_db
 
 
 class TestAccount(AssertStripeFksMixin, TestCase):
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         side_effect=[deepcopy(FAKE_FILEUPLOAD_ICON), deepcopy(FAKE_FILEUPLOAD_LOGO)],
@@ -60,7 +59,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -91,7 +90,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -106,7 +105,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -121,7 +120,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -138,7 +137,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -153,7 +152,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
             fake_account["settings"]["branding"]["icon"], account.branding_icon.id
         )
 
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -176,7 +175,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
             stripe_account=fake_account["id"],
         )
 
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -206,7 +205,7 @@ class TestAccount(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_ACCOUNT),
     )
     @patch(
@@ -245,7 +244,7 @@ class TestAccountMethods:
             ({"name": ""}, {"display_name": ""}, "<id=acct_1032D82eZvKYlo2C>"),
         ),
     )
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -267,7 +266,7 @@ class TestAccountMethods:
 
         assert str(account) == expected_account_str
 
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -300,7 +299,7 @@ class TestAccountMethods:
             (deepcopy(FAKE_PLATFORM_ACCOUNT), True),
         ],
     )
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -350,7 +349,7 @@ class TestAccountMethods:
             (deepcopy(FAKE_PLATFORM_ACCOUNT), True),
         ],
     )
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.File.retrieve",
         return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
@@ -390,7 +389,7 @@ class TestAccountRestrictedKeys(TestCase):
         STRIPE_TEST_PUBLIC_KEY="pk_test_foo",
         STRIPE_LIVE_MODE=False,
     )
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     def test_account_str_restricted_key(self, account_retrieve_mock):
         """
         Test that we do not attempt to retrieve account ID with restricted keys.
@@ -416,7 +415,7 @@ class TestAccountRestrictedKeys(TestCase):
 )
 @patch(
     target="djstripe.models.connect.StripeModel._create_from_stripe_object",
-    autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+    autospec=True,
 )
 def test_account__create_from_stripe_object(
     mock_super__create_from_stripe_object,

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -13,12 +13,7 @@ from djstripe.exceptions import InvalidStripeAPIKey
 from djstripe.models import Account, APIKey
 from djstripe.models.api import get_api_key_details_by_prefix
 
-from . import (
-    FAKE_FILEUPLOAD_ICON,
-    FAKE_FILEUPLOAD_LOGO,
-    FAKE_PLATFORM_ACCOUNT,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
-)
+from . import FAKE_FILEUPLOAD_ICON, FAKE_FILEUPLOAD_LOGO, FAKE_PLATFORM_ACCOUNT
 
 # avoid literal api keys to prevent git secret scanners false-positives
 SK_TEST = "sk_test_" + "XXXXXXXXXXXXXXXXXXXX1234"
@@ -138,7 +133,7 @@ class APIKeyTest(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.File.retrieve",

--- a/tests/test_balance_transaction.py
+++ b/tests/test_balance_transaction.py
@@ -20,7 +20,6 @@ from . import (
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
 
 pytestmark = pytest.mark.django_db
@@ -95,7 +94,7 @@ class TestBalanceTransaction(TestCase):
     )
     @patch(
         "stripe.Charge.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_CHARGE),
     )
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
@@ -157,7 +156,7 @@ class TestBalanceTransaction(TestCase):
     )
     @patch(
         "stripe.Charge.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_CHARGE),
     )
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
@@ -215,7 +214,7 @@ class TestBalanceTransaction(TestCase):
     )
     @patch(
         "stripe.Charge.retrieve",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_CHARGE),
     )
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)

--- a/tests/test_bank_account.py
+++ b/tests/test_bank_account.py
@@ -19,7 +19,6 @@ from . import (
     FAKE_CUSTOM_ACCOUNT,
     FAKE_CUSTOMER_IV,
     FAKE_STANDARD_ACCOUNT,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -154,12 +153,12 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve",
         return_value=deepcopy(FAKE_CUSTOMER_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_api_retrieve_by_customer_equals_retrieval_by_account(
         self, account_retrieve_external_account_mock, customer_retrieve_mock
@@ -312,7 +311,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_with_customer_and_account(
         self, account_retrieve_mock, customer_retrieve_mock
@@ -332,12 +331,12 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve",
         return_value=deepcopy(FAKE_CUSTOMER_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_with_customer_absent(
         self, account_retrieve_mock, customer_retrieve_mock
@@ -350,7 +349,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BankAccount.retrieve",
@@ -365,7 +364,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_SOURCE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_bankaccount_by_customer(
         self,
@@ -402,12 +401,12 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.delete_external_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_bankaccount_by_account(
         self,
@@ -444,12 +443,12 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.delete_external_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_already_deleted_bankaccount_by_account(
         self,
@@ -488,7 +487,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Customer.retrieve",
@@ -498,7 +497,7 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_SOURCE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_already_deleted_bank_account(
         self,

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -21,7 +21,6 @@ from . import (
     FAKE_CUSTOM_ACCOUNT,
     FAKE_CUSTOMER,
     FAKE_STANDARD_ACCOUNT,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -116,12 +115,12 @@ class CardTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_api_retrieve_by_customer_equals_retrieval_by_account(
         self,
@@ -281,7 +280,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_with_customer_absent(self, account_retrieve_mock):
         stripe_card = Card._api_create(
@@ -296,7 +295,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_with_customer_and_account(
         self, account_retrieve_mock, customer_retrieve_mock
@@ -314,7 +313,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Card.retrieve", return_value=deepcopy(FAKE_CARD), autospec=True)
     @patch(
@@ -323,7 +322,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_card_by_customer(
         self,
@@ -351,12 +350,12 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.delete_external_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_card_by_account(self, account_retrieve_mock, card_delete_mock):
 
@@ -383,12 +382,12 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Account.delete_external_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_already_deleted_card_by_account(
         self, account_retrieve_mock, card_delete_mock
@@ -420,7 +419,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
@@ -428,7 +427,7 @@ class CardTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_remove_already_deleted_card(
         self,

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -30,7 +30,6 @@ from . import (
     FAKE_STANDARD_ACCOUNT,
     FAKE_SUBSCRIPTION,
     FAKE_TRANSFER,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -98,7 +97,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Charge.retrieve", autospec=True)
     @patch(
@@ -156,17 +155,13 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
             },
         )
 
-    @patch(
-        "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED
-        and IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
-    )
+    @patch("djstripe.models.Account.get_default_account", autospec=True)
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
         autospec=True,
     )
-    @patch("stripe.Charge.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Charge.retrieve", autospec=True)
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
@@ -238,7 +233,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Charge.retrieve", autospec=True)
     @patch(
@@ -344,7 +339,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -470,7 +465,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_sync_from_stripe_data_max_amount(
         self,
@@ -508,7 +503,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -576,7 +571,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -670,7 +665,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_sync_from_stripe_data_with_transfer(
         self,
@@ -722,7 +717,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         )
 
     @patch("stripe.Charge.retrieve", autospec=True)
-    @patch("stripe.Account.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Account.retrieve", autospec=True)
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
@@ -827,13 +822,9 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         self.assertEqual(starting_source, charge.source)
         mock_payment_method._get_or_create_source.assert_not_called()
 
-    @patch(
-        "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED
-        and IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
-    )
+    @patch("djstripe.models.Account.get_default_account", autospec=True)
     @patch("stripe.BalanceTransaction.retrieve", autospec=True)
-    @patch("stripe.Charge.retrieve", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED)
+    @patch("stripe.Charge.retrieve", autospec=True)
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -55,7 +55,6 @@ from . import (
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_II,
     FAKE_UPCOMING_INVOICE,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
     StripeList,
     datetime_to_unix,
@@ -427,14 +426,14 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Customer.delete", autospec=True)
     @patch("stripe.Customer.retrieve", autospec=True)
     @patch(
         "stripe.Customer.retrieve_source",
         side_effect=[deepcopy(FAKE_CARD), deepcopy(FAKE_CARD_III)],
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_customer_purge_leaves_customer_record(
         self,
@@ -507,7 +506,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Customer.delete", autospec=True)
     @patch(
@@ -543,7 +542,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_customer_delete_raises_unexpected_exception(
         self,
@@ -830,7 +829,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -925,7 +924,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1030,7 +1029,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1074,7 +1073,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1133,7 +1132,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1182,7 +1181,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1223,7 +1222,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1264,7 +1263,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1323,7 +1322,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1379,7 +1378,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -1425,7 +1424,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -1523,7 +1522,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Invoice.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.list",
@@ -1542,7 +1541,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Invoice.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Invoice.list", return_value=StripeList(data=[]), autospec=True)
     @patch(
@@ -1556,7 +1555,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Charge.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Charge.list",
@@ -1574,7 +1573,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Charge.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Charge.list", return_value=StripeList(data=[]), autospec=True)
     @patch(
@@ -1588,7 +1587,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Subscription.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.list",
@@ -1607,7 +1606,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Subscription.sync_from_stripe_data",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Subscription.list", return_value=StripeList(data=[]), autospec=True)
     @patch(
@@ -1856,7 +1855,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     @patch(
         "djstripe.models.InvoiceItem.sync_from_stripe_data",
         return_value="pancakes",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.InvoiceItem.create",
@@ -1888,7 +1887,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     @patch(
         "djstripe.models.InvoiceItem.sync_from_stripe_data",
         return_value="pancakes",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.InvoiceItem.create",
@@ -1962,7 +1961,7 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Invoice.upcoming",
         return_value=deepcopy(FAKE_UPCOMING_INVOICE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_upcoming_invoice_plan(
         self,
@@ -2326,7 +2325,7 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Invoice.upcoming",
         return_value=deepcopy(FAKE_UPCOMING_INVOICE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_upcoming_invoice(
         self,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -17,7 +17,6 @@ from . import (
     FAKE_EVENT_TRANSFER_CREATED,
     FAKE_PLATFORM_ACCOUNT,
     FAKE_TRANSFER,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
 
 
@@ -165,7 +164,7 @@ class EventRaceConditionTest(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -142,7 +142,6 @@ from . import (
     FAKE_TAX_ID,
     FAKE_TAX_ID_UPDATED,
     FAKE_TRANSFER,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -194,7 +193,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_bank_account_event(
@@ -223,7 +222,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_bank_account_event(
@@ -252,7 +251,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_bank_account_event(
@@ -294,7 +293,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_created_card_event(
@@ -321,7 +320,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_deleted_card_event(
@@ -350,7 +349,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_external_account_updated_card_event(
@@ -389,7 +388,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_bank_account_event(
@@ -418,7 +417,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_bank_account_event(
@@ -447,7 +446,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_BANK_ACCOUNT_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_bank_account_event(
@@ -489,7 +488,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_created_card_event(
@@ -516,7 +515,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_deleted_card_event(
@@ -545,7 +544,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve_external_account",
         return_value=deepcopy(FAKE_CARD_IV),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_external_account_updated_card_event(
@@ -586,7 +585,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_STANDARD_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_standard_account_updated_event(
@@ -622,7 +621,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_EXPRESS_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_express_account_updated_event(
@@ -658,7 +657,7 @@ class TestAccountEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_EVENT_CUSTOM_ACCOUNT_UPDATED["data"]["object"]),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Event.retrieve", autospec=True)
     def test_custom_account_updated_event(
@@ -703,7 +702,7 @@ class TestChargeEvents(EventTestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1101,13 +1100,13 @@ class TestCustomerEvents(EventTestCase):
 
     @patch(
         "stripe.Customer.delete_source",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Customer.delete", autospec=True)
     @patch(
         "stripe.Customer.retrieve_source",
         side_effect=[deepcopy(FAKE_CARD), deepcopy(FAKE_CARD_III)],
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Customer.retrieve", return_value=FAKE_CUSTOMER, autospec=True)
     def test_customer_deleted(
@@ -1165,7 +1164,7 @@ class TestCustomerEvents(EventTestCase):
     @patch(
         "stripe.Customer.retrieve_source",
         return_value=deepcopy(FAKE_CARD),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_customer_card_created(
         self, customer_retrieve_source_mock, event_retrieve_mock, customer_retrieve_mock
@@ -1721,7 +1720,7 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "djstripe.models.Account.get_default_account",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1783,7 +1782,7 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "djstripe.models.Account.get_default_account",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1848,7 +1847,7 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "djstripe.models.Account.get_default_account",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1919,7 +1918,7 @@ class TestInvoiceItemEvents(EventTestCase):
     @patch(
         "djstripe.models.Account.get_default_account",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -2007,7 +2006,7 @@ class TestInvoiceItemEvents(EventTestCase):
     @patch(
         "djstripe.models.Account.get_default_account",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -2341,7 +2340,7 @@ class TestPaymentIntentEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.File.retrieve",
@@ -2842,7 +2841,7 @@ class TestTaxIdEvents(EventTestCase):
     @patch(
         "stripe.Customer.retrieve_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Event.retrieve",
@@ -2864,7 +2863,7 @@ class TestTaxIdEvents(EventTestCase):
     )
     @patch(
         "stripe.Customer.retrieve_tax_id",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Event.retrieve",
@@ -2896,7 +2895,7 @@ class TestTaxIdEvents(EventTestCase):
     )
     @patch(
         "stripe.Customer.retrieve_tax_id",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Event.retrieve",
@@ -2924,7 +2923,7 @@ class TestTransferEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Transfer.retrieve", autospec=True)
     @patch("stripe.Event.retrieve", autospec=True)
@@ -2952,7 +2951,7 @@ class TestTransferEvents(EventTestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Transfer.retrieve", return_value=FAKE_TRANSFER, autospec=True)
     def test_transfer_deleted(

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -30,7 +30,6 @@ from . import (
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
     FAKE_TAX_RATE_EXAMPLE_2_SALES,
     FAKE_UPCOMING_INVOICE,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -71,7 +70,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -136,7 +135,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -238,7 +237,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -291,7 +290,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -349,7 +348,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -406,7 +405,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch("stripe.Invoice.retrieve", autospec=True)
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -466,7 +465,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch("stripe.Invoice.retrieve", autospec=True)
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -518,7 +517,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -566,7 +565,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -614,7 +613,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -660,7 +659,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -708,7 +707,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -756,7 +755,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -818,7 +817,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -874,7 +873,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -923,7 +922,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -973,7 +972,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1021,7 +1020,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1069,7 +1068,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -1148,7 +1147,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Invoice.upcoming",
         return_value=deepcopy(FAKE_UPCOMING_INVOICE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
@@ -1245,7 +1244,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Invoice.upcoming",
         return_value=deepcopy(FAKE_UPCOMING_INVOICE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_upcoming_invoice_with_subscription(
         self,
@@ -1305,7 +1304,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Invoice.upcoming",
         return_value=deepcopy(FAKE_UPCOMING_INVOICE),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -33,7 +33,6 @@ from . import (
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_III,
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -70,7 +69,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -162,7 +161,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -261,7 +260,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -355,7 +354,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -453,7 +452,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch("stripe.Price.retrieve", return_value=deepcopy(FAKE_PRICE_II), autospec=True)
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN_II), autospec=True)
@@ -509,7 +508,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -18,7 +18,6 @@ from . import (
     FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_TRANSFER,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
 
 
@@ -154,7 +153,7 @@ class TransferManagerTest(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_transfer_summary(
         self, account_retrieve_mock, transfer__attach_object_post_save_hook_mock

--- a/tests/test_payment_method.py
+++ b/tests/test_payment_method.py
@@ -17,7 +17,6 @@ from . import (
     FAKE_CARD_AS_PAYMENT_METHOD,
     FAKE_CUSTOMER,
     FAKE_PAYMENT_METHOD_I,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
     PaymentMethodDict,
 )
@@ -110,7 +109,7 @@ class PaymentMethodTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.PaymentMethod._cls_attach",
         return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_attach(self, attach_mock):
 
@@ -129,7 +128,7 @@ class PaymentMethodTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.PaymentMethod._cls_attach",
         return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_attach_obj(self, attach_mock):
         pm = models.PaymentMethod.sync_from_stripe_data(FAKE_PAYMENT_METHOD_I)
@@ -147,7 +146,7 @@ class PaymentMethodTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.PaymentMethod._cls_attach",
         return_value=deepcopy(FAKE_PAYMENT_METHOD_I),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_attach_synced(self, attach_mock):
         fake_payment_method = deepcopy(FAKE_PAYMENT_METHOD_I)

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -22,7 +22,6 @@ from . import (
     FAKE_PRODUCT,
     FAKE_REFUND,
     FAKE_SUBSCRIPTION,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -63,7 +62,7 @@ class RefundTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -115,7 +114,7 @@ class RefundTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -171,7 +170,7 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     # TODO Move to test_enums module
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -236,7 +235,7 @@ class RefundTest(AssertStripeFksMixin, TestCase):
 
     @patch(
         "djstripe.models.Account.get_default_account",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",

--- a/tests/test_tax_id.py
+++ b/tests/test_tax_id.py
@@ -11,12 +11,7 @@ from djstripe import enums
 from djstripe.models import Customer, TaxId
 from djstripe.settings import djstripe_settings
 
-from . import (
-    FAKE_CUSTOMER,
-    FAKE_TAX_ID,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
-    AssertStripeFksMixin,
-)
+from . import FAKE_CUSTOMER, FAKE_TAX_ID, AssertStripeFksMixin
 
 pytestmark = pytest.mark.django_db
 
@@ -30,7 +25,7 @@ class TestTaxIdStr(TestCase):
     @patch(
         "stripe.Customer.retrieve_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test___str__(
         self,
@@ -54,7 +49,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_sync_from_stripe_data(
         self,
@@ -83,7 +78,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.create_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create(
         self,
@@ -112,7 +107,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.create_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_no_id_kwarg(
         self,
@@ -130,7 +125,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.create_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test__api_create_no_customer(
         self,
@@ -151,7 +146,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Customer.retrieve_tax_id",
         return_value=deepcopy(FAKE_TAX_ID),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_api_retrieve(
         self,
@@ -172,7 +167,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.Customer.list_tax_ids",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_api_list(
         self,

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -13,7 +13,6 @@ from . import (
     FAKE_BALANCE_TRANSACTION_II,
     FAKE_STANDARD_ACCOUNT,
     FAKE_TRANSFER,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -45,7 +44,7 @@ class TestTransferStr:
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -80,7 +79,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -116,7 +115,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -142,7 +141,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",

--- a/tests/test_transfer_reversal.py
+++ b/tests/test_transfer_reversal.py
@@ -15,7 +15,6 @@ from . import (
     FAKE_PLATFORM_ACCOUNT,
     FAKE_TRANSFER,
     FAKE_TRANSFER_WITH_1_REVERSAL,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -27,7 +26,7 @@ class TestTransferReversalStr(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -58,7 +57,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -100,7 +99,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_PLATFORM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
@@ -109,7 +108,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Transfer.retrieve_reversal",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_TRANSFER_WITH_1_REVERSAL),
     )
     def test_api_retrieve(
@@ -141,7 +140,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Transfer.create_reversal",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_TRANSFER_WITH_1_REVERSAL),
     )
     def test__api_create(
@@ -160,9 +159,7 @@ class TestTransfer(AssertStripeFksMixin, TestCase):
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
         )
 
-    @patch(
-        "stripe.Transfer.list_reversals", autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED
-    )
+    @patch("stripe.Transfer.list_reversals", autospec=True)
     def test_api_list(self, transfer_reversal_list_mock):
         p = PropertyMock(return_value=deepcopy(FAKE_TRANSFER_WITH_1_REVERSAL))
         type(transfer_reversal_list_mock).auto_paging_iter = p

--- a/tests/test_usage_record.py
+++ b/tests/test_usage_record.py
@@ -17,7 +17,6 @@ from . import (
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION_ITEM,
     FAKE_USAGE_RECORD,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -117,7 +116,7 @@ class TestUsageRecord(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.SubscriptionItem.create_usage_record",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
         return_value=deepcopy(FAKE_USAGE_RECORD),
     )
     @patch(

--- a/tests/test_usage_record_summary.py
+++ b/tests/test_usage_record_summary.py
@@ -18,7 +18,6 @@ from . import (
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION_ITEM,
     FAKE_USAGE_RECORD_SUMMARY,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
     AssertStripeFksMixin,
 )
 
@@ -203,7 +202,7 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
 
     @patch(
         "stripe.SubscriptionItem.list_usage_record_summaries",
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "djstripe.models.billing.SubscriptionItem.objects.get",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,8 +17,6 @@ from djstripe.utils import (
     get_supported_currency_choices,
 )
 
-from . import IS_STATICMETHOD_AUTOSPEC_SUPPORTED
-
 TZ_IS_UTC = time.tzname == ("UTC", "UTC")
 
 
@@ -45,7 +43,7 @@ class TestGetSupportedCurrencyChoices(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value={"country": "US"},
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     def test_get_choices(
         self, stripe_account_retrieve_mock, stripe_countryspec_retrieve_mock

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -26,7 +26,6 @@ from . import (
     FAKE_STANDARD_ACCOUNT,
     FAKE_TRANSFER,
     FAKE_WEBHOOK_ENDPOINT_1,
-    IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
 )
 
 pytestmark = pytest.mark.django_db
@@ -103,7 +102,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -166,12 +165,12 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.WebhookSignature.verify_header",
         return_value=True,
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -210,7 +209,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -321,7 +320,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -350,7 +349,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -385,7 +384,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_STANDARD_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True
@@ -420,7 +419,7 @@ class TestWebhookEventTrigger(TestCase):
     @patch(
         "stripe.Account.retrieve",
         return_value=deepcopy(FAKE_CUSTOM_ACCOUNT),
-        autospec=IS_STATICMETHOD_AUTOSPEC_SUPPORTED,
+        autospec=True,
     )
     @patch(
         "stripe.Transfer.retrieve", return_value=deepcopy(FAKE_TRANSFER), autospec=True


### PR DESCRIPTION

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed unnecessary flag `IS_STATICMETHOD_AUTOSPEC_SUPPORTED` as the minimum supported python version now is `3.7.12`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.
