### PR TITLE
Added missing discounts field on BaseInvoice

### DIFF
--- a/djstripe/migrations/0019_add_customer_discount.py
+++ b/djstripe/migrations/0019_add_customer_discount.py
@@ -8,7 +8,6 @@ import djstripe.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("djstripe", "0018_discount"),
     ]
@@ -17,6 +16,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="customer",
             name="discount",
+            field=djstripe.fields.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="invoice",
+            name="discounts",
+            field=djstripe.fields.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="upcominginvoice",
+            name="discounts",
             field=djstripe.fields.JSONField(blank=True, null=True),
         ),
     ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1452,6 +1452,7 @@ FAKE_INVOICE_II = InvoiceDict(
         "created": 1439785128,
         "description": None,
         "discount": None,
+        "discounts": [],
         "due_date": None,
         "ending_balance": 0,
         "lines": {
@@ -1498,6 +1499,7 @@ FAKE_INVOICE_III = InvoiceDict(
         "customer": "cus_6lsBvm5rJ0zyHc",
         "description": None,
         "discount": None,
+        "discounts": [],
         "due_date": None,
         "ending_balance": 20,
         "lines": {
@@ -1563,6 +1565,7 @@ FAKE_INVOICE_METERED_SUBSCRIPTION = InvoiceDict(
         "object": "invoice",
         "charge": None,
         "discount": None,
+        "discounts": [],
         "due_date": None,
         "ending_balance": 0,
         "lines": {
@@ -1621,6 +1624,7 @@ FAKE_UPCOMING_INVOICE = InvoiceDict(
             }
         ],
         "discount": None,
+        "discounts": [],
         "due_date": None,
         "ending_balance": None,
         "lines": {

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -566,7 +566,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         invoice_retrieve_mock.assert_called_once_with(
             id=invoice.id,
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
-            expand=[],
+            expand=["discounts"],
             stripe_account=invoice.djstripe_owner_account.id,
             stripe_version=djstripe_settings.STRIPE_API_VERSION,
         )
@@ -1688,6 +1688,9 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
             "id"
         ]
         fake_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"]
+        fake_invoice_data["lines"]["data"][0]["discounts"][0][
             "subscription"
         ] = FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"]
         invoice_retrieve_mock.return_value = fake_invoice_data

--- a/tests/test_usage_record_summary.py
+++ b/tests/test_usage_record_summary.py
@@ -162,14 +162,14 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
                 call(
                     id=FAKE_INVOICE_METERED_SUBSCRIPTION["id"],
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
-                    expand=[],
+                    expand=["discounts"],
                     stripe_account=None,
                     stripe_version="2020-08-27",
                 ),
                 call(
                     id="in_16af5A2eZvKYlo2CJjANLL81",
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
-                    expand=[],
+                    expand=["discounts"],
                     stripe_account=None,
                     stripe_version="2020-08-27",
                 ),


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description
Please merge the following PRs (top to bottom; top first) before merging this one:

1. #1746
2. #1747 
3. #1749 
4. #1748 
5. #1750
6. #1751
7. #1753 


<!-- What are you proposing? -->

This PR contains the following changes:

1. Added missing `discounts` field on `BaseInvoice`.
2. Also added the ability to sync discount objects in `_attach_objects_post_save_hook()`


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Better parity with Stripe