### PR TITLE
Updated MandateAdmin and UsageRecordAdmin to remove _sync_all_instances action

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -434,6 +434,18 @@ class MandateAdmin(StripeModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("payment_method")
 
+    def get_actions(self, request):
+        """
+        Returns _resync_instances only for
+        models with a defined model.stripe_class.retrieve
+        """
+        actions = super().get_actions(request)
+
+        # remove "_sync_all_instances" as Mandates cannot be listed
+        actions.pop("_sync_all_instances", None)
+
+        return actions
+
 
 @admin.register(models.Plan)
 class PlanAdmin(StripeModelAdmin):
@@ -690,6 +702,18 @@ class UsageRecordAdmin(StripeModelAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("subscription_item")
+
+    def get_actions(self, request):
+        """
+        Returns _resync_instances only for
+        models with a defined model.stripe_class.retrieve
+        """
+        actions = super().get_actions(request)
+
+        # remove "_sync_all_instances" as UsageRecords cannot be listed
+        actions.pop("_sync_all_instances", None)
+
+        return actions
 
 
 @admin.register(models.UsageRecordSummary)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -476,6 +476,9 @@ class TestAdminRegisteredModelsChildrenOfStripeModel(TestCase):
                         assert "_resync_instances" in actions
                         assert "_sync_all_instances" in actions
                         assert "_cancel" in actions
+                    elif model.__name__ in ("Mandate", "UsageRecord"):
+                        assert "_resync_instances" in actions
+                        assert "_sync_all_instances" not in actions
                     else:
                         assert "_resync_instances" in actions
                         assert "_sync_all_instances" in actions
@@ -1112,9 +1115,13 @@ class TestCustomActionMixin:
         all_models_lst = app_config.get_models()
 
         for model in all_models_lst:
-            if model in site._registry.keys() and (
-                model.__name__ == "WebhookEndpoint"
-                or model.__name__ not in self.ignore_models
+            if (
+                model in site._registry.keys()
+                and model.__name__ not in ("Mandate", "UsageRecord")
+                and (
+                    model.__name__ == "WebhookEndpoint"
+                    or model.__name__ not in self.ignore_models
+                )
             ):
 
                 # get the standard changelist_view url


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `MandateAdmin` to remove `_sync_all_instances` admin action as Stripe doesn't allow that.
2. Updated `UsageRecordAdmin` to remove `_sync_all_instances` admin action as Stripe doesn't allow that.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Better parity with Stripe.