### PR TITLE
Fixed bug in _stripe_object_to_refunds

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -9,6 +9,7 @@ from django.utils import dateformat, timezone
 from django.utils.encoding import smart_str
 from stripe.api_resources.abstract.api_resource import APIResource
 from stripe.error import InvalidRequestError
+from stripe.util import convert_to_stripe_object
 
 from ..fields import (
     JSONField,
@@ -957,13 +958,14 @@ class StripeModel(StripeBaseModel):
         :type charge: djstripe.models.Refund
         :return:
         """
+        stripe_refunds = convert_to_stripe_object(data.get("refunds"))
 
-        refunds = data.get("refunds")
-        if not refunds:
+        if not stripe_refunds:
             return []
 
         refund_objs = []
-        for refund_data in refunds.auto_paging_iter():
+
+        for refund_data in stripe_refunds.auto_paging_iter():
             item, _ = target_cls._get_or_create_from_stripe_object(
                 refund_data,
                 refetch=False,

--- a/tests/fixtures/charge_ch_fakefakefakefakefake0001.json
+++ b/tests/fixtures/charge_ch_fakefakefakefakefake0001.json
@@ -76,7 +76,12 @@
     "receipt_number": null,
     "receipt_url": "https://pay.stripe.com/receipts/acct_1EaetYCOCguPTL2B/ch_fakefakefakefakefake0001/rcpt_F4oXnrfNz0ijmlgXiDK31ArpYEgLEko",
     "refunded": false,
-    "refunds": {},
+    "refunds": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "url": "/v1/charges/ch_fakefakefakefakefake0001/refunds"
+    },
     "review": null,
     "shipping": null,
     "source": {


### PR DESCRIPTION


<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Fixed bug in `_stripe_object_to_refunds()`. `refunds` in the `Charge` object need to be converted back to the Stripe Object in order to take advantage of Stripe's `auto_paging_iter()` especially if there are more than 1 page of results.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
Fix: #1783 