### PR TITLE
Remove Redundant Sync methods

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1366,15 +1366,6 @@ class Customer(StripeModel):
         for stripe_invoice in Invoice.api_list(customer=self.id, **kwargs):
             Invoice.sync_from_stripe_data(stripe_invoice, api_key=api_key)
 
-    def _sync_subscriptions(self, **kwargs):
-        from .billing import Subscription
-
-        api_key = kwargs.get("api_key") or self.default_api_key
-        for stripe_subscription in Subscription.api_list(
-            customer=self.id, status="all", **kwargs
-        ):
-            Subscription.sync_from_stripe_data(stripe_subscription, api_key=api_key)
-
 
 class Dispute(StripeModel):
     """

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1366,13 +1366,6 @@ class Customer(StripeModel):
         for stripe_invoice in Invoice.api_list(customer=self.id, **kwargs):
             Invoice.sync_from_stripe_data(stripe_invoice, api_key=api_key)
 
-    def _sync_cards(self, **kwargs):
-        from .payment_methods import Card
-
-        api_key = kwargs.get("api_key") or self.default_api_key
-        for stripe_card in Card.api_list(customer=self, **kwargs):
-            Card.sync_from_stripe_data(stripe_card, api_key=api_key)
-
     def _sync_subscriptions(self, **kwargs):
         from .billing import Subscription
 

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1366,11 +1366,6 @@ class Customer(StripeModel):
         for stripe_invoice in Invoice.api_list(customer=self.id, **kwargs):
             Invoice.sync_from_stripe_data(stripe_invoice, api_key=api_key)
 
-    def _sync_charges(self, **kwargs):
-        api_key = kwargs.get("api_key") or self.default_api_key
-        for stripe_charge in Charge.api_list(customer=self.id, **kwargs):
-            Charge.sync_from_stripe_data(stripe_charge, api_key=api_key)
-
     def _sync_cards(self, **kwargs):
         from .payment_methods import Card
 

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -1554,38 +1554,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.assertEqual(0, invoice_sync_mock.call_count)
 
     @patch(
-        "djstripe.models.Charge.sync_from_stripe_data",
-        autospec=True,
-    )
-    @patch(
-        "stripe.Charge.list",
-        return_value=StripeList(data=[deepcopy(FAKE_CHARGE)]),
-        autospec=True,
-    )
-    @patch(
-        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
-    )
-    def test_sync_charges(
-        self, customer_retrieve_mock, charge_list_mock, charge_sync_mock
-    ):
-        self.customer._sync_charges()
-        self.assertEqual(1, charge_sync_mock.call_count)
-
-    @patch(
-        "djstripe.models.Charge.sync_from_stripe_data",
-        autospec=True,
-    )
-    @patch("stripe.Charge.list", return_value=StripeList(data=[]), autospec=True)
-    @patch(
-        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
-    )
-    def test_sync_charges_none(
-        self, customer_retrieve_mock, charge_list_mock, charge_sync_mock
-    ):
-        self.customer._sync_charges()
-        self.assertEqual(0, charge_sync_mock.call_count)
-
-    @patch(
         "djstripe.models.Subscription.sync_from_stripe_data",
         autospec=True,
     )

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -53,7 +53,6 @@ from . import (
     FAKE_SOURCE,
     FAKE_SOURCE_II,
     FAKE_SUBSCRIPTION,
-    FAKE_SUBSCRIPTION_II,
     FAKE_UPCOMING_INVOICE,
     AssertStripeFksMixin,
     StripeList,
@@ -1552,39 +1551,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     ):
         self.customer._sync_invoices()
         self.assertEqual(0, invoice_sync_mock.call_count)
-
-    @patch(
-        "djstripe.models.Subscription.sync_from_stripe_data",
-        autospec=True,
-    )
-    @patch(
-        "stripe.Subscription.list",
-        return_value=StripeList(
-            data=[deepcopy(FAKE_SUBSCRIPTION), deepcopy(FAKE_SUBSCRIPTION_II)]
-        ),
-    )
-    @patch(
-        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
-    )
-    def test_sync_subscriptions(
-        self, customer_retrieve_mock, subscription_list_mock, subscription_sync_mock
-    ):
-        self.customer._sync_subscriptions()
-        self.assertEqual(2, subscription_sync_mock.call_count)
-
-    @patch(
-        "djstripe.models.Subscription.sync_from_stripe_data",
-        autospec=True,
-    )
-    @patch("stripe.Subscription.list", return_value=StripeList(data=[]), autospec=True)
-    @patch(
-        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
-    )
-    def test_sync_subscriptions_none(
-        self, customer_retrieve_mock, subscription_list_mock, subscription_sync_mock
-    ):
-        self.customer._sync_subscriptions()
-        self.assertEqual(0, subscription_sync_mock.call_count)
 
     @patch("stripe.Subscription.create", autospec=True)
     @patch(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Removed redundant `_sync_charges` in favour of the `sync_from_stripe_data` classmethod.
2. Removed redundant `_sync_cards` in favour of the `sync_from_stripe_data` classmethod.
3. Removed redundant `_sync_subscriptions` in favour of the `sync_from_stripe_data` classmethod.
4. Removed redundant `sync` module in favour of the `sync_from_stripe_data` classmethod.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improve long term maintainability with regular cleanup of unused and unnecessary modules and functions.