### PR TITLE
Add missing Search Method

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -49,6 +49,22 @@ class StripeBaseModel(models.Model):
 
         return cls.stripe_class.list(api_key=api_key, **kwargs).auto_paging_iter()
 
+    @classmethod
+    def api_search(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):
+        """
+        Call the stripe API's search operation for this model.
+
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+
+        See Stripe documentation for accepted kwargs for each object.
+        docs: https://stripe.com/docs/api/pagination/search
+
+        :returns: an iterator over all items in the query
+        """
+        return cls.stripe_class.search(api_key=api_key, **kwargs)
+
 
 class StripeModel(StripeBaseModel):
     # This must be defined in descendants of this model/mixin

--- a/tests/test_stripe_model.py
+++ b/tests/test_stripe_model.py
@@ -318,3 +318,28 @@ def test_api_search(
         api_key=expected_api_key,
         stripe_account=stripe_account,
     )
+
+
+@pytest.mark.parametrize("stripe_account", (None, "acct_fakefakefakefake001"))
+@pytest.mark.parametrize(
+    "api_key, expected_api_key",
+    (
+        (None, None),
+        ("sk_fakefakefake01", "sk_fakefakefake01"),
+    ),
+)
+@patch.object(target=StripeBaseModel, attribute="stripe_class")
+def test_api_list(
+    mock_stripe_class,
+    stripe_account,
+    api_key,
+    expected_api_key,
+):
+    """Test that API list properly uses the passed in parameters."""
+    test_model = ExampleStripeBaseModel()
+    test_model.api_list(api_key=api_key, stripe_account=stripe_account, id="FAKEFAKE")
+    mock_stripe_class.list.assert_called_once_with(
+        id="FAKEFAKE",
+        api_key=expected_api_key,
+        stripe_account=stripe_account,
+    )


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Stripe allows to issue `search` operations on certain models. Added that method to `StripeBaseModel` along with tests.
2. Added missing test for the `api_list` classmethod.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improved parity with Stripe.