### PR TITLE
Added django-upgrade to pre-commit for django 3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.10.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "3.2"]
+
   - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -94,7 +94,7 @@ def get_remote_ip(request):
     """
 
     # HTTP_X_FORWARDED_FOR is relevant for django running behind a proxy
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    x_forwarded_for = request.headers.get("X-Forwarded-For")
     if x_forwarded_for:
         ip = x_forwarded_for.split(",")[0]
     else:

--- a/tests/apps/testapp/urls.py
+++ b/tests/apps/testapp/urls.py
@@ -1,6 +1,5 @@
-from django.conf.urls import include
 from django.http import HttpResponse
-from django.urls import path
+from django.urls import include, path
 
 
 def empty_view(request):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, PropertyMock, call, patch
 from uuid import UUID
 
 import pytest
+from django.http.request import HttpHeaders
 from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
@@ -575,6 +576,10 @@ class TestGetRemoteIp:
         @property
         def META(self):
             return self.data
+
+        @property
+        def headers(self):
+            return HttpHeaders(self.META)
 
     @pytest.mark.parametrize(
         "data",

--- a/tests/test_zz_jsonfield.py
+++ b/tests/test_zz_jsonfield.py
@@ -17,7 +17,7 @@ try:
     try:
         from django.db.models import JSONField as DjangoJSONField
     except ImportError:
-        from django.contrib.postgres.fields import JSONField as DjangoJSONField
+        from django.db.models import JSONField as DjangoJSONField
 except ImportError:
     pass
 

--- a/tests/test_zz_jsonfield.py
+++ b/tests/test_zz_jsonfield.py
@@ -7,19 +7,12 @@ import sys
 from unittest import skipUnless
 
 from django.apps.registry import apps
+from django.db.models import JSONField as DjangoJSONField
 from django.test import TestCase
 from django.test.utils import override_settings
 from jsonfield import JSONField as UglyJSONField
 
 from djstripe.fields import import_jsonfield
-
-try:
-    try:
-        from django.db.models import JSONField as DjangoJSONField
-    except ImportError:
-        from django.db.models import JSONField as DjangoJSONField
-except ImportError:
-    pass
 
 
 @override_settings(DJSTRIPE_USE_NATIVE_JSONFIELD=False)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,6 @@
-from django.conf.urls import include
 from django.contrib import admin
 from django.http.response import HttpResponse
-from django.urls import path
+from django.urls import include, path
 
 admin.autodiscover()
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

This Pull Request is adding [django-upgrade](https://github.com/adamchainz/django-upgrade) to dj-stripe. The target version is django 3.2

> django-upgrade automatically upgrades your Django project code.


This PR contains the following changes:

1. the config for django-upgrade in pre-commit-config.yaml file
2. some import path modifications
3. a switch from `request.META.get("HTTP_X_FORWARDED_FOR")` to `request.headers.get("X-Forwarded-For")` and the needed modifications for the tests


Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

> django-upgrade automatically upgrades your Django project code.
