### PR TITLE
Added SubscriptionSchedule Admin Inline

### DIFF
--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -833,7 +833,7 @@ class SubscriptionAdmin(StripeModelAdmin):
     list_display = ("customer", "status", "get_default_tax_rates")
     list_filter = ("status", "cancel_at_period_end")
 
-    inlines = (SubscriptionItemInline,)
+    inlines = (SubscriptionItemInline, SubscriptionScheduleInline)
 
     def get_actions(self, request):
         # get all actions

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -521,7 +521,7 @@ class CustomerAdmin(StripeModelAdmin):
         "deleted",
     )
     search_fields = ("email", "description", "deleted")
-    inlines = (SubscriptionInline, TaxIdInline)
+    inlines = (SubscriptionInline, SubscriptionScheduleInline, TaxIdInline)
 
     def get_queryset(self, request):
         return (

--- a/djstripe/admin.py
+++ b/djstripe/admin.py
@@ -322,6 +322,24 @@ class SubscriptionInline(admin.StackedInline):
     show_change_link = True
 
 
+class SubscriptionScheduleInline(admin.StackedInline):
+    """A TabularInline for use models.SubscriptionSchedule."""
+
+    model = models.SubscriptionSchedule
+    extra = 0
+    readonly_fields = ("id", "created", "djstripe_owner_account")
+    raw_id_fields = get_forward_relation_fields_for_model(model)
+    show_change_link = True
+
+    def __init__(self, parent_model, admin_site):
+        super().__init__(parent_model, admin_site)
+
+        # dynamically set fk_name as SubscriptionScheduleInline is used
+        # in CustomerAdmin as well as SubscriptionAdmin
+        if parent_model is models.Subscription:
+            self.fk_name = "subscription"
+
+
 class TaxIdInline(admin.TabularInline):
     """A TabularInline for use models.Subscription."""
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1823,6 +1823,7 @@ class SubscriptionSchedule(StripeModel):
     """
 
     stripe_class = stripe.SubscriptionSchedule
+    stripe_dashboard_item_name = "subscription_schedules"
 
     canceled_at = StripeDateTimeField(
         null=True,


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added `stripe_dashboard_item_name` attribute to the `SubscriptionSchedule` model, so that the correct Dashboard URL can be created.
2. Added a `SubscriptionScheduleInline` Stackedinline model. This admin model would be used with the Customer and Subscription Admin Views.
3. Added `SubscriptionScheduleInline` to `CustomerAdmin`
4. Added `SubscriptionScheduleInline` to `SubscriptionAdmin`


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will improve project parity with `Stripe`.