### PR TITLE
docs: Fix a few typos

### DIFF
--- a/djstripe/management/commands/djstripe_process_events.py
+++ b/djstripe/management/commands/djstripe_process_events.py
@@ -21,7 +21,7 @@ class Command(VerbosityAwareOutputMixin, BaseCommand):
     )
 
     def add_arguments(self, parser):
-        """Add optional arugments to filter Events by."""
+        """Add optional arguments to filter Events by."""
         # Use a mutually exclusive group to prevent multiple arguments being
         # specified together.
         group = parser.add_mutually_exclusive_group()

--- a/djstripe/management/commands/djstripe_update_invoiceitem_ids.py
+++ b/djstripe/management/commands/djstripe_update_invoiceitem_ids.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = "Update old InvoiceItem IDs to the new, 2019-12-03 format."
 
     def add_arguments(self, parser):
-        """Add optional arugments to filter Events by."""
+        """Add optional arguments to filter Events by."""
         # Use a mutually exclusive group to prevent multiple arguments being
         # specified together.
         group = parser.add_mutually_exclusive_group()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -278,12 +278,12 @@ class TestConfirmCustomActionView:
                 # Invoke the Custom Actions
                 view._sync_all_instances(request, model.objects.none())
 
-                # assert correct Success messages are emmitted
+                # assert correct Success messages are emitted
                 messages_sent_dictionary = {
                     m.message: m.level_tag for m in messages.get_messages(request)
                 }
 
-                # assert correct success message was emmitted
+                # assert correct success message was emitted
                 assert (
                     messages_sent_dictionary.get("Successfully Synced All Instances")
                     == "success"
@@ -346,12 +346,12 @@ class TestConfirmCustomActionView:
         # Invoke the Custom Actions
         view._resync_instances(request, [instance])
 
-        # assert correct Success messages are emmitted
+        # assert correct Success messages are emitted
         messages_sent_dictionary = {
             m.message: m.level_tag for m in messages.get_messages(request)
         }
 
-        # assert correct success message was emmitted
+        # assert correct success message was emitted
         assert (
             messages_sent_dictionary.get(f"Successfully Synced: {instance}")
             == "success"
@@ -409,12 +409,12 @@ class TestConfirmCustomActionView:
         # Invoke the Custom Actions
         view._resync_instances(request, [instance])
 
-        # assert correct Success messages are emmitted
+        # assert correct Success messages are emitted
         messages_sent_dictionary = {
             m.message.user_message: m.level_tag for m in messages.get_messages(request)
         }
 
-        # assert correct success message was emmitted
+        # assert correct success message was emitted
         assert messages_sent_dictionary.get("some random error message") == "warning"
 
     def test__resync_instances_stripe_invalid_request_error(self, monkeypatch):
@@ -542,12 +542,12 @@ class TestConfirmCustomActionView:
         # Invoke the Custom Actions
         view._cancel(request, [instance])
 
-        # assert correct Success messages are emmitted
+        # assert correct Success messages are emitted
         messages_sent_dictionary = {
             m.message: m.level_tag for m in messages.get_messages(request)
         }
 
-        # assert correct success message was emmitted
+        # assert correct success message was emitted
         assert (
             messages_sent_dictionary.get(f"Successfully Canceled: {instance}")
             == "success"
@@ -721,12 +721,12 @@ class TestConfirmCustomActionView:
         # Invoke the Custom Actions
         view._release_subscription_schedule(request, [instance])
 
-        # assert correct Success messages are emmitted
+        # assert correct Success messages are emitted
         messages_sent_dictionary = {
             m.message: m.level_tag for m in messages.get_messages(request)
         }
 
-        # assert correct success message was emmitted
+        # assert correct success message was emitted
         assert (
             messages_sent_dictionary.get(f"Successfully Released: {instance}")
             == "success"
@@ -818,12 +818,12 @@ class TestConfirmCustomActionView:
         # Invoke the Custom Actions
         view._cancel_subscription_schedule(request, [instance])
 
-        # assert correct Success messages are emmitted
+        # assert correct Success messages are emitted
         messages_sent_dictionary = {
             m.message: m.level_tag for m in messages.get_messages(request)
         }
 
-        # assert correct success message was emmitted
+        # assert correct success message was emitted
         assert (
             messages_sent_dictionary.get(f"Successfully Canceled: {instance}")
             == "success"


### PR DESCRIPTION
There are small typos in:
- djstripe/management/commands/djstripe_process_events.py
- djstripe/management/commands/djstripe_update_invoiceitem_ids.py
- tests/test_views.py

Fixes:
- Should read `emitted` rather than `emmitted`.
- Should read `arguments` rather than `arugments`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md