### PR TITLE
Fix links and admonitions in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,11 +40,17 @@ The full documentation is available [on Read the Docs](https://dj-stripe.github.
 
 ## Installation
 
-See [installation](docs/installation.md) instructions.
+See [installation](installation.md) instructions.
 
 ## Changelog
 
-[See release notes on Read the Docs](https://dj-stripe.github.io/dj-stripe/history/2_5_0/).
+[See release notes on Read the Docs](history/2_7_0/).
+
+<!-- This link *will* get stale again eventually. There should be an index page for the
+     changelog that can be linked to.
+
+     For example:
+     https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages -->
 
 ## Funding and Support
 

--- a/docs/api_versions.md
+++ b/docs/api_versions.md
@@ -35,8 +35,7 @@ version Stripe only allows you to upgrade to the **latest** version.
 ## Stripe's current latest API version
 
 You can find this on your Stripe dashboard labelled "**latest**" or in
-[Stripe's API documentation]
-(https://stripe.com/docs/upgrades#api-changelog)
+[Stripe's API documentation](https://stripe.com/docs/upgrades#api-changelog)
 
 This is the version used by new accounts and it's also "**true**" internal
 version of Stripe's API

--- a/docs/stripe_elements_js.md
+++ b/docs/stripe_elements_js.md
@@ -36,4 +36,4 @@ If you're using `stripe.createToken`, see if you can upgrade to
 `stripe.createSource` or ideally to Payment Intents .
 
 !!! tip
-Checkout [Card Elements Quickstart JS](https://stripe.com/docs/payments/accept-a-payment-charges?platform=web)
+    Checkout [Card Elements Quickstart JS](https://stripe.com/docs/payments/accept-a-payment-charges?platform=web)

--- a/docs/usage/subscribing_customers.md
+++ b/docs/usage/subscribing_customers.md
@@ -53,10 +53,10 @@ support all the arguments you need for your implementation. When this
 happens you can just call the official `stripe.Customer.subscribe()`.
 
 !!! tip
-Check out the following examples:
+    Check out the following examples:
 
--   [`form_valid view example`][tests.apps.example.views.PurchaseSubscriptionView.form_valid]
--   [`djstripe.models.Customer.add_payment_method`][djstripe.models.core.Customer.add_payment_method]
+    -   [`form_valid view example`][tests.apps.example.views.PurchaseSubscriptionView.form_valid]
+    -   [`djstripe.models.Customer.add_payment_method`][djstripe.models.core.Customer.add_payment_method]
 
 
     Note that PaymentMethods can be used instead of Cards/Source by


### PR DESCRIPTION
This fixes a few broken links and admonitions. 

Please review the change in `docs/usage/subscribing_customers.md`, especially. I'm not sure if the admonition box should contain everything until the end of the document.
