### PR TITLE
Updated Order model with ability to sync associated Discount objects

### DIFF
--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -90,7 +90,6 @@ class TestOrder(AssertStripeFksMixin, TestCase):
         balance_transaction_retrieve_mock,
     ):
         default_expected_blank_fks = {
-            "djstripe.Customer.coupon",
             "djstripe.Customer.default_payment_method",
             "djstripe.Customer.subscriber",
             "djstripe.Charge.latest_upcominginvoice (related name)",


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

Please merge the following PRs (top to bottom; top first) before merging this one:

1. #1746
2. #1747 
3. #1749 
4. #1748 
5. #1750
6. #1751


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Updated `Order` model with ability to sync associated `Discount` objects


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1744
Improved Parity with Stripe.