### PR TITLE
Removed Redundant human_readable_amount property from Child Classes of StripeModel.

### DIFF
--- a/djstripe/models/connect.py
+++ b/djstripe/models/connect.py
@@ -1,8 +1,6 @@
 import stripe
 from django.db import models
 
-from djstripe.utils import get_friendly_currency_amount
-
 from .. import enums
 from ..fields import (
     JSONField,
@@ -251,10 +249,6 @@ class Transfer(StripeModel):
             return f"{self.human_readable_amount} Partially Reversed"
         # No Reversal
         return f"{self.human_readable_amount}"
-
-    @property
-    def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount / 100, self.currency)
 
     def _attach_objects_post_save_hook(
         self,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2407,7 +2407,3 @@ class Refund(StripeModel):
         return (
             f"{self.human_readable_amount} ({enums.RefundStatus.humanize(self.status)})"
         )
-
-    @property
-    def human_readable_amount(self) -> str:
-        return get_friendly_currency_amount(self.amount / 100, self.currency)


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed redundant `human_readable_amount` property from 'Transfer` model that inherits from `StripeModel`.
2. Removed redundant `human_readable_amount` property from 'Refund` model that inherits from `StripeModel`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improve Project maintainability.