### PR TITLE
Added  cancel method to SubscriptionSchedule model

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -897,11 +897,22 @@ class SubscriptionScheduleAdmin(StripeModelAdmin):
         )
         return render(request, "djstripe/admin/confirm_action.html", context)
 
+    @admin.display(description="Cancel Selected Subscription Schedules")
+    def _cancel_subscription_schedule(self, request, queryset):
+        """Cancel a SubscriptionSchedule."""
+        context = self.get_admin_action_context(
+            queryset, "_cancel_subscription_schedule", CustomActionForm
+        )
+        return render(request, "djstripe/admin/confirm_action.html", context)
+
     def get_actions(self, request):
         # get all actions
         actions = super().get_actions(request)
         actions["_release_subscription_schedule"] = self.get_action(
             "_release_subscription_schedule"
+        )
+        actions["_cancel_subscription_schedule"] = self.get_action(
+            "_cancel_subscription_schedule"
         )
         return actions
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1900,7 +1900,6 @@ class SubscriptionSchedule(StripeModel):
         releasing it will remove its subscription property and set the subscription’s
         ID to the released_subscription property
         and returns the Released SubscriptionSchedule.
-
         :param api_key: The api key to use for this request.
             Defaults to djstripe_settings.STRIPE_SECRET_KEY.
         :type api_key: string
@@ -1915,6 +1914,30 @@ class SubscriptionSchedule(StripeModel):
             stripe_account = self._get_stripe_account_id(api_key)
 
         stripe_subscription_schedule = self.stripe_class.release(
+            self.id, api_key=api_key, stripe_account=stripe_account, **kwargs
+        )
+
+        return SubscriptionSchedule.sync_from_stripe_data(stripe_subscription_schedule)
+
+    def cancel(self, api_key=None, stripe_account=None, **kwargs):
+        """
+        Cancels a subscription schedule and its associated subscription immediately
+        (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is not_started or active
+        and returns the Canceled SubscriptionSchedule.
+        :param api_key: The api key to use for this request.
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        :param stripe_account: The optional connected account \
+            for which this request is being made.
+        :type stripe_account: string
+        """
+
+        api_key = api_key or self.default_api_key
+        # Prefer passed in stripe_account if set.
+        if not stripe_account:
+            stripe_account = self._get_stripe_account_id(api_key)
+
+        stripe_subscription_schedule = self.stripe_class.cancel(
             self.id, api_key=api_key, stripe_account=stripe_account, **kwargs
         )
 

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -170,3 +170,12 @@ class ConfirmCustomAction(FormView):
                 messages.success(request, f"Successfully Released: {instance}")
             except stripe.error.InvalidRequestError as error:
                 messages.warning(request, error)
+
+    def _cancel_subscription_schedule(self, request, queryset):
+        """Cancel a SubscriptionSchedule."""
+        for subscription_schedule in queryset:
+            try:
+                instance = subscription_schedule.cancel()
+                messages.success(request, f"Successfully Canceled: {instance}")
+            except stripe.error.InvalidRequestError as error:
+                messages.warning(request, error)

--- a/docs/history/2_7_0.md
+++ b/docs/history/2_7_0.md
@@ -30,3 +30,5 @@ the changes, please see the discussion on Github:
 -   Remove support for the `DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS` setting
 -   Added support for releasing `Subscription Schedules` by using the `SubscriptionSchedule.release()` method.
 -   Added support for releasing `Subscription Schedules` from Django-Admin.
+-   Added support for cancelling `Subscription Schedules` by using the `SubscriptionSchedule.cancel()` method.
+-   Added support for cancelling `Subscription Schedules` from Django-Admin.

--- a/tests/fields/admin.py
+++ b/tests/fields/admin.py
@@ -9,15 +9,20 @@ from .models import TestCustomActionModel
 
 @admin.register(TestCustomActionModel)
 class TestCustomActionModelAdmin(StripeModelAdmin):
-
-    # For Subscription model's custom action, _cancel
-    # For SubscriptionSchedule's custom action, _release_subscription_schedule
     def get_actions(self, request):
         # get all actions
         actions = super().get_actions(request)
+
+        # For Subscription model's custom action, _cancel
         actions["_cancel"] = self.get_action("_cancel")
+
+        # For SubscriptionSchedule's custom action, _release_subscription_schedule
         actions["_release_subscription_schedule"] = self.get_action(
             "_release_subscription_schedule"
+        )
+        # For SubscriptionSchedule's custom action, _cancel_subscription_schedule
+        actions["_cancel_subscription_schedule"] = self.get_action(
+            "_cancel_subscription_schedule"
         )
         return actions
 
@@ -32,5 +37,12 @@ class TestCustomActionModelAdmin(StripeModelAdmin):
         """Release a SubscriptionSchedule."""
         context = self.get_admin_action_context(
             queryset, "_release_subscription_schedule", CustomActionForm
+        )
+        return render(request, "djstripe/admin/confirm_action.html", context)
+
+    def _cancel_subscription_schedule(self, request, queryset):
+        """Cancel a SubscriptionSchedule."""
+        context = self.get_admin_action_context(
+            queryset, "_cancel_subscription_schedule", CustomActionForm
         )
         return render(request, "djstripe/admin/confirm_action.html", context)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1271,3 +1271,74 @@ class TestSubscriptionScheduleAdminCustomAction:
 
         # assert user got 200 status code
         assert response.status_code == 200
+
+    def test__cancel_subscription_schedule(
+        self,
+        admin_client,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # get the standard changelist_view url
+        change_url = reverse(
+            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+        )
+
+        data = {
+            "action": "_cancel_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        response = admin_client.post(change_url, data)
+
+        # assert user got 200 status code
+        assert response.status_code == 200

--- a/tests/test_subscription_schedule.py
+++ b/tests/test_subscription_schedule.py
@@ -138,6 +138,7 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
 
         self.assert_fks(schedule, expected_blank_fks=self.default_expected_blank_fks)
 
+
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
@@ -160,6 +161,36 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
             return_value=FAKE_SUBSCRIPTION_SCHEDULE,
         ) as patched__api_update:
             schedule.release()
+
+        patched__api_update.assert_called_once_with(
+            FAKE_SUBSCRIPTION_SCHEDULE["id"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            stripe_account=schedule.djstripe_owner_account.id,
+        )
+
+
+    @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    def test_cancel(
+        self,
+        customer_retrieve_mock,
+        product_retrieve_mock,
+        plan_retrieve_mock,
+    ):
+        schedule = SubscriptionSchedule.sync_from_stripe_data(
+            deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        )
+        with patch.object(
+            stripe.SubscriptionSchedule,
+            "cancel",
+            return_value=FAKE_SUBSCRIPTION_SCHEDULE,
+        ) as patched__api_update:
+            schedule.cancel()
 
         patched__api_update.assert_called_once_with(
             FAKE_SUBSCRIPTION_SCHEDULE["id"],

--- a/tests/test_subscription_schedule.py
+++ b/tests/test_subscription_schedule.py
@@ -138,7 +138,6 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
 
         self.assert_fks(schedule, expected_blank_fks=self.default_expected_blank_fks)
 
-
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
@@ -167,7 +166,6 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             stripe_account=schedule.djstripe_owner_account.id,
         )
-
 
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
     @patch(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -57,6 +57,7 @@ class TestConfirmCustomActionView:
             "_sync_all_instances",
             "_cancel",
             "_release_subscription_schedule",
+            "_cancel_subscription_schedule",
         ],
     )
     def test_get_form_kwargs(self, action_name, admin_user, monkeypatch):
@@ -100,6 +101,7 @@ class TestConfirmCustomActionView:
             "_sync_all_instances",
             "_cancel",
             "_release_subscription_schedule",
+            "_cancel_subscription_schedule",
         ],
     )
     @pytest.mark.parametrize("is_admin_user", [True, False])
@@ -156,6 +158,7 @@ class TestConfirmCustomActionView:
             "_sync_all_instances",
             "_cancel",
             "_release_subscription_schedule",
+            "_cancel_subscription_schedule",
         ],
     )
     @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
@@ -227,6 +230,7 @@ class TestConfirmCustomActionView:
             "_sync_all_instances",
             "_cancel",
             "_release_subscription_schedule",
+            "_cancel_subscription_schedule",
         ],
     )
     @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
@@ -786,6 +790,103 @@ class TestConfirmCustomActionView:
             == "success"
         )
 
+    def test__cancel_subscription_schedule(  # noqa: C901
+        self,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # monkeypatch subscription_schedule.cancel()
+        def mock_subscription_schedule_cancel(*args, **keywargs):
+            return instance
+
+        monkeypatch.setattr(instance, "cancel", mock_subscription_schedule_cancel)
+
+        data = {
+            "action": "_cancel_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        kwargs = {
+            "action_name": "_cancel_subscription_schedule",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the Custom Actions
+        view._cancel_subscription_schedule(request, [instance])
+
+        # assert correct Success messages are emmitted
+        messages_sent_dictionary = {
+            m.message: m.level_tag for m in messages.get_messages(request)
+        }
+
+        # assert correct success message was emmitted
+        assert (
+            messages_sent_dictionary.get(f"Successfully Canceled: {instance}")
+            == "success"
+        )
+
     def test__release_subscription_schedule_stripe_invalid_request_error(  # noqa: C901
         self,
         monkeypatch,
@@ -872,3 +973,90 @@ class TestConfirmCustomActionView:
         with pytest.warns(None, match=r"some random error message"):
             # Invoke the Custom Actions
             view._release_subscription_schedule(request, [instance])
+
+    def test__cancel_subscription_schedule_stripe_invalid_request_error(  # noqa: C901
+        self,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # monkeypatch subscription_schedule.cancel()
+        def mock_subscription_schedule_cancel(*args, **keywargs):
+            raise stripe.error.InvalidRequestError({}, "some random error message")
+
+        monkeypatch.setattr(instance, "cancel", mock_subscription_schedule_cancel)
+
+        data = {
+            "action": "_cancel_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        kwargs = {
+            "action_name": "_cancel_subscription_schedule",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        with pytest.warns(None, match=r"some random error message"):
+            # Invoke the Custom Actions
+            view._cancel_subscription_schedule(request, [instance])


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `cancel()` method to `SubscriptionSchedule` model.
2. Added `SubscriptionScheduleAdmin` to expose SubscriptionSchedule object on the admin.
3. Added a `_cancel_subscription_schedule` Custom Django Action to `SubscriptionSchedule`. This would allow the user to select and `cancel` SubscriptionSchedules from the admin like they can cancel Subscriptions.
4. Updated `Release Docs` with changes contained in this PR.
5. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve project parity with `Stripe`.