### PR TITLE
fix: unit_amount value on tiered pricing when when only flat fee is set

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -2327,7 +2327,7 @@ class Price(StripeModel):
             tier_1 = self.tiers[0]
             flat_amount_tier_1 = tier_1["flat_amount"]
             formatted_unit_amount_tier_1 = get_friendly_currency_amount(
-                tier_1["unit_amount"] / 100, self.currency
+                (tier_1["unit_amount"] or 0) / 100, self.currency
             )
             amount = f"Starts at {formatted_unit_amount_tier_1} per unit"
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. When dealing with tiered pricing and setting a price level with a flat fee but no unit price, the returned `unit_amount` field is `null`. This results in a raised exception when trying to compute the price's `human_readable_price()`.

![CleanShot 2022-08-07 at 16 12 25@2x](https://user-images.githubusercontent.com/759215/183294942-ef07cdd1-98c0-419f-a5c4-766f1b369a66.png)


Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

Fix #1767 (see comment https://github.com/dj-stripe/dj-stripe/issues/1767#issuecomment-1207414893) 