### PR TITLE
Updated Price.create classmethod to remove the dollar to cents conversion

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2273,7 +2273,6 @@ class Price(StripeModel):
     def create(cls, **kwargs):
         # A few minor things are changed in the api-version of the create call
         api_kwargs = dict(kwargs)
-        api_kwargs["unit_amount"] = int(api_kwargs["unit_amount"] * 100)
 
         if isinstance(api_kwargs.get("product"), StripeModel):
             api_kwargs["product"] = api_kwargs["product"].id

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -40,7 +40,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
     @patch("stripe.Price.create", return_value=deepcopy(FAKE_PRICE), autospec=True)
     def test_create_from_product_id(self, price_create_mock, product_retrieve_mock):
         fake_price = deepcopy(FAKE_PRICE)
-        fake_price["unit_amount"] /= 100
+
         assert isinstance(fake_price["product"], str)
 
         price = Price.create(**fake_price)
@@ -59,7 +59,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
     def test_create_from_stripe_product(self, price_create_mock, product_retrieve_mock):
         fake_price = deepcopy(FAKE_PRICE)
         fake_price["product"] = self.stripe_product
-        fake_price["unit_amount"] /= 100
+
         assert isinstance(fake_price["product"], dict)
 
         price = Price.create(**fake_price)
@@ -82,7 +82,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
     ):
         fake_price = deepcopy(FAKE_PRICE)
         fake_price["product"] = Product.sync_from_stripe_data(self.stripe_product)
-        fake_price["unit_amount"] /= 100
+
         assert isinstance(fake_price["product"], Product)
 
         price = Price.create(**fake_price)
@@ -100,7 +100,7 @@ class PriceCreateTest(AssertStripeFksMixin, TestCase):
     def test_create_with_metadata(self, price_create_mock, product_retrieve_mock):
         metadata = {"other_data": "more_data"}
         fake_price = deepcopy(FAKE_PRICE)
-        fake_price["unit_amount"] /= 100
+
         fake_price["metadata"] = metadata
         assert isinstance(fake_price["product"], str)
 


### PR DESCRIPTION

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `Price.create` to remove conversion of `dollar` to `cents`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Brings us one step closer to reducing the usage of the legacy `StripeDecimalCurrencyAmountField`