### PR TITLE
Updated Customer.subscribe() to return the newly created Subscription

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -905,7 +905,7 @@ class Customer(StripeModel):
         )
 
         api_key = kwargs.get("api_key") or self.default_api_key
-        Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
+        return Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
 
     def charge(
         self,

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -1638,11 +1638,18 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         fake_subscription["latest_invoice"] = None
         subscription_create_mock.return_value = fake_subscription
 
+        current_subscriptions = self.customer.subscriptions.count()
+
         price = Price.sync_from_stripe_data(deepcopy(FAKE_PRICE))
 
         self.assert_fks(price, expected_blank_fks={})
 
         self.customer.subscribe(items=[{"price": price.id}])
+
+        updated_subscriptions = self.customer.subscriptions.count()
+
+        # assert 1 new subscription got created
+        assert updated_subscriptions == current_subscriptions + 1
 
     @patch("stripe.Subscription.create", autospec=True)
     @patch(
@@ -1663,11 +1670,17 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         fake_subscription["latest_invoice"] = None
         subscription_create_mock.return_value = fake_subscription
 
+        current_subscriptions = self.customer.subscriptions.count()
         price = Price.sync_from_stripe_data(deepcopy(FAKE_PRICE))
 
         self.assert_fks(price, expected_blank_fks={})
 
         self.customer.subscribe(price=price.id)
+
+        updated_subscriptions = self.customer.subscriptions.count()
+
+        # assert 1 new subscription got created
+        assert updated_subscriptions == current_subscriptions + 1
 
     @patch("stripe.Subscription.create", autospec=True)
     @patch(
@@ -2164,7 +2177,13 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         fake_subscription["latest_invoice"] = None
         subscription_create_mock.return_value = fake_subscription
 
+        current_subscriptions = self.customer.subscriptions.count()
         self.customer.subscribe(items=[{"plan": plan.id}])
+
+        updated_subscriptions = self.customer.subscriptions.count()
+
+        # assert 1 new subscription got created
+        assert updated_subscriptions == current_subscriptions + 1
 
     @patch(
         "stripe.Subscription.create",
@@ -2192,7 +2211,13 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         fake_subscription["latest_invoice"] = None
         subscription_create_mock.return_value = fake_subscription
 
+        current_subscriptions = self.customer.subscriptions.count()
         self.customer.subscribe(plan=plan.id)
+
+        updated_subscriptions = self.customer.subscriptions.count()
+
+        # assert 1 new subscription got created
+        assert updated_subscriptions == current_subscriptions + 1
 
     @patch.object(Subscription, "_api_create", autospec=True)
     @patch("stripe.Subscription.create", autospec=True)


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `Customer.subscribe()` to return the newly created `Subscription`.
2. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1629
