### PR TITLE
Overrode migrate and makemigrations management commands to not generate unnecessary migrations

### DIFF
--- a/djstripe/fields.py
+++ b/djstripe/fields.py
@@ -19,24 +19,6 @@ def import_jsonfield():
     return BaseJSONField
 
 
-class FieldDeconstructMixin:
-    IGNORED_ATTRS = [
-        "verbose_name",
-        "help_text",
-        "choices",
-        "get_latest_by",
-        "ordering",
-    ]
-
-    def deconstruct(self):
-        """Remove field attributes that have nothing to
-        do with the database. Otherwise unencessary migrations are generated."""
-        name, path, args, kwargs = super().deconstruct()
-        for attr in self.IGNORED_ATTRS:
-            kwargs.pop(attr, None)
-        return name, path, args, kwargs
-
-
 class StripeForeignKey(models.ForeignKey):
     setting_name = "DJSTRIPE_FOREIGN_KEY_TO_FIELD"
 
@@ -61,13 +43,13 @@ class StripeForeignKey(models.ForeignKey):
         return super().get_default()
 
 
-class PaymentMethodForeignKey(FieldDeconstructMixin, models.ForeignKey):
+class PaymentMethodForeignKey(models.ForeignKey):
     def __init__(self, **kwargs):
         kwargs.setdefault("to", "DjstripePaymentMethod")
         super().__init__(**kwargs)
 
 
-class StripePercentField(FieldDeconstructMixin, models.DecimalField):
+class StripePercentField(models.DecimalField):
     """A field used to define a percent according to djstripe logic."""
 
     def __init__(self, *args, **kwargs):
@@ -81,7 +63,7 @@ class StripePercentField(FieldDeconstructMixin, models.DecimalField):
         super().__init__(*args, **defaults)
 
 
-class StripeCurrencyCodeField(FieldDeconstructMixin, models.CharField):
+class StripeCurrencyCodeField(models.CharField):
     """
     A field used to store a three-letter currency code (eg. usd, eur, ...)
     """
@@ -92,7 +74,7 @@ class StripeCurrencyCodeField(FieldDeconstructMixin, models.CharField):
         super().__init__(*args, **defaults)
 
 
-class StripeQuantumCurrencyAmountField(FieldDeconstructMixin, models.BigIntegerField):
+class StripeQuantumCurrencyAmountField(models.BigIntegerField):
     """
     A field used to store currency amounts in cents (etc) as per stripe.
     By contacting stripe support, some accounts will have their limit raised to 11
@@ -102,7 +84,7 @@ class StripeQuantumCurrencyAmountField(FieldDeconstructMixin, models.BigIntegerF
     pass
 
 
-class StripeDecimalCurrencyAmountField(FieldDeconstructMixin, models.DecimalField):
+class StripeDecimalCurrencyAmountField(models.DecimalField):
     """
     A legacy field to store currency amounts in dollars (etc).
 
@@ -135,7 +117,7 @@ class StripeDecimalCurrencyAmountField(FieldDeconstructMixin, models.DecimalFiel
             return val / decimal.Decimal("100")
 
 
-class StripeEnumField(FieldDeconstructMixin, models.CharField):
+class StripeEnumField(models.CharField):
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
         choices = enum.choices
@@ -149,7 +131,7 @@ class StripeEnumField(FieldDeconstructMixin, models.CharField):
         return name, path, args, kwargs
 
 
-class StripeIdField(FieldDeconstructMixin, models.CharField):
+class StripeIdField(models.CharField):
     """A field with enough space to hold any stripe ID."""
 
     def __init__(self, *args, **kwargs):
@@ -166,7 +148,7 @@ class StripeIdField(FieldDeconstructMixin, models.CharField):
         super().__init__(*args, **defaults)
 
 
-class StripeDateTimeField(FieldDeconstructMixin, models.DateTimeField):
+class StripeDateTimeField(models.DateTimeField):
     """A field used to define a DateTimeField value according to djstripe logic."""
 
     def stripe_to_db(self, data):
@@ -178,7 +160,7 @@ class StripeDateTimeField(FieldDeconstructMixin, models.DateTimeField):
             return convert_tstamp(val)
 
 
-class JSONField(FieldDeconstructMixin, import_jsonfield()):
+class JSONField(import_jsonfield()):
     """A field used to define a JSONField value according to djstripe logic."""
 
     pass

--- a/djstripe/urls.py
+++ b/djstripe/urls.py
@@ -9,8 +9,6 @@ Wire this into the root URLConf this way::
 """
 from django.urls import path, re_path
 
-from djstripe.admin import views as admin_views
-
 from . import views
 from .settings import djstripe_settings as app_settings
 

--- a/tests/management/commands/__init__.py
+++ b/tests/management/commands/__init__.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+original_deconstruct = models.Field.deconstruct
+
+IGNORED_ATTRS = [
+    "verbose_name",
+    "help_text",
+    "choices",
+    "get_latest_by",
+    "ordering",
+]
+
+
+def new_deconstruct(self):
+    """Remove field attributes that have nothing to
+    do with the database. Otherwise unencessary migrations are generated."""
+
+    # we use original_deconstruct to reference the models.Field baseclass.
+    name, path, args, kwargs = original_deconstruct(self)
+    for attr in IGNORED_ATTRS:
+        kwargs.pop(attr, None)
+    return name, path, args, kwargs

--- a/tests/management/commands/makemigrations.py
+++ b/tests/management/commands/makemigrations.py
@@ -1,0 +1,6 @@
+from django.core.management.commands.makemigrations import Command  # noqa:F401
+from django.db import models
+
+from . import new_deconstruct
+
+models.Field.deconstruct = new_deconstruct

--- a/tests/management/commands/migrate.py
+++ b/tests/management/commands/migrate.py
@@ -1,0 +1,6 @@
+from django.core.management.commands.migrate import Command  # noqa:F401
+from django.db import models
+
+from . import new_deconstruct
+
+models.Field.deconstruct = new_deconstruct


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->
Please merge #1740 before merging this.

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Overrode `migrate` and `makemigrations` management commands to not generate unnecessary migrations for `model` and `model field` changes that have nothing to do with the database like `verbose_name`, `help_text`, `choices`, get_latest_by`, and `ordering`. This has been done in such a way that these commands have been overridden only for `dj-stripe` and no downstream project using `dj-stripe` will get affected.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`dj-stripe` will no longer generate unnecessary migrations for operations that have nothing to do with the database.