### PR TITLE
Added support for sync of Customer Attached Source Objects

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -68,6 +68,7 @@ class Command(BaseCommand):
         if not hasattr(model.stripe_class, "list"):
             if model in (
                 models.ApplicationFeeRefund,
+                models.Source,
                 models.TransferReversal,
                 models.TaxId,
                 models.UsageRecordSummary,
@@ -219,6 +220,22 @@ class Command(BaseCommand):
         return all_list_kwargs
 
     @staticmethod
+    def get_list_kwargs_src(default_list_kwargs):
+        """Returns sequence of kwargs to sync Sources for
+        all Stripe Accounts"""
+
+        all_list_kwargs = []
+        for def_kwarg in default_list_kwargs:
+            stripe_account = def_kwarg.get("stripe_account")
+            api_key = def_kwarg.get("api_key")
+            for stripe_customer in models.Customer.api_list(
+                stripe_account=stripe_account, api_key=api_key
+            ):
+                all_list_kwargs.append({"id": stripe_customer.id, **def_kwarg})
+
+        return all_list_kwargs
+
+    @staticmethod
     def get_list_kwargs_si(default_list_kwargs):
         """Returns sequence of kwrags to sync Subscription Items for
         all Stripe Accounts"""
@@ -322,6 +339,7 @@ class Command(BaseCommand):
 
         list_kwarg_handlers_dict = {
             "PaymentMethod": self.get_list_kwargs_pm,
+            "Source": self.get_list_kwargs_src,
             "SubscriptionItem": self.get_list_kwargs_si,
             "CountrySpec": self.get_list_kwargs_country_spec,
             "TransferReversal": self.get_list_kwargs_trr,

--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -741,6 +741,20 @@ class Source(StripeModel):
             )
             return False
 
+    @classmethod
+    def api_list(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):
+        """
+        Call the stripe API's list operation for this model.
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        See Stripe documentation for accepted kwargs for each object.
+        :returns: an iterator over all items in the query
+        """
+        return Customer.stripe_class.list_sources(
+            object="source", api_key=api_key, **kwargs
+        ).auto_paging_iter()
+
 
 class PaymentMethod(StripeModel):
     """


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added a custom `api_list()` classmethod as stripe only allows to retrieve `Source` objects attached to `Customers`. 
2. Updated the `djstripe_sync_models` management command to allow `Customer` attached `Source` objects to get synced.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Customer Attached `Source` models will now get synced correctly.