### PR TITLE
Updated Admin Custom Action to leverage built in functionality

### DIFF
--- a/djstripe/admin/actions.py
+++ b/djstripe/admin/actions.py
@@ -5,10 +5,11 @@ from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import quote
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils.html import format_html
 from django.utils.text import capfirst
 
+from . import views
 from .forms import CustomActionForm
 
 
@@ -17,6 +18,16 @@ class CustomActionMixin:
     # So that actions get shown even if there are 0 instances
     # https://docs.djangoproject.com/en/dev/ref/contrib/admin/#django.contrib.admin.ModelAdmin.show_full_result_count
     show_full_result_count = False
+
+    def get_urls(self):
+        custom_urls = [
+            path(
+                "action/<str:action_name>/<str:model_name>/",
+                self.admin_site.admin_view(views.ConfirmCustomAction.as_view()),
+                name="djstripe_custom_action",
+            ),
+        ]
+        return custom_urls + super().get_urls()
 
     def get_admin_action_context(self, queryset, action_name, form_class):
 

--- a/djstripe/admin/views.py
+++ b/djstripe/admin/views.py
@@ -9,7 +9,6 @@ from django.contrib.admin import helpers, site
 from django.core.management import call_command
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.encoding import iri_to_uri
 from django.views.generic import FormView
 
 from djstripe import utils
@@ -22,13 +21,6 @@ logger = logging.getLogger(__name__)
 class ConfirmCustomAction(FormView):
     template_name = "djstripe/admin/confirm_action.html"
     form_class = CustomActionForm
-
-    def dispatch(self, request, *args, **kwargs):
-        if not (request.user.is_authenticated and request.user.is_staff):
-            return HttpResponseRedirect(
-                reverse("admin:login") + f"?next={iri_to_uri(request.path_info)}"
-            )
-        return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
         model_name = self.kwargs.get("model_name")

--- a/djstripe/templates/djstripe/admin/confirm_action.html
+++ b/djstripe/templates/djstripe/admin/confirm_action.html
@@ -58,7 +58,7 @@
             {% endfor %}
         </ul>
 
-        <form id="form_custom_action" method="post" onsubmit="django.jQuery('#main_content').hide(); django.jQuery('.messagelist').hide(); django.jQuery('#div_spinner').show();" action="{% url 'djstripe:djstripe_custom_action' action_name=action_name model_name=model_name %}">
+        <form id="form_custom_action" method="post" onsubmit="django.jQuery('#main_content').hide(); django.jQuery('.messagelist').hide(); django.jQuery('#div_spinner').show();" action="{% url 'admin:djstripe_custom_action' action_name=action_name model_name=model_name %}">
             {% csrf_token %}
             {{form}}
 

--- a/djstripe/urls.py
+++ b/djstripe/urls.py
@@ -28,9 +28,4 @@ urlpatterns = [
         views.ProcessWebhookView.as_view(),
         name="djstripe_webhook_by_uuid",
     ),
-    path(
-        "action/<str:action_name>/<str:model_name>/",
-        admin_views.ConfirmCustomAction.as_view(),
-        name="djstripe_custom_action",
-    ),
 ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -8,7 +8,6 @@ import stripe
 from django.apps import apps
 from django.contrib import messages
 from django.contrib.admin import helpers, site
-from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test.client import RequestFactory
@@ -76,7 +75,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().get(change_url)
         # add the admin user to the mocked request
@@ -93,63 +92,6 @@ class TestConfirmCustomActionView:
         form_kwargs = view.get_form_kwargs()
         assert form_kwargs.get("model_name") == model.__name__.lower()
         assert form_kwargs.get("action_name") == action_name
-
-    @pytest.mark.parametrize(
-        "action_name",
-        [
-            "_resync_instances",
-            "_sync_all_instances",
-            "_cancel",
-            "_release_subscription_schedule",
-            "_cancel_subscription_schedule",
-        ],
-    )
-    @pytest.mark.parametrize("is_admin_user", [True, False])
-    def test_dispatch(self, is_admin_user, action_name, admin_user, monkeypatch):
-
-        model = TestCustomActionModel
-
-        # monkeypatch utils.get_model
-        def mock_get_model(*args, **kwargs):
-            return model
-
-        monkeypatch.setattr(utils, "get_model", mock_get_model)
-
-        kwargs = {
-            "action_name": action_name,
-            "model_name": model.__name__.lower(),
-        }
-
-        # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
-
-        request = RequestFactory().get(change_url)
-
-        if is_admin_user:
-            # add the admin user to the mocked request
-            request.user = admin_user
-        else:
-            # add the AnonymousUser to the mocked request
-            request.user = AnonymousUser()
-
-        # Add the session/message middleware to the request
-        SessionMiddleware(self.dummy_get_response).process_request(request)
-        MessageMiddleware(self.dummy_get_response).process_request(request)
-
-        view = ConfirmCustomAction()
-        view.setup(request, **kwargs)
-
-        # Invoke the dispatch method
-        response = view.dispatch(request)
-
-        if is_admin_user:
-            assert response.status_code == 200
-        else:
-            assert response.status_code == 302
-            assert (
-                response.url
-                == f"/admin/login/?next=/djstripe/action/{action_name}/testcustomactionmodel/"
-            )
 
     @pytest.mark.parametrize(
         "action_name",
@@ -193,7 +135,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -263,7 +205,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -320,7 +262,7 @@ class TestConfirmCustomActionView:
 
                 # get the custom action POST url
                 change_url = reverse(
-                    "djstripe:djstripe_custom_action",
+                    "admin:djstripe_custom_action",
                     kwargs=kwargs,
                 )
 
@@ -390,7 +332,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -453,7 +395,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -502,7 +444,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -586,7 +528,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -678,7 +620,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -765,7 +707,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -862,7 +804,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -959,7 +901,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 
@@ -1046,7 +988,7 @@ class TestConfirmCustomActionView:
         }
 
         # get the custom action POST url
-        change_url = reverse("djstripe:djstripe_custom_action", kwargs=kwargs)
+        change_url = reverse("admin:djstripe_custom_action", kwargs=kwargs)
 
         request = RequestFactory().post(change_url, data=data, follow=True)
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Overrode `admin.ModelAdmin.get_urls()`. This was done to re-use django's built in admin view functionality.
2. Removed redundant `ConfirmCustomAction.dispatch()` as admin_site.admin_view() automatically prevents unauthorised access.
3. Updated Corresponding Tests.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

This PR is essentially a rewrite of the commit: 4744fbccab484140b7b5488dff6057e09119338f
as it would reduce the code to achieve the same functionality. 