### PR TITLE
Updated check_stripe_api_key check to not be a blocker for new dj-stripe users

### DIFF
--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -41,4 +41,6 @@
 
 ## Other changes
 
--   ...
+-  Updated `check_stripe_api_key` django system check to not be a blocker for new dj-stripe users by raising Info warnings on the console. If the Stripe keys were not defined in the settings file, the `Critical` warning was preventing users to add them directly from the admin as mentioned in the docs. This was creating a chicken-egg situation where one could only add keys in the admin before they were defined in settings.
+
+- `check_stripe_api_key` will raise appropriate warnings on the console directing users to add keys directly from the django admin.


### PR DESCRIPTION
The check_stripe_api_key was raising critical warnings if the Stripe keys were not defined in the settings file but the docs were asking the users to add them directly from the admin. This was creating a chicken-egg situation where one could add keys in the admin before they were defined in settings.

Also raised appropriate warnings on the console directing users to add keys directly from the django admin.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
