### PR TITLE
Improve Sync of Stripe Subscriptions

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1535,6 +1535,23 @@ class Subscription(StripeModel):
 
         return f"{self.customer} on {' and '.join(products_lst)}"
 
+    @classmethod
+    def api_list(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):
+        """
+        Call the stripe API's list operation for this model.
+        :param api_key: The api key to use for this request. \
+            Defaults to djstripe_settings.STRIPE_SECRET_KEY.
+        :type api_key: string
+        See Stripe documentation for accepted kwargs for each object.
+        :returns: an iterator over all items in the query
+        """
+        if not kwargs.get("status"):
+            # special case: https://stripe.com/docs/api/subscriptions/list#list_subscriptions-status
+            # See Issue: https://github.com/dj-stripe/dj-stripe/issues/1763
+            kwargs["status"] = "all"
+
+        return super().api_list(api_key=api_key, **kwargs)
+
     def update(
         self,
         plan: Union[StripeModel, str] = None,


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Overrode `Subscription.api_list` to set `status` to `all` in case no value is passed. This would allow all `Subscriptions` to get synced by default. 


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
More intuitive sync behaviour
Fix: #1763 