### PR TITLE
Updated `BaseInvoice.__str__()` to better reflect the Stripe Dashboard

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -385,6 +385,7 @@ class InvoiceAdmin(StripeModelAdmin):
         "due_date",
     )
     list_filter = (
+        "status",
         "paid",
         "attempted",
         "created",

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -555,9 +555,11 @@ class BaseInvoice(StripeModel):
         ordering = ["-created"]
 
     def __str__(self):
-        return "Invoice #{number}".format(
-            number=self.number or self.receipt_number or self.id
-        )
+        return f"Invoice #{self.number or self.receipt_number or self.id} for {self.human_readable_amount} ({self.status})"
+
+    @property
+    def human_readable_amount(self) -> str:
+        return get_friendly_currency_amount(self.amount_paid / 100, self.currency)
 
     @classmethod
     def upcoming(

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -109,7 +109,9 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         default_account_mock.return_value = self.account
         invoice = Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
-        self.assertEqual(str(invoice), "Invoice #{}".format(FAKE_INVOICE["number"]))
+        self.assertEqual(
+            str(invoice), f"Invoice #{FAKE_INVOICE['number']} for $20.00 USD (paid)"
+        )
         self.assertGreater(len(invoice.status_transitions.keys()), 1)
         self.assertTrue(bool(invoice.account_country))
         self.assertTrue(bool(invoice.account_name))


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge PR #1714 before merging this PR.


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `BaseInvoice.__str__()` to better reflect the Stripe Dashboard.
2. Added `status` model field to the `InvoiceAdmin` list_filter attribute.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`BaseInvoice` and `Invoice` models would better reflect the Stripe Dashboard.