### PR TITLE
Replaced  _attach_objects_hook() with _attach_objects_pre_save_hook()

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import warnings
 from datetime import timedelta
 from typing import Dict, List, Optional
 
@@ -518,8 +519,12 @@ class StripeModel(StripeBaseModel):
         :param current_ids: stripe ids of objects that are currently being processed
         :type current_ids: set
         """
-        pass
 
+        warnings.DeprecationWarning(
+            "_attach_objects_hook() is deprecated, will be removed in dj-stripe 2.9. "
+            "Look at _attach_objects_pre_save_hook instead.",
+            DeprecationWarning,
+        )
 
     def _attach_objects_pre_save_hook(
         self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -518,6 +518,22 @@ class StripeModel(StripeBaseModel):
         :param current_ids: stripe ids of objects that are currently being processed
         :type current_ids: set
         """
+        pass
+
+
+    def _attach_objects_pre_save_hook(
+        self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
+    ):
+        """
+        Gets called by this object's create and sync methods just before save.
+        Use this to populate fields before the model is saved.
+
+        :param cls: The target class for the instantiated object.
+        :param data: The data dictionary received from the Stripe API.
+        :type data: dict
+        :param current_ids: stripe ids of objects that are currently being processed
+        :type current_ids: set
+        """
 
         pass
 
@@ -612,7 +628,7 @@ class StripeModel(StripeBaseModel):
             # TODO dictionary unpacking will not work if cls has any ManyToManyField
             instance = cls(**stripe_data)
 
-            instance._attach_objects_hook(
+            instance._attach_objects_pre_save_hook(
                 cls, data, api_key=api_key, current_ids=current_ids
             )
 
@@ -1005,7 +1021,7 @@ class StripeModel(StripeBaseModel):
             record_data = cls._stripe_object_to_record(data, api_key=api_key)
             for attr, value in record_data.items():
                 setattr(instance, attr, value)
-            instance._attach_objects_hook(
+            instance._attach_objects_pre_save_hook(
                 cls, data, api_key=api_key, current_ids=current_ids
             )
             instance.save()

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -820,10 +820,10 @@ class UpcomingInvoice(BaseInvoice):
     def get_stripe_dashboard_url(self):
         return ""
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
     ):
-        super()._attach_objects_hook(
+        super()._attach_objects_pre_save_hook(
             cls, data, api_key=api_key, current_ids=current_ids
         )
         self._invoiceitems = cls._stripe_object_to_invoice_items(

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1330,7 +1330,7 @@ class Customer(StripeModel):
         if save:
             self.save()
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
     ):
         # When we save a customer to Stripe, we add a reference to its Django PK
@@ -1546,7 +1546,7 @@ class Event(StripeModel):
     def __str__(self):
         return f"type={self.type}, id={self.id}"
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
     ):
         if self.api_version is None:

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -698,7 +698,7 @@ class Source(StripeModel):
         data["source_data"] = data[data["type"]]
         return data
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
     ):
         customer = None
@@ -725,7 +725,7 @@ class Source(StripeModel):
         api_key = self.default_api_key
         try:
             # TODO - we could use the return value of sync_from_stripe_data
-            #  or call its internals - self._sync/_attach_objects_hook etc here
+            #  or call its internals - self._sync/_attach_objects_pre_save_hook etc here
             #  to update `self` at this point?
             self.sync_from_stripe_data(
                 self.api_retrieve(api_key=api_key).detach(), api_key=api_key
@@ -885,7 +885,7 @@ class PaymentMethod(StripeModel):
             return self.customer.get_stripe_dashboard_url()
         return ""
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY, current_ids=None
     ):
         customer = None

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -64,14 +64,14 @@ class WebhookEndpoint(StripeModel):
     def __str__(self):
         return self.url or str(self.djstripe_uuid)
 
-    def _attach_objects_hook(
+    def _attach_objects_pre_save_hook(
         self, cls, data, current_ids=None, api_key=djstripe_settings.STRIPE_SECRET_KEY
     ):
         """
         Gets called by this object's create and sync methods just before save.
         Use this to populate fields before the model is saved.
         """
-        super()._attach_objects_hook(
+        super()._attach_objects_pre_save_hook(
             cls, data, current_ids=current_ids, api_key=api_key
         )
 

--- a/docs/history/2_7_0.md
+++ b/docs/history/2_7_0.md
@@ -19,6 +19,8 @@ the changes, please see the discussion on Github:
 -   The `DJSTRIPE_WEBHOOK_URL` setting is deprecated. It will be removed in dj-stripe
     2.9. It was added to give a way of "hiding" the webhook endpoint URL, but that is no
     longer necessary with the new webhook endpoint system.
+-   `StripeModel._attach_objects_hook` method is deprecated. It will be
+removed in dj-stripe 2.9. It has been replaced with  `StripeModel._attach_objects_pre_save_hook` method.
 
 ## Breaking changes
 

--- a/tests/test_bank_account.py
+++ b/tests/test_bank_account.py
@@ -139,14 +139,14 @@ class BankAccountTest(AssertStripeFksMixin, TestCase):
 
         self.customer = fake_empty_customer.create_for_user(user)
 
-    def test_attach_objects_hook_without_customer(self):
+    def test_attach_objects_pre_save_hook_without_customer(self):
         FAKE_BANK_ACCOUNT_DICT = deepcopy(FAKE_BANK_ACCOUNT_SOURCE)
         FAKE_BANK_ACCOUNT_DICT["customer"] = None
 
         bank_account = BankAccount.sync_from_stripe_data(FAKE_BANK_ACCOUNT_DICT)
         self.assertEqual(bank_account.customer, None)
 
-    def test_attach_objects_hook_without_account(self):
+    def test_attach_objects_pre_save_hook_without_account(self):
         bank_account = BankAccount.sync_from_stripe_data(FAKE_BANK_ACCOUNT_SOURCE)
         self.assertEqual(bank_account.account, None)
 

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -98,14 +98,14 @@ class CardTest(AssertStripeFksMixin, TestCase):
 
         self.customer = fake_empty_customer.create_for_user(user)
 
-    def test_attach_objects_hook_without_customer(self):
+    def test_attach_objects_pre_save_hook_without_customer(self):
         FAKE_CARD_DICT = deepcopy(FAKE_CARD)
         FAKE_CARD_DICT["customer"] = None
 
         card = Card.sync_from_stripe_data(FAKE_CARD_DICT)
         self.assertEqual(card.customer, None)
 
-    def test_attach_objects_hook_without_account(self):
+    def test_attach_objects_pre_save_hook_without_account(self):
         card = Card.sync_from_stripe_data(FAKE_CARD)
         self.assertEqual(card.account, None)
 

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -787,7 +787,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         target="djstripe.models.payment_methods.DjstripePaymentMethod", autospec=True
     )
     @patch(target="djstripe.models.account.Account", autospec=True)
-    def test__attach_objects_hook_missing_source_data(
+    def test__attach_objects_pre_save_hook_missing_source_data(
         self, mock_account, mock_payment_method, mock_charge_source
     ):
         """
@@ -807,7 +807,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         mock_data = {}
         starting_source = charge.source
 
-        charge._attach_objects_hook(cls=mock_cls, data=mock_data)
+        charge._attach_objects_pre_save_hook(cls=mock_cls, data=mock_data)
 
         # source shouldn't be touched
         self.assertEqual(starting_source, charge.source)
@@ -816,7 +816,7 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
         # try again with a source key, but no object sub key.
         mock_data = {"source": {"foo": "bar"}}
 
-        charge._attach_objects_hook(cls=mock_cls, data=mock_data)
+        charge._attach_objects_pre_save_hook(cls=mock_cls, data=mock_data)
 
         # source shouldn't be touched
         self.assertEqual(starting_source, charge.source)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -36,7 +36,7 @@ class SourceTest(AssertStripeFksMixin, TestCase):
         self.customer.sources.all().delete()
         self.customer.legacy_cards.all().delete()
 
-    def test_attach_objects_hook_without_customer(self):
+    def test_attach_objects_pre_save_hook_without_customer(self):
         source = Source.sync_from_stripe_data(deepcopy(FAKE_SOURCE_II))
         self.assertEqual(source.customer, None)
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Replaced  `_attach_objects_hook()` with `_attach_objects_pre_save_hook()` throughout the internal code. The latter name is more intuitive and complements the naming of the other hook `_attach_objects_post_save_hook()`.
2. Updated `_attach_objects_hook()` to raise a `Deprecation` warning to let the users know of this upcoming deprecation.
3. Updated `2.7.0` release docs with this upcoming `Deprecation`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Makes the naming convention of class methods more intuitive.