### PR TITLE
fix display of plans when there is no per-unit price

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1242,7 +1242,7 @@ class Plan(StripeModel):
             tier_1 = self.tiers[0]
             flat_amount_tier_1 = tier_1["flat_amount"]
             formatted_unit_amount_tier_1 = get_friendly_currency_amount(
-                tier_1["unit_amount"] / 100, self.currency
+                (tier_1["unit_amount"] or 0) / 100, self.currency
             )
             amount = f"Starts at {formatted_unit_amount_tier_1} per unit"
 


### PR DESCRIPTION
very similar to https://github.com/dj-stripe/dj-stripe/pull/1773

<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->

## Description

<!-- What are you proposing? -->

This PR contains the following changes:

Fixes the same problem as https://github.com/dj-stripe/dj-stripe/pull/1773 but for the `Plan` model


Checklist:

- [x] I've updated the `tests` or confirm that my change doesn't require any updates.
- [x] I've updated the `documentation` or confirm that my change doesn't require any updates.
- [x] I confirm that my change doesn't drop code coverage below the current level.
- [x] I've updated `migrations` or confirm that my change doesn't make changes to any model.

## Rationale

Same as https://github.com/dj-stripe/dj-stripe/pull/1773 / https://github.com/dj-stripe/dj-stripe/issues/1767#issuecomment-1207414893
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
