### PR TITLE
Fix classmethods of models to strictly refer to their class using the "cls" argument

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1172,8 +1172,8 @@ class Plan(StripeModel):
         """Get or create a Plan."""
 
         try:
-            return Plan.objects.get(id=kwargs["id"]), False
-        except Plan.DoesNotExist:
+            return cls.objects.get(id=kwargs["id"]), False
+        except cls.DoesNotExist:
             return cls.create(**kwargs), True
 
     @classmethod

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -804,8 +804,8 @@ class Customer(StripeModel):
         """
 
         try:
-            return Customer.objects.get(subscriber=subscriber, livemode=livemode), False
-        except Customer.DoesNotExist:
+            return cls.objects.get(subscriber=subscriber, livemode=livemode), False
+        except cls.DoesNotExist:
             action = f"create:{subscriber.pk}"
             idempotency_key = djstripe_settings.get_idempotency_key(
                 "customer", action, livemode
@@ -832,7 +832,7 @@ class Customer(StripeModel):
             metadata=metadata,
             stripe_account=stripe_account,
         )
-        customer, created = Customer.objects.get_or_create(
+        customer, created = cls.objects.get_or_create(
             id=stripe_customer["id"],
             defaults={
                 "subscriber": subscriber,
@@ -2267,8 +2267,8 @@ class Price(StripeModel):
         """Get or create a Price."""
 
         try:
-            return Price.objects.get(id=kwargs["id"]), False
-        except Price.DoesNotExist:
+            return cls.objects.get(id=kwargs["id"]), False
+        except cls.DoesNotExist:
             return cls.create(**kwargs), True
 
     @classmethod

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -216,15 +216,15 @@ class WebhookEventTrigger(models.Model):
 
         try:
             # Validate the webhook first
-            signals.webhook_pre_validate.send(sender=WebhookEventTrigger, instance=obj)
+            signals.webhook_pre_validate.send(sender=cls, instance=obj)
             obj.valid = obj.validate(secret=secret, api_key=api_key)
             signals.webhook_post_validate.send(
-                sender=WebhookEventTrigger, instance=obj, valid=obj.valid
+                sender=cls, instance=obj, valid=obj.valid
             )
 
             if obj.valid:
                 signals.webhook_pre_process.send(
-                    sender=WebhookEventTrigger, instance=obj
+                    sender=cls, instance=obj
                 )
                 if djstripe_settings.WEBHOOK_EVENT_CALLBACK:
                     # If WEBHOOK_EVENT_CALLBACK, pass it for processing
@@ -233,16 +233,16 @@ class WebhookEventTrigger(models.Model):
                     # Process the item (do not save it, it'll get saved below)
                     obj.process(save=False, api_key=api_key)
                 signals.webhook_post_process.send(
-                    sender=WebhookEventTrigger, instance=obj, api_key=api_key
+                    sender=cls, instance=obj, api_key=api_key
                 )
         except Exception as e:
-            max_length = WebhookEventTrigger._meta.get_field("exception").max_length
+            max_length = cls._meta.get_field("exception").max_length
             obj.exception = str(e)[:max_length]
             obj.traceback = format_exc()
 
             # Send the exception as the webhook_processing_error signal
             signals.webhook_processing_error.send(
-                sender=WebhookEventTrigger,
+                sender=cls,
                 instance=obj,
                 api_key=api_key,
                 exception=e,


### PR DESCRIPTION
Some of the classmethods of models refer to the class by its name rather than the "cls" argument. 
To make these methods friendlier to overriding by inheriting proxy models, all class methods should strictly use "cls" in their implementation.