### PR TITLE
Added default value to the Coupon.duration Model field

### DIFF
--- a/djstripe/migrations/0001_initial.py
+++ b/djstripe/migrations/0001_initial.py
@@ -390,7 +390,7 @@ class Migration(migrations.Migration):
                 (
                     "duration",
                     djstripe.fields.StripeEnumField(
-                        enum=djstripe.enums.CouponDuration, max_length=9
+                        default='once', enum=djstripe.enums.CouponDuration, max_length=9
                     ),
                 ),
                 (

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -119,6 +119,7 @@ class Coupon(StripeModel):
             "Describes how long a customer who applies this coupon "
             "will get the discount."
         ),
+        default=enums.CouponDuration.once,
     )
     duration_in_months = models.PositiveIntegerField(
         null=True,

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -21,7 +21,7 @@ class TransferTest(TestCase):
 class CouponTest(TestCase):
     def test_blank_coupon_str(self):
         coupon = Coupon()
-        self.assertEqual(str(coupon).strip(), "(invalid amount) off")
+        self.assertEqual(str(coupon).strip(), "(invalid amount) off once")
 
     def test___str__(self):
         coupon = Coupon.objects.create(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Added default value to the `Coupon.duration` Model field as indicated by the `Stripe` docs.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Better Parity with the Stripe API.