### PR TITLE
Update tax code

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -654,7 +654,7 @@ class SubscriptionScheduleAdmin(StripeModelAdmin):
 
 @admin.register(models.TaxCode)
 class TaxCodeAdmin(StripeModelAdmin):
-    list_display = ("name",)
+    list_display = ("name", "description")
     list_filter = ("name",)
 
 

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -304,6 +304,14 @@ class Command(BaseCommand):
         return all_list_kwargs
 
     @staticmethod
+    def get_list_kwargs_txcd(default_list_kwargs):
+        """Returns sequence of kwargs to sync Tax Codes for
+        all Stripe Accounts"""
+
+        # tax codes are the same for all Stripe Accounts
+        return [{}]
+
+    @staticmethod
     def get_list_kwargs_trr(default_list_kwargs):
         """Returns sequence of kwrags to sync Transfer Reversals for
         all Stripe Accounts"""
@@ -386,6 +394,7 @@ class Command(BaseCommand):
             "CountrySpec": self.get_list_kwargs_country_spec,
             "TransferReversal": self.get_list_kwargs_trr,
             "ApplicationFeeRefund": self.get_list_kwargs_fee_refund,
+            "TaxCode": self.get_list_kwargs_txcd,
             "TaxId": self.get_list_kwargs_tax_id,
             "UsageRecordSummary": self.get_list_kwargs_sis,
         }

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -2096,6 +2096,11 @@ class TaxCode(StripeModel):
     def __str__(self):
         return f"{self.name}: {self.id}"
 
+    @classmethod
+    def _find_owner_account(cls, data, api_key=djstripe_settings.STRIPE_SECRET_KEY):
+        # Tax Codes do not belong to any Stripe Account
+        pass
+
 
 class TaxId(StripeModel):
     """


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `djstripe_sync_models` to correctly sync `Tax Codes`. As Tax Codes do not belong to any Stripe Account, it didn't make sense to recursively sync them for each account in the database.
2. Overrode `TaxCode._find_owner_account` as they are independent of Stripe Accounts.
3. Added `description` model field to `TaxCodeAdmin`.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

More intuitive behaviour as well as slightly faster syncs.