### PR TITLE
Added missing discounts field on InvoiceItem

### DIFF
--- a/djstripe/migrations/0019_add_customer_discount.py
+++ b/djstripe/migrations/0019_add_customer_discount.py
@@ -28,4 +28,9 @@ class Migration(migrations.Migration):
             name="discounts",
             field=djstripe.fields.JSONField(blank=True, null=True),
         ),
+        migrations.AddField(
+            model_name="invoiceitem",
+            name="discounts",
+            field=djstripe.fields.JSONField(blank=True, null=True),
+        ),
     ]

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -258,7 +258,7 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         invoice_retrieve_mock.assert_called_once_with(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             stripe_version=djstripe_settings.STRIPE_API_VERSION,
-            expand=[],
+            expand=["discounts"],
             id=FAKE_INVOICE_II["id"],
             stripe_account=None,
         )


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description
Please merge the following PRs (top to bottom; top first) before merging this one:

1. #1746
2. #1747 
3. #1749 
4. #1748 
5. #1750
6. #1751
7. #1753 
8. #1754 
<!-- What are you proposing? -->

This PR contains the following changes:

1. Added missing `discounts` field on `InvoiceItem`.
2. Also added the ability to sync `discount` objects in `_attach_objects_post_save_hook`.

Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improved Parity with Stripe.