### PR TITLE
Fixed minor type in StripeModel._stripe_object_to_record()

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -323,10 +323,10 @@ class StripeModel(StripeBaseModel):
 
         manipulated_data = cls._manipulate_stripe_object_hook(data)
 
-        if not cls.is_valid_object(data):
+        if not cls.is_valid_object(manipulated_data):
             raise ValueError(
                 "Trying to fit a %r into %r. Aborting."
-                % (data.get("object", ""), cls.__name__)
+                % (manipulated_data.get("object", ""), cls.__name__)
             )
 
         result = {}


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed minor type in `StripeModel._stripe_object_to_record()`. `manipulated_data` object had to be passed into the `is_valid_object()` check instead of the `data` object.
 

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.
