### PR TITLE
Fixed StripeModel.human_readable_amount()

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -124,7 +124,7 @@ class StripeModel(StripeBaseModel):
 
     @property
     def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount, self.currency)
+        return get_friendly_currency_amount(self.amount / 100, self.currency)
 
     @property
     def default_api_key(self) -> str:

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -106,10 +106,6 @@ class BalanceTransaction(StripeModel):
     def get_stripe_dashboard_url(self):
         return self.get_source_instance().get_stripe_dashboard_url()
 
-    @property
-    def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount / 100, self.currency)
-
 
 class Charge(StripeModel):
     """
@@ -1503,10 +1499,6 @@ class Dispute(StripeModel):
                 stripe_balance_transaction, api_key=api_key
             )
 
-    @property
-    def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount / 100, self.currency)
-
 
 class Event(StripeModel):
     """
@@ -1913,10 +1905,6 @@ class PaymentIntent(StripeModel):
         api_key = api_key or self.default_api_key
 
         return self.api_retrieve(api_key=api_key).confirm(**kwargs)
-
-    @property
-    def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount / 100, self.currency)
 
 
 class SetupIntent(StripeModel):

--- a/tests/fixtures/webhook_endpoint_fake0001.json
+++ b/tests/fixtures/webhook_endpoint_fake0001.json
@@ -1,7 +1,5 @@
 {
-    "djstripe_id": 1,
     "id": "we_1Jto4CJSZQVUcJYgJKJPEBll",
-    "djstripe_owner_account": 1,
     "livemode": false,
     "metadata": {
         "djstripe_uuid": "f6f9aa0e-cb6c-4e0f-b5ee-5e2b9e0716d8"

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -74,26 +74,26 @@ class ChargeTest(AssertStripeFksMixin, TestCase):
             captured=False,
             paid=False,
         )
-        self.assertEqual(str(charge), "$50.00 USD (Uncaptured)")
+        self.assertEqual(str(charge), "$0.50 USD (Uncaptured)")
 
         charge.captured = True
-        self.assertEqual(str(charge), "$50.00 USD (Failed)")
+        self.assertEqual(str(charge), "$0.50 USD (Failed)")
         charge.status = ChargeStatus.succeeded
 
         charge.disputed = True
-        self.assertEqual(str(charge), "$50.00 USD (Disputed)")
+        self.assertEqual(str(charge), "$0.50 USD (Disputed)")
 
         charge.disputed = False
         charge.refunded = True
         charge.amount_refunded = 50
-        self.assertEqual(str(charge), "$50.00 USD (Refunded)")
+        self.assertEqual(str(charge), "$0.50 USD (Refunded)")
 
         charge.refunded = False
         charge.amount_refunded = 0
-        self.assertEqual(str(charge), "$50.00 USD (Succeeded)")
+        self.assertEqual(str(charge), "$0.50 USD (Succeeded)")
 
         charge.status = ChargeStatus.pending
-        self.assertEqual(str(charge), "$50.00 USD (Pending)")
+        self.assertEqual(str(charge), "$0.50 USD (Pending)")
 
     @patch(
         "djstripe.models.Account.get_default_account",

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -8,9 +8,7 @@ import pytest
 import stripe
 from django.test import TestCase
 
-from djstripe.enums import PaymentIntentStatus
-from djstripe.models import Account, Customer, PaymentIntent
-from djstripe.utils import get_friendly_currency_amount
+from djstripe.models import PaymentIntent
 
 from . import (
     FAKE_ACCOUNT,


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed `StripeModel.human_readable_amount()` to use `amount / 100` as Stripe returns `Amount` for all models in the lowest currency unit, which would always be a multiple of 100.
2. Removed unnecessary overrides for `StripeModel.human_readable_amount()` in the `BalanceTransaction`, `Dispute`, and `PaymentIntent` models.
3. Updated Corresponding Tests.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Will make the code more maintainable.