### PR TITLE
Updated Subscription.__str__ to check for null products

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1510,7 +1510,7 @@ class Subscription(StripeModel):
         products_lst = [
             subscription.plan.product.name
             for subscription in subscriptions_lst
-            if subscription and subscription.plan
+            if subscription and subscription.plan and subscription.plan.product
         ]
 
         return f"{self.customer} on {' and '.join(products_lst)}"


### PR DESCRIPTION
This is because subscription associated plans can have null products.

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed Subscription.__str__ to not error out if the subscription associated plan's product is `null`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

