### PR TITLE
Improved string representation of financial numbers

### DIFF
--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 import stripe
 from django.apps import apps
 from django.conf import settings
+from django.contrib.humanize.templatetags.humanize import intcomma
 from django.db.models.query import QuerySet
 from django.utils import timezone
 
@@ -55,9 +56,8 @@ CURRENCY_SIGILS = {"CAD": "$", "EUR": "€", "GBP": "£", "USD": "$"}
 def get_friendly_currency_amount(amount, currency: str) -> str:
     currency = currency.upper()
     sigil = CURRENCY_SIGILS.get(currency, "")
-    return "{sigil}{amount:.2f} {currency}".format(
-        sigil=sigil, amount=amount, currency=currency
-    )
+    amount_two_decimals = f"{amount:.2f}"
+    return f"{sigil}{intcomma(amount_two_decimals)} {currency}"
 
 
 class QuerySetMock(QuerySet):

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -115,14 +115,14 @@ class TestStrPaymentIntent:
 
             assert (
                 str(pi)
-                == "$1902.00 USD (The funds are in your account.) for dj-stripe by Michael Smith"
+                == "$1,902.00 USD (The funds are in your account.) for dj-stripe by Michael Smith"
             )
 
         elif has_account and not has_customer:
 
             assert (
                 str(pi)
-            ) == "$1902.00 USD for dj-stripe. The funds are in your account."
+            ) == "$1,902.00 USD for dj-stripe. The funds are in your account."
 
         elif has_customer and not has_account:
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Improved `Amount` representation by leveraging the Humanize templatetag `intcomma`. Stripe renders big numbers with common like 4500000.4 will be rendered as 4,500,000.40. We were
rendering the same number as 4500000.40.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
The `dj-stripe` dashboard will now much more closely resemble the `Stripe Dashboard`.