### PR TITLE
Swapped ProgrammingError with DatabaseError Parent Class

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -4,7 +4,7 @@ dj-stripe System Checks
 import re
 
 from django.core import checks
-from django.db.utils import ProgrammingError
+from django.db.utils import DatabaseError
 
 STRIPE_API_VERSION_PATTERN = re.compile(
     r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})(; [\w=]*)?$"
@@ -131,7 +131,7 @@ def check_webhook_secret(app_configs=None, **kwargs):
     messages = []
     try:
         webhooks = list(WebhookEndpoint.objects.all())
-    except ProgrammingError:
+    except DatabaseError:
         # skip the db-based check (db most likely not migrated yet)
         webhooks = []
 
@@ -194,7 +194,7 @@ def check_webhook_validation(app_configs=None, **kwargs):
 
         try:
             webhooks = list(WebhookEndpoint.objects.all())
-        except ProgrammingError:
+        except DatabaseError:
             # Skip the db-based check (database most likely not migrated yet)
             webhooks = []
 
@@ -231,7 +231,7 @@ def check_webhook_endpoint_has_secret(app_configs=None, **kwargs):
 
     try:
         qs = list(WebhookEndpoint.objects.filter(secret="").all())
-    except ProgrammingError:
+    except DatabaseError:
         # Skip the check - Database most likely not migrated yet
         return []
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1. Swapped `ProgrammingError` with `DatabaseError` Parent Class. This was done because `ProgrammingError` wasn't catching all cases.



Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
`sqlite` was raising an `OperationalError`.