### PR TITLE
added auto set customer name in stripe

### DIFF
--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1,7 +1,6 @@
 import warnings
 from decimal import Decimal
 from typing import Optional, Union
-import re
 
 import stripe
 from django.apps import apps
@@ -824,12 +823,11 @@ class Customer(StripeModel):
         if subscriber_key not in ("", None):
             metadata[subscriber_key] = subscriber.pk
 
-        if hasattr(subscriber, 'name') and subscriber.name:
+        try:
             # if subscriber table has name column use it as customer name
             name = subscriber.name
-        else:
-            # use email's username as customer name
-            name = re.sub('[_.-]', ' ', subscriber.email.split('@')[0]).title()
+        except AttributeError:
+            name = None
 
         stripe_customer = cls._api_create(
             email=subscriber.email,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -828,7 +828,7 @@ class Customer(StripeModel):
             name = subscriber.name
         else:
             # use email's username as customer name
-            name = re.sub('[_.-]', ' ', subscriber.email).title()
+            name = re.sub('[_.-]', ' ', subscriber.email.split('@')[0]).title()
 
         stripe_customer = cls._api_create(
             email=subscriber.email,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -823,8 +823,16 @@ class Customer(StripeModel):
         if subscriber_key not in ("", None):
             metadata[subscriber_key] = subscriber.pk
 
+        try:
+            # if subscriber column has name field use it as customer name
+            name = subscriber.name
+        except:
+            # use email username as customer name
+            name = re.sub('[_.-]', ' ', subscriber.email).title()
+
         stripe_customer = cls._api_create(
             email=subscriber.email,
+            name=name,
             idempotency_key=idempotency_key,
             metadata=metadata,
             stripe_account=stripe_account,

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -823,11 +823,11 @@ class Customer(StripeModel):
         if subscriber_key not in ("", None):
             metadata[subscriber_key] = subscriber.pk
 
-        try:
-            # if subscriber column has name field use it as customer name
+        if hasattr(subscriber, 'name') and subscriber.name:
+            # if subscriber table has name column use it as customer name
             name = subscriber.name
-        except:
-            # use email username as customer name
+        else:
+            # use email's username as customer name
             name = re.sub('[_.-]', ' ', subscriber.email).title()
 
         stripe_customer = cls._api_create(

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1,6 +1,7 @@
 import warnings
 from decimal import Decimal
 from typing import Optional, Union
+import re
 
 import stripe
 from django.apps import apps


### PR DESCRIPTION
Plans to set customer name in the following manner:

1) If the `subscriber` table has a `name` column use that as the customer name
2) Otherwise generate the customer name from their email 

### Reason:

Stripe does not allow export transactions if the customer name is not set in the stripe dashboard. Also, customers cannot set their billing name from the stripe-hosted customer portal.