### PR TITLE
Replace dangerous assert statement with If loops

### DIFF
--- a/djstripe/admin/forms.py
+++ b/djstripe/admin/forms.py
@@ -80,7 +80,8 @@ class WebhookEndpointAdminBaseForm(forms.ModelForm):
 
     def save(self, commit: bool = False):
         # If we do the following in _post_clean(), the data doesn't save properly.
-        assert self._stripe_data
+        if not self._stripe_data:
+            raise ValueError("_stripe_data is not present. ")
 
         # Update scenario
         # Add back secret if endpoint already exists

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -718,9 +718,8 @@ class StripeModel(StripeBaseModel):
         # *and* we didn't refetch by id, then `should_expand` is True and we
         # don't have the data to actually create the object.
         # If this happens when syncing Stripe data, it's a djstripe bug. Report it!
-        assert not should_expand, "No data to create {} from {}".format(
-            cls.__name__, field_name
-        )
+        if should_expand:
+            raise ValueError(f"No data to create {cls.__name__} from {field_name}")
 
         try:
             # We wrap the `_create_from_stripe_object` in a transaction to


### PR DESCRIPTION
    

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Replaced dangerous `assert` statement with `If loops` and `ValueErrors`. It is a bad idea to use assert statements to do `data validation` in python as they can be globally disabled at the interpreter level if one desires  to "optimise" python.
 

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`dj-stripe`'s behaviour would be more predictable in production as it may very well be the case that assert statement might turn into a `null` operation.
