### PR TITLE
Updated validate_stripe_api_version check to allow for beta Stripe API Versions

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -1,8 +1,13 @@
 """
 dj-stripe System Checks
 """
+import re
+
 from django.core import checks
-from django.utils.dateparse import date_re
+
+STRIPE_API_VERSION_PATTERN = re.compile(
+    r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})(; [\w=]*)?$"
+)
 
 
 @checks.register("djstripe")
@@ -34,13 +39,15 @@ def validate_stripe_api_version(version):
     """
     Check the API version is formatted correctly for Stripe.
 
-    The expected format is an iso8601 date: `YYYY-MM-DD`
+    The expected format is `YYYY-MM-DD` (an iso8601 date) or
+    for access to alphs or beta releases the expected format is: `YYYY-MM-DD; modelname_version=version_number`.
+    Ex "2020-08-27; orders_beta=v3"
 
     :param version: The version to set for the Stripe API.
     :type version: ``str``
     :returns bool: Whether the version is formatted correctly.
     """
-    return date_re.match(version)
+    return re.match(STRIPE_API_VERSION_PATTERN, version)
 
 
 @checks.register("djstripe")


### PR DESCRIPTION

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `validate_stripe_api_version` check to allow for `beta/alpha` Stripe API Versions.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

`dj-stripe` will work when a user sets the `Stripe API Version` of the format `2020-08-27; orders_beta=v3`