### PR TITLE
Added Custom Header to get the webhook signing secret of the stripe cli

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -295,7 +295,14 @@ class WebhookEventTrigger(models.Model):
             # HTTP headers are case-insensitive, but we store them as a dict.
             headers = CaseInsensitiveMapping(self.headers)
             signature = headers.get("stripe-signature")
+            local_cli_signing_secret = headers.get("x-djstripe-webhook-secret")
             try:
+                # check if the x-djstripe-webhook-secret Custom Header exists
+                if local_cli_signing_secret:
+                    # Set Endpoint Signing Secret to the output of Stripe CLI
+                    # for signature verification
+                    secret = local_cli_signing_secret
+
                 stripe.WebhookSignature.verify_header(
                     self.body, signature, secret, tolerance
                 )

--- a/docs/usage/local_webhook_testing.md
+++ b/docs/usage/local_webhook_testing.md
@@ -1,0 +1,29 @@
+# Local Webhook Testing
+
+To perform local webhook testing using the `Stripe CLI`, please do the following:
+
+1. Set `-H` to `x-djstripe-webhook-secret` Custom Header in Stripe `listen` to the `Webhook Signing Secret` output of `Stripe CLI`. That is what Stripe expects and uses to create the `stripe-signature` header. Without that `webhook` validation will fail and you would get a `400` status code.
+
+2. Set `--forward-to` to the `URL` you want stripe to forward the request to. New Style `UUID` urls are also supported from `v2.7` onwards.
+
+3. Start the local `Stripe` server like so:
+
+  ```bash
+
+  stripe listen -H "x-djstripe-webhook-secret: <STRIPE_CLI_WEBHOOK_SIGNING_SECRET_OUTPUT>" --forward-to <URL>
+
+```
+
+4. `Stripe` events can now be triggered like so:
+
+```bash
+
+stripe trigger customer.created
+
+```
+
+```
+
+!!! note
+
+    In case the `Stripe CLI` is used to perform local webhook testing, set `-H` to `x-djstripe-webhook-secret` Custom Header in Stripe `listen` to the `Webhook Signing Secret` output of `Stripe CLI`. That is what Stripe expects and uses to create the `stripe-signature` header.

--- a/docs/usage/using_with_docker.md
+++ b/docs/usage/using_with_docker.md
@@ -52,7 +52,8 @@ services:
 
   stripe:
     image: stripe/stripe-cli:v1.7.4
-    command: listen --forward-to http://web:8000/djstripe/webhook/
+    # In case Stripe CLI is used to perform local webhook testing, set x-djstripe-webhook-secret custom header to output of Stripe CLI.
+    command: ["listen", "-H", "x-djstripe-webhook-secret: whsec_******", "--forward-to", "http://web:8000/djstripe/webhook/"] 
     depends_on:
       - web
     environment:
@@ -63,4 +64,4 @@ services:
 
 !!! note
 
-    stripe expects the `WEBHOOK ENDPOINT SIGNING SECRET (whsec_...)` to match the output of `stripe CLI`.
+    In case the `Stripe CLI` is used to perform local webhook testing, set `x-djstripe-webhook-secret` Custom Header in Stripe `listen` to the `Webhook Signing Secret` output of `Stripe CLI`. That is what Stripe expects and uses to create the `stripe-signature` header.


### PR DESCRIPTION

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added Custom Header to get the webhook signing secret of the stripe cli. `X-Djstripe-Local-Cli-Signing-Secret` needs to be set equal to the webhook signing secret of the stripe cli as that is what stripe expects for local webhook testing. Failure to do so would result in a failed `webhook signature validation`. `Note Stripe expects ALL webhooks to have the same secret as the one outputted by the CLI.`
2. Added `docs` ensuring that users correctly configure `stripe listen`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`Djstripe` will remain useable for local `webhook` testing after the `multiple webhook endpoints` release.