### PR TITLE
Added  release method to SubscriptionSchedule model

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -857,6 +857,22 @@ class SubscriptionScheduleAdmin(StripeModelAdmin):
     list_filter = ("status", "subscription", "customer")
     list_select_related = ("customer", "customer__subscriber", "subscription")
 
+    @admin.display(description="Release Selected Subscription Schedules")
+    def _release_subscription_schedule(self, request, queryset):
+        """Release a SubscriptionSchedule."""
+        context = self.get_admin_action_context(
+            queryset, "_release_subscription_schedule", CustomActionForm
+        )
+        return render(request, "djstripe/admin/confirm_action.html", context)
+
+    def get_actions(self, request):
+        # get all actions
+        actions = super().get_actions(request)
+        actions["_release_subscription_schedule"] = self.get_action(
+            "_release_subscription_schedule"
+        )
+        return actions
+
 
 @admin.register(models.TaxRate)
 class TaxRateAdmin(StripeModelAdmin):

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -851,6 +851,13 @@ class SubscriptionAdmin(StripeModelAdmin):
             return ", ".join(result)
 
 
+@admin.register(models.SubscriptionSchedule)
+class SubscriptionScheduleAdmin(StripeModelAdmin):
+    list_display = ("status", "subscription", "current_phase", "customer")
+    list_filter = ("status", "subscription", "customer")
+    list_select_related = ("customer", "customer__subscriber", "subscription")
+
+
 @admin.register(models.TaxRate)
 class TaxRateAdmin(StripeModelAdmin):
     list_display = ("active", "display_name", "inclusive", "jurisdiction", "percentage")

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1890,6 +1890,35 @@ class SubscriptionSchedule(StripeModel):
         help_text="ID of the subscription managed by the subscription schedule.",
     )
 
+    def release(self, api_key=None, stripe_account=None, **kwargs):
+        """
+        Releases the subscription schedule immediately, which will stop scheduling
+        of its phases, but leave any existing subscription in place.
+        A schedule can only be released if its status is not_started or active.
+        If the subscription schedule is currently associated with a subscription,
+        releasing it will remove its subscription property and set the subscription’s
+        ID to the released_subscription property
+        and returns the Released SubscriptionSchedule.
+
+        :param api_key: The api key to use for this request.
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        :param stripe_account: The optional connected account \
+            for which this request is being made.
+        :type stripe_account: string
+        """
+
+        api_key = api_key or self.default_api_key
+        # Prefer passed in stripe_account if set.
+        if not stripe_account:
+            stripe_account = self._get_stripe_account_id(api_key)
+
+        stripe_subscription_schedule = self.stripe_class.release(
+            self.id, api_key=api_key, stripe_account=stripe_account, **kwargs
+        )
+
+        return SubscriptionSchedule.sync_from_stripe_data(stripe_subscription_schedule)
+
 
 class TaxId(StripeModel):
     """

--- a/djstripe/views.py
+++ b/djstripe/views.py
@@ -161,3 +161,12 @@ class ConfirmCustomAction(FormView):
                 messages.success(request, f"Successfully Canceled: {instance}")
             except stripe.error.InvalidRequestError as error:
                 messages.warning(request, error)
+
+    def _release_subscription_schedule(self, request, queryset):
+        """Release a SubscriptionSchedule."""
+        for subscription_schedule in queryset:
+            try:
+                instance = subscription_schedule.release()
+                messages.success(request, f"Successfully Released: {instance}")
+            except stripe.error.InvalidRequestError as error:
+                messages.warning(request, error)

--- a/docs/history/2_7_0.md
+++ b/docs/history/2_7_0.md
@@ -28,3 +28,5 @@ the changes, please see the discussion on Github:
 
 -   Remove support for the deprecated `DJSTRIPE_SUBSCRIPTION_REDIRECT` setting
 -   Remove support for the `DJSTRIPE_SUBSCRIPTION_REQUIRED_EXCEPTION_URLS` setting
+-   Added support for releasing `Subscription Schedules` by using the `SubscriptionSchedule.release()` method.
+-   Added support for releasing `Subscription Schedules` from Django-Admin.

--- a/tests/fields/admin.py
+++ b/tests/fields/admin.py
@@ -11,14 +11,26 @@ from .models import TestCustomActionModel
 class TestCustomActionModelAdmin(StripeModelAdmin):
 
     # For Subscription model's custom action, _cancel
+    # For SubscriptionSchedule's custom action, _release_subscription_schedule
     def get_actions(self, request):
         # get all actions
         actions = super().get_actions(request)
         actions["_cancel"] = self.get_action("_cancel")
+        actions["_release_subscription_schedule"] = self.get_action(
+            "_release_subscription_schedule"
+        )
         return actions
 
     @admin.action(description="Cancel selected subscriptions")
     def _cancel(self, request, queryset):
         """Cancel a subscription."""
         context = self.get_admin_action_context(queryset, "_cancel", CustomActionForm)
+        return render(request, "djstripe/admin/confirm_action.html", context)
+
+    @admin.display(description="Release Selected Subscription Schedules")
+    def _release_subscription_schedule(self, request, queryset):
+        """Release a SubscriptionSchedule."""
+        context = self.get_admin_action_context(
+            queryset, "_release_subscription_schedule", CustomActionForm
+        )
         return render(request, "djstripe/admin/confirm_action.html", context)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -30,6 +30,7 @@ from tests import (
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_SCHEDULE,
 )
 
 from .fields.models import TestCustomActionModel
@@ -1162,6 +1163,79 @@ class TestSubscriptionAdminCustomAction:
         )
 
         data = {"action": "_cancel", helpers.ACTION_CHECKBOX_NAME: [instance.pk]}
+
+        response = admin_client.post(change_url, data)
+
+        # assert user got 200 status code
+        assert response.status_code == 200
+
+
+class TestSubscriptionScheduleAdminCustomAction:
+    def test__release_subscription_schedule(
+        self,
+        admin_client,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # get the standard changelist_view url
+        change_url = reverse(
+            f"admin:{model._meta.app_label}_{model.__name__.lower()}_changelist"
+        )
+
+        data = {
+            "action": "_release_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
 
         response = admin_client.post(change_url, data)
 

--- a/tests/test_subscription_schedule.py
+++ b/tests/test_subscription_schedule.py
@@ -4,12 +4,13 @@ dj-stripe SubscriptionSchedule model tests.
 from copy import deepcopy
 from unittest.mock import patch
 
+import stripe
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from djstripe.enums import SubscriptionScheduleStatus
-from djstripe.models import SubscriptionSchedule
-from djstripe.models.billing import Invoice
+from djstripe.models import Invoice, SubscriptionSchedule
+from djstripe.settings import djstripe_settings
 
 from . import (
     FAKE_BALANCE_TRANSACTION,
@@ -136,3 +137,32 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
         self.assertEqual(f"<id={FAKE_SUBSCRIPTION_SCHEDULE['id']}>", str(schedule))
 
         self.assert_fks(schedule, expected_blank_fks=self.default_expected_blank_fks)
+
+    @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+    @patch(
+        "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    def test_release(
+        self,
+        customer_retrieve_mock,
+        product_retrieve_mock,
+        plan_retrieve_mock,
+    ):
+        schedule = SubscriptionSchedule.sync_from_stripe_data(
+            deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        )
+        with patch.object(
+            stripe.SubscriptionSchedule,
+            "release",
+            return_value=FAKE_SUBSCRIPTION_SCHEDULE,
+        ) as patched__api_update:
+            schedule.release()
+
+        patched__api_update.assert_called_once_with(
+            FAKE_SUBSCRIPTION_SCHEDULE["id"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            stripe_account=schedule.djstripe_owner_account.id,
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -27,6 +27,7 @@ from tests import (
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_SCHEDULE,
 )
 
 from .fields.models import TestCustomActionModel
@@ -50,7 +51,13 @@ class TestConfirmCustomActionView:
         return None
 
     @pytest.mark.parametrize(
-        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+        "action_name",
+        [
+            "_resync_instances",
+            "_sync_all_instances",
+            "_cancel",
+            "_release_subscription_schedule",
+        ],
     )
     def test_get_form_kwargs(self, action_name, admin_user, monkeypatch):
 
@@ -87,7 +94,13 @@ class TestConfirmCustomActionView:
         assert form_kwargs.get("action_name") == action_name
 
     @pytest.mark.parametrize(
-        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+        "action_name",
+        [
+            "_resync_instances",
+            "_sync_all_instances",
+            "_cancel",
+            "_release_subscription_schedule",
+        ],
     )
     @pytest.mark.parametrize("is_admin_user", [True, False])
     def test_dispatch(self, is_admin_user, action_name, admin_user, monkeypatch):
@@ -137,7 +150,13 @@ class TestConfirmCustomActionView:
             )
 
     @pytest.mark.parametrize(
-        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+        "action_name",
+        [
+            "_resync_instances",
+            "_sync_all_instances",
+            "_cancel",
+            "_release_subscription_schedule",
+        ],
     )
     @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
     def test_form_valid(self, djstripe_owner_account_exists, action_name, monkeypatch):
@@ -202,7 +221,13 @@ class TestConfirmCustomActionView:
         assert response.url == "/admin/fields/testcustomactionmodel/"
 
     @pytest.mark.parametrize(
-        "action_name", ["_resync_instances", "_sync_all_instances", "_cancel"]
+        "action_name",
+        [
+            "_resync_instances",
+            "_sync_all_instances",
+            "_cancel",
+            "_release_subscription_schedule",
+        ],
     )
     @pytest.mark.parametrize("djstripe_owner_account_exists", [False, True])
     def test_form_invalid(
@@ -663,3 +688,187 @@ class TestConfirmCustomActionView:
         with pytest.warns(None, match=r"some random error message"):
             # Invoke the Custom Actions
             view._cancel(request, [instance])
+
+    def test__release_subscription_schedule(  # noqa: C901
+        self,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # monkeypatch subscription_schedule.release()
+        def mock_subscription_schedule_release(*args, **keywargs):
+            return instance
+
+        monkeypatch.setattr(instance, "release", mock_subscription_schedule_release)
+
+        data = {
+            "action": "_release_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        kwargs = {
+            "action_name": "_release_subscription_schedule",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        # Invoke the Custom Actions
+        view._release_subscription_schedule(request, [instance])
+
+        # assert correct Success messages are emmitted
+        messages_sent_dictionary = {
+            m.message: m.level_tag for m in messages.get_messages(request)
+        }
+
+        # assert correct success message was emmitted
+        assert (
+            messages_sent_dictionary.get(f"Successfully Released: {instance}")
+            == "success"
+        )
+
+    def test__release_subscription_schedule_stripe_invalid_request_error(  # noqa: C901
+        self,
+        monkeypatch,
+    ):
+        def mock_balance_transaction_get(*args, **kwargs):
+            return FAKE_BALANCE_TRANSACTION
+
+        def mock_subscription_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION
+
+        def mock_charge_get(*args, **kwargs):
+            return FAKE_CHARGE
+
+        def mock_payment_method_get(*args, **kwargs):
+            return FAKE_CARD_AS_PAYMENT_METHOD
+
+        def mock_payment_intent_get(*args, **kwargs):
+            return FAKE_PAYMENT_INTENT_I
+
+        def mock_product_get(*args, **kwargs):
+            return FAKE_PRODUCT
+
+        def mock_invoice_get(*args, **kwargs):
+            return FAKE_INVOICE
+
+        def mock_customer_get(*args, **kwargs):
+            return FAKE_CUSTOMER
+
+        def mock_plan_get(*args, **kwargs):
+            return FAKE_PLAN
+
+        # monkeypatch stripe retrieve calls to return
+        # the desired json response.
+        monkeypatch.setattr(
+            stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
+        )
+        monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
+
+        monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
+        monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
+        monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
+
+        monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
+
+        monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
+
+        # create latest invoice
+        models.Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        model = models.SubscriptionSchedule
+        subscription_schedule_fake = deepcopy(FAKE_SUBSCRIPTION_SCHEDULE)
+        instance = model.sync_from_stripe_data(subscription_schedule_fake)
+
+        # monkeypatch subscription_schedule.release()
+        def mock_subscription_schedule_release(*args, **keywargs):
+            raise stripe.error.InvalidRequestError({}, "some random error message")
+
+        monkeypatch.setattr(instance, "release", mock_subscription_schedule_release)
+
+        data = {
+            "action": "_release_subscription_schedule",
+            helpers.ACTION_CHECKBOX_NAME: [instance.pk],
+        }
+
+        kwargs = {
+            "action_name": "_release_subscription_schedule",
+            "model_name": model.__name__.lower(),
+        }
+
+        # get the custom action POST url
+        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+
+        request = RequestFactory().post(change_url, data=data, follow=True)
+
+        # Add the session/message middleware to the request
+        SessionMiddleware(self.dummy_get_response).process_request(request)
+        MessageMiddleware(self.dummy_get_response).process_request(request)
+
+        view = ConfirmCustomAction()
+        view.setup(request, **kwargs)
+
+        with pytest.warns(None, match=r"some random error message"):
+            # Invoke the Custom Actions
+            view._release_subscription_schedule(request, [instance])


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `release()` method to `SubscriptionSchedule` model.
2. Added `SubscriptionScheduleAdmin` to expose SubscriptionSchedule object on the admin.
3. Added a `_release_subscription_schedule` Custom Django Action to `SubscriptionSchedule`. This would allow the user to select and `release` SubscriptionSchedules from the admin like they can cancel Subscriptions.
4. Updated `Release Docs` with changes contained in this PR.
5. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve project parity with `Stripe`.