### PR TITLE
Swapped Critical Error to Info for _check_webhook_endpoint_validation check

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -190,10 +190,10 @@ def _check_webhook_endpoint_validation(secret, messages, endpoint=None):
             secret_attr = "DJSTRIPE_WEBHOOK_SECRET"
 
         messages.append(
-            checks.Critical(
+            checks.Info(
                 f"DJSTRIPE_WEBHOOK_VALIDATION is set to 'verify_signature' {extra_msg}",
-                hint=f"Set {secret_attr} or set DJSTRIPE_WEBHOOK_VALIDATION='retrieve_event'",
-                id="djstripe.C006",
+                hint=f"Set {secret_attr} from Django shell or set DJSTRIPE_WEBHOOK_VALIDATION='retrieve_event'",
+                id="djstripe.I006",
             )
         )
     return messages

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -44,3 +44,4 @@
 -  Updated `check_stripe_api_key` django system check to not be a blocker for new dj-stripe users by raising Info warnings on the console. If the Stripe keys were not defined in the settings file, the `Critical` warning was preventing users to add them directly from the admin as mentioned in the docs. This was creating a chicken-egg situation where one could only add keys in the admin before they were defined in settings.
 
 - `check_stripe_api_key` will raise appropriate warnings on the console directing users to add keys directly from the django admin.
+-  Swapped Critical Error to Info for `_check_webhook_endpoint_validation` check to allow the users to use the django admin.


### PR DESCRIPTION
This was done because a critical check would not allow the user to log on to the admin to update the secret.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
