### PR TITLE
Expanded total_details.breakdown model field of Order model

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -26,6 +26,7 @@ Invoke like so:
 from typing import List
 
 from django.apps import apps
+from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import models as django_models
 
@@ -228,51 +229,56 @@ class Command(BaseCommand):
                 # add expand_field on the current model
                 expand.append(f"data.{field}")
 
-                field_inst = model._meta.get_field(field)
+                try:
+                    field_inst = model._meta.get_field(field)
 
-                # get expand_fields on Forward FK and OneToOneField relations on the current model
-                if isinstance(
-                    field_inst, (django_models.ForeignKey, django_models.OneToOneField)
-                ):
+                    # get expand_fields on Forward FK and OneToOneField relations on the current model
+                    if isinstance(
+                        field_inst,
+                        (django_models.ForeignKey, django_models.OneToOneField),
+                    ):
 
-                    try:
-                        for (
-                            related_model_expand_field
-                        ) in field_inst.related_model.expand_fields:
-                            # add expand_field on the current model
-                            expand.append(f"data.{field}.{related_model_expand_field}")
-
-                            related_model_expand_field_inst = (
-                                field_inst.related_model._meta.get_field(
-                                    related_model_expand_field
+                        try:
+                            for (
+                                related_model_expand_field
+                            ) in field_inst.related_model.expand_fields:
+                                # add expand_field on the current model
+                                expand.append(
+                                    f"data.{field}.{related_model_expand_field}"
                                 )
-                            )
 
-                            # get expand_fields on Forward FK and OneToOneField relations on the current model
-                            if isinstance(
-                                related_model_expand_field_inst,
-                                (
-                                    django_models.ForeignKey,
-                                    django_models.OneToOneField,
-                                ),
-                            ):
-
-                                try:
-                                    # need to prepend "field_name." to each of the entry in the expand_fields list
-                                    related_model_expand_fields = map(
-                                        lambda i: f"data.{field_inst.name}.{related_model_expand_field}.{i}",
-                                        related_model_expand_field_inst.related_model.expand_fields,
+                                related_model_expand_field_inst = (
+                                    field_inst.related_model._meta.get_field(
+                                        related_model_expand_field
                                     )
+                                )
 
-                                    expand = [
-                                        *expand,
-                                        *related_model_expand_fields,
-                                    ]
-                                except AttributeError:
-                                    continue
-                    except AttributeError:
-                        continue
+                                # get expand_fields on Forward FK and OneToOneField relations on the current model
+                                if isinstance(
+                                    related_model_expand_field_inst,
+                                    (
+                                        django_models.ForeignKey,
+                                        django_models.OneToOneField,
+                                    ),
+                                ):
 
+                                    try:
+                                        # need to prepend "field_name." to each of the entry in the expand_fields list
+                                        related_model_expand_fields = map(
+                                            lambda i: f"data.{field_inst.name}.{related_model_expand_field}.{i}",
+                                            related_model_expand_field_inst.related_model.expand_fields,
+                                        )
+
+                                        expand = [
+                                            *expand,
+                                            *related_model_expand_fields,
+                                        ]
+                                    except AttributeError:
+                                        continue
+                        except AttributeError:
+                            continue
+                except FieldDoesNotExist:
+                    pass
         except AttributeError:
             pass
 

--- a/djstripe/models/orders.py
+++ b/djstripe/models/orders.py
@@ -22,7 +22,7 @@ class Order(StripeModel):
     """
 
     stripe_class = stripe.Order
-    expand_fields = ["customer", "line_items"]
+    expand_fields = ["customer", "line_items", "total_details.breakdown"]
     stripe_dashboard_item_name = "orders"
 
     amount_subtotal = StripeQuantumCurrencyAmountField(


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Added `total_details.breakdown` to `Order.expand_fields` attribute.
2. Addressed bug in `get_default_list_kwargs`. `expand_fields` can contain nested fields of the type `A.B.C` where A, B, and C don't have to be `RelatedFields`, which is what the logic incorrectly assumed and didn't handle correctly.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Generic Sync ability added for `non-relational` nested `expand_fields` of the type `A.B.C`.