### PR TITLE
Raised RuntimeError if api_retrieve returns null data

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -193,12 +193,22 @@ class StripeModel(StripeBaseModel):
         if not stripe_account:
             stripe_account = self._get_stripe_account_id(api_key)
 
-        return self.stripe_class.retrieve(
+        data = self.stripe_class.retrieve(
             id=self.id,
             api_key=api_key or self.default_api_key,
             expand=self.expand_fields,
             stripe_account=stripe_account,
         )
+
+        if not data:
+            raise RuntimeError(
+                f"No data returned from Stripe for {self.stripe_class}, id={self.id}, "
+                f"api_key={api_key or self.default_api_key}, stripe_account={stripe_account}, "
+                f"expand_fields={self.expand_fields}. "
+                "This is a bug, please report to dj-stripe!"
+            )
+
+        return data
 
     @classmethod
     def _api_create(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY, **kwargs):


### PR DESCRIPTION

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

1.  Raised `ValueError` in `api_retrieve` if Stripe returns `null` data.


Checklist:

- [X] I've updated the `tests` or confirm that my change doesn't require any updates.
- [X] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [X] I confirm that my change doesn't drop code coverage below the current level.
- [X] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

This seems to happen from time to time that the retrieve call doesn't fail but returns null data. This has been experienced by me a few times and also by Dominik of Zemtu. Hoping the raised error will provide more insight into what is causing this issue.

