### PR TITLE
Made Price and Plan syncs consistent 

### DIFF
--- a/djstripe/management/commands/djstripe_sync_plans_from_stripe.py
+++ b/djstripe/management/commands/djstripe_sync_plans_from_stripe.py
@@ -1,9 +1,8 @@
 """
 sync_plans_from_stripe command.
 """
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
-
-from ...models import Plan, Price
 
 
 class Command(BaseCommand):
@@ -12,10 +11,4 @@ class Command(BaseCommand):
     help = "Sync prices (and plans) from stripe."
 
     def handle(self, *args, **options):
-        for price_data in Price.api_list():
-            price = Price.sync_from_stripe_data(price_data)
-            self.stdout.write(f"Synchronized price {price.id}")
-
-        for plan_data in Plan.api_list():
-            plan = Plan.sync_from_stripe_data(plan_data)
-            self.stdout.write(f"Synchronized plan {plan.id}")
+        call_command("djstripe_sync_models", "Price", "Plan")

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1073,7 +1073,7 @@ class Plan(StripeModel):
     """
 
     stripe_class = stripe.Plan
-    expand_fields = ["tiers"]
+    expand_fields = ["product", "tiers"]
     stripe_dashboard_item_name = "plans"
 
     active = models.BooleanField(

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2178,7 +2178,7 @@ class Price(StripeModel):
     """
 
     stripe_class = stripe.Price
-    expand_fields = ["tiers"]
+    expand_fields = ["product", "tiers"]
     stripe_dashboard_item_name = "prices"
 
     active = models.BooleanField(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. `Price` and `Plan` syncs were not consistent as the nested fields didn't properly populate the `expand_fields` parameter leading to cases where the optional `tiers` field would not get included. This was highly dependant on how exactly the syncs were run.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1767
