### PR TITLE
Add optional `created` kwarg to djstripe_sync_models management command

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -22,6 +22,13 @@ Invoke like so:
 
     7) To only sync Stripe Accounts and Charges for sk_test_XXX and sk_test_YYY API keys:
         python manage.py djstripe_sync_models Account Charge --api-keys sk_test_XXX sk_test_YYY
+
+    6) To only sync Stripe Accounts for sk_test_XXX and sk_test_YYY API keys for objects created after {unix_timestamp}:
+        python manage.py djstripe_sync_models Account --api-keys sk_test_XXX sk_test_YYY --created "{\"gt\": {unix_timestamp}}"
+
+    7) To only sync Stripe Accounts and Charges for sk_test_XXX and sk_test_YYY API keys for objects created between {unix_gt_timestamp} and {unix_lt_timestamp}:
+        python manage.py djstripe_sync_models Account Charge --api-keys sk_test_XXX sk_test_YYY --created "{\"gte\": {unix_gt_timestamp}, \"lte\": {unix_lt_timestamp}}"
+
 """
 import json
 from typing import Dict, List, Union

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -23,7 +23,8 @@ Invoke like so:
     7) To only sync Stripe Accounts and Charges for sk_test_XXX and sk_test_YYY API keys:
         python manage.py djstripe_sync_models Account Charge --api-keys sk_test_XXX sk_test_YYY
 """
-from typing import List
+import json
+from typing import Dict, List, Union
 
 from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
@@ -60,11 +61,26 @@ class Command(BaseCommand):
             # action="extend",
             help="Specify the api_keys you would like to perform this sync for.",
         )
+        # Named (optional) arguments
+        parser.add_argument(
+            "--created",
+            metavar="Created",
+            nargs="?",
+            type=str,
+            help="Specify the created you would like to perform this sync for.",
+        )
 
-    def handle(self, *args, api_keys, **options):
+    def handle(self, *args, api_keys, created, **options):
         app_label = "djstripe"
         app_config = apps.get_app_config(app_label)
         model_list = []  # type: List[models.StripeModel]
+        if created:
+            try:
+                created = json.loads(created)
+            except json.decoder.JSONDecodeError as error:
+                raise CommandError(
+                    "Unable to convert created to python dict object. " + str(error)
+                ) from error
 
         if args:
             for model_label in args:
@@ -98,7 +114,7 @@ class Command(BaseCommand):
 
         for model in model_list:
             for api_key in api_qs:
-                self.sync_model(model, api_key=api_key)
+                self.sync_model(model, api_key=api_key, created=created)
 
     def _should_sync_model(self, model):
         if not issubclass(model, StripeBaseModel):
@@ -127,7 +143,7 @@ class Command(BaseCommand):
 
         return True, ""
 
-    def sync_model(self, model, api_key: str):
+    def sync_model(self, model, api_key: str, created: Union[Dict, int]):
         model_name = model.__name__
 
         should_sync, reason = self._should_sync_model(model)
@@ -140,7 +156,9 @@ class Command(BaseCommand):
         count = 0
         try:
             # todo convert get_list_kwargs into a generator to make the code memory effecient.
-            for list_kwargs in self.get_list_kwargs(model, api_key=api_key.secret):
+            for list_kwargs in self.get_list_kwargs(
+                model, api_key=api_key.secret, created=created
+            ):
                 stripe_account = list_kwargs.get("stripe_account", "")
 
                 if (
@@ -220,7 +238,7 @@ class Command(BaseCommand):
 
     # todo simplfy this code by spliting into 1-2 functions
     @staticmethod
-    def get_default_list_kwargs(model, accounts_set, api_key: str):
+    def get_default_list_kwargs(model, accounts_set, api_key: str, created):
         """Returns default sequence of kwargs to sync
         all Stripe Accounts"""
         expand = []
@@ -290,6 +308,7 @@ class Command(BaseCommand):
                     "expand": expand,
                     "stripe_account": account,
                     "api_key": api_key,
+                    "created": created,
                 }
                 for account in accounts_set
             ]
@@ -299,6 +318,7 @@ class Command(BaseCommand):
                 {
                     "stripe_account": account,
                     "api_key": api_key,
+                    "created": created,
                 }
                 for account in accounts_set
             ]
@@ -442,7 +462,7 @@ class Command(BaseCommand):
         return all_list_kwargs
 
     # todo handle supoorting double + nested fields like data.invoice.subscriptions.customer etc?
-    def get_list_kwargs(self, model, api_key: str):
+    def get_list_kwargs(self, model, api_key: str, created: Union[Dict, int]):
         """
         Returns a sequence of kwargs dicts to pass to model.api_list
 
@@ -470,7 +490,7 @@ class Command(BaseCommand):
         accs_set = self.get_stripe_account(api_key=api_key)
 
         default_list_kwargs = self.get_default_list_kwargs(
-            model, accs_set, api_key=api_key
+            model, accs_set, api_key=api_key, created=created
         )
 
         handler = list_kwarg_handlers_dict.get(

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -47,12 +47,22 @@ class StripeBaseModel(models.Model):
 
         :returns: an iterator over all items in the query
         """
+        try:
+            results = cls.stripe_class.list(
+                api_key=api_key,
+                stripe_version=djstripe_settings.STRIPE_API_VERSION,
+                **kwargs,
+            ).auto_paging_iter()
+        except InvalidRequestError as e:
+            if "Received unknown parameter: created" == e.user_message:
+                kwargs.pop("created", None)
+                results = cls.stripe_class.list(
+                    api_key=api_key, **kwargs
+                ).auto_paging_iter()
+            else:
+                raise
 
-        return cls.stripe_class.list(
-            api_key=api_key,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
-            **kwargs,
-        ).auto_paging_iter()
+        return results
 
 
 class StripeModel(StripeBaseModel):

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -17,6 +17,7 @@
     -   `djstripe.signals.webhook_post_process(instance, api_key)`: Fired after webhook successful processing.
 -   `djstripe.signals.webhook_processing_error` now also takes `instance` and `api_key` arguments
 -   `stripe.api_version` is no longer manipulated by dj-stripe.
+-   Added optional `created` kwarg to the `djstripe_sync_models` management command to allow users to specify the unix datetime they would like to initiate sync from. This is more effecient than always initiating sync from the beginning.
 
 ## Deprecated features
 

--- a/docs/usage/manually_syncing_with_stripe.md
+++ b/docs/usage/manually_syncing_with_stripe.md
@@ -27,6 +27,12 @@ A list of models to sync can also be provided along with the API Keys.
 ```
 This will sync all the Invoice and Subscription data for the given API Keys. Please note that the API Keys sk_test_YYY and sk_test_XXX need to be in the database.
 
+An Optional Kwarg `created` can be added to restrict syncing objects created between a certain timeperiod as mentioned in the [Stripe docs.](https://stripe.com/docs/api/customers/list#list_customers-created). Please note that the `created` kwarg is not supported by all Stripe models and we silently ignore it is the model being synced does not support it.
+
+```bash
+    ./manage.py djstripe_sync_models Invoice Subscription --api-keys sk_test_XXX sk_test_YYY --created "{\"gte\": {unix_gt_timestamp}, \"lte\": {unix_lt_timestamp}}"
+```
+
 You can manually reprocess events using the management commands
 [`djstripe_process_events`][djstripe.management.commands.djstripe_process_events]. By default this processes all events, but
 options can be passed to limit the events processed. Note the Stripe API

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1142,6 +1142,52 @@ class SubscriptionTest(AssertStripeFksMixin, TestCase):
             stripe_version=djstripe_settings.STRIPE_API_VERSION,
         )
 
+    @patch("stripe.Subscription.list")
+    def test_api_list_with_valid_timestamp_created(self, subscription_list_mock):
+        p = PropertyMock(return_value=deepcopy(FAKE_SUBSCRIPTION))
+        type(subscription_list_mock).auto_paging_iter = p
+
+        # invoke Subscription.api_list with created populated
+        Subscription.api_list(created="123456789")
+
+        subscription_list_mock.assert_called_once_with(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            status="all",
+            stripe_version=djstripe_settings.STRIPE_API_VERSION,
+            created="123456789",
+        )
+
+    @patch("stripe.Subscription.list")
+    def test_api_list_with_valid_dict_created(self, subscription_list_mock):
+        p = PropertyMock(return_value=deepcopy(FAKE_SUBSCRIPTION))
+        type(subscription_list_mock).auto_paging_iter = p
+
+        # invoke Subscription.api_list with created populated
+        Subscription.api_list(created={"gt": 123456789})
+
+        subscription_list_mock.assert_called_once_with(
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            status="all",
+            stripe_version=djstripe_settings.STRIPE_API_VERSION,
+            created={"gt": 123456789},
+        )
+
+    @patch("stripe.Subscription.list")
+    def test_api_list_with_invalid_dict_created(self, subscription_list_mock):
+        p = PropertyMock(return_value=deepcopy(FAKE_SUBSCRIPTION))
+        type(subscription_list_mock).auto_paging_iter = p
+        subscription_list_mock.side_effect = InvalidRequestError(
+            "Received unknown parameter: created", "created"
+        )
+
+        with pytest.raises(InvalidRequestError) as error:
+            # invoke Subscription.api_list with created populated
+            Subscription.api_list(created={"gtpq": 123456789})
+
+        assert "Received unknown parameter: created", (
+            "created" == error.value.user_message
+        )
+
 
 class TestSubscriptionDecimal:
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

Added optional `created` kwarg to the `djstripe_sync_models` management command to allow users to specify the datetime they would like to initiate sync from. This is far better than always initiating sync from the beginning.