### PR TITLE
Updated LineItem model to sync Discount Objects

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1179,10 +1179,15 @@ class LineItem(StripeModel):
         # get current invoice if any
         invoice_id = kwargs.pop("id")
 
+        # get expand parameter that needs to be passed to invoice.lines.list call
+        expand_fields = kwargs.pop("expand")
+
         invoice = Invoice.stripe_class.retrieve(invoice_id, api_key=api_key, **kwargs)
 
         # iterate over all the line items on the current invoice
-        return invoice.lines.list(api_key=api_key, **kwargs).auto_paging_iter()
+        return invoice.lines.list(
+            api_key=api_key, expand=expand_fields, **kwargs
+        ).auto_paging_iter()
 
 
 class Plan(StripeModel):

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1053,8 +1053,7 @@ class LineItem(StripeModel):
     """
 
     stripe_class = stripe.InvoiceLineItem
-    # todo uncomment when discount model gets implemented
-    # expand_fields = ["discounts"]
+    expand_fields = ["discounts"]
 
     amount = StripeQuantumCurrencyAmountField(help_text="The amount, in cents.")
     amount_excluding_tax = StripeQuantumCurrencyAmountField(
@@ -1144,22 +1143,20 @@ class LineItem(StripeModel):
 
         return data
 
-    # todo uncomment when discount model gets implemented
-    # def _attach_objects_post_save_hook(
-    #     self,
-    #     cls,
-    #     data,
-    #     api_key=djstripe_settings.STRIPE_SECRET_KEY,
-    #     pending_relations=None,
-    # ):
-    #     super()._attach_objects_post_save_hook(
-    #         cls, data, api_key=api_key, pending_relations=pending_relations
-    #     )
-    #
-    #
-    # # sync every discount
-    # for discount in self.discounts:
-    #     Discount.sync_from_stripe_data(discount, api_key=api_key)
+    def _attach_objects_post_save_hook(
+        self,
+        cls,
+        data,
+        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+        pending_relations=None,
+    ):
+        super()._attach_objects_post_save_hook(
+            cls, data, api_key=api_key, pending_relations=pending_relations
+        )
+
+        # sync every discount
+        for discount in self.discounts:
+            Discount.sync_from_stripe_data(discount, api_key=api_key)
 
     @classmethod
     def api_list(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1385,11 +1385,13 @@ FAKE_DISCOUNT_CUSTOMER = {
 
 
 FAKE_LINE_ITEM = load_fixture("line_item_il_invoice_item_fakefakefakefakefake0001.json")
-
+FAKE_LINE_ITEM["discounts"] = [deepcopy(FAKE_DISCOUNT_CUSTOMER)]
 
 FAKE_LINE_ITEM_SUBSCRIPTION = load_fixture(
     "line_item_il_invoice_item_fakefakefakefakefake0002.json"
 )
+FAKE_LINE_ITEM_SUBSCRIPTION["discounts"] = [deepcopy(FAKE_DISCOUNT_CUSTOMER)]
+FAKE_LINE_ITEM_SUBSCRIPTION["discounts"][0]["subscription"] = "sub_1rn1dp7WgjMtx9"
 
 
 class InvoiceDict(StripeItem):

--- a/tests/test_line_item.py
+++ b/tests/test_line_item.py
@@ -41,7 +41,10 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.Charge.on_behalf_of",
             "djstripe.Charge.source_transfer",
             "djstripe.Charge.transfer",
+<<<<<<< HEAD
             "djstripe.Customer.coupon",
+=======
+>>>>>>> 3cc20a6c (Updated LineItem model to also sync discount objects.)
             "djstripe.Customer.default_payment_method",
             "djstripe.Customer.subscriber",
             "djstripe.Invoice.default_payment_method",
@@ -52,7 +55,10 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.PaymentIntent.on_behalf_of",
             "djstripe.PaymentIntent.payment_method",
             "djstripe.PaymentIntent.upcominginvoice (related name)",
+<<<<<<< HEAD
             "djstripe.Product.default_price",
+=======
+>>>>>>> 3cc20a6c (Updated LineItem model to also sync discount objects.)
             "djstripe.Subscription.default_payment_method",
             "djstripe.Subscription.default_source",
             "djstripe.Subscription.pending_setup_intent",
@@ -147,7 +153,7 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
             type(patched_obj).auto_paging_iter = p
 
             # Invoke LineItem.api_list(...)
-            LineItem.api_list(id=FAKE_INVOICE["id"])
+            LineItem.api_list(id=FAKE_INVOICE["id"], expand=["data.discounts"])
 
             # assert invoice_retrieve_mock was called once
             invoice_retrieve_mock.assert_called_once_with(
@@ -157,5 +163,5 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
 
             # assert invoice.lines.list(...) was called once
             patched_obj.assert_called_once_with(
-                api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                api_key=djstripe_settings.STRIPE_SECRET_KEY, expand=["data.discounts"]
             )

--- a/tests/test_line_item.py
+++ b/tests/test_line_item.py
@@ -41,10 +41,6 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.Charge.on_behalf_of",
             "djstripe.Charge.source_transfer",
             "djstripe.Charge.transfer",
-<<<<<<< HEAD
-            "djstripe.Customer.coupon",
-=======
->>>>>>> 3cc20a6c (Updated LineItem model to also sync discount objects.)
             "djstripe.Customer.default_payment_method",
             "djstripe.Customer.subscriber",
             "djstripe.Invoice.default_payment_method",
@@ -55,10 +51,7 @@ class LineItemTest(AssertStripeFksMixin, TestCase):
             "djstripe.PaymentIntent.on_behalf_of",
             "djstripe.PaymentIntent.payment_method",
             "djstripe.PaymentIntent.upcominginvoice (related name)",
-<<<<<<< HEAD
             "djstripe.Product.default_price",
-=======
->>>>>>> 3cc20a6c (Updated LineItem model to also sync discount objects.)
             "djstripe.Subscription.default_payment_method",
             "djstripe.Subscription.default_source",
             "djstripe.Subscription.pending_setup_intent",


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description
Please merge the following PRs (top to bottom; top first) before merging this one:

1. #1746
2. #1747 
3. #1749 
4. #1748 
5. #1750
6. #1751
7. #1753 
8. #1754 
9. #1755 
<!-- What are you proposing? -->

This PR contains the following changes:

1.  Updated `LineItem` model to also sync `Discount` objects.
2.  Fixed bug in `LineItem.api_list()`. It was incorrectly passing the `expand` field parameter to the `Invoice` retrieve call in addition to the list call. Updated the code to pass it only to the list call.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Improved Parity with Stripe