### PR TITLE
Fixed Django 4.1 version compatibility issue

### DIFF
--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -1989,12 +1989,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.assertEqual(0, len(items))
         self.assertIsNotNone(invoice.plan)
 
-    @patch("stripe.Customer.retrieve", autospec=True)
-    def test_delete_subscriber_without_customer_is_noop(self, customer_retrieve_mock):
-        self.user.delete()
-        for customer in self.user.djstripe_customers.all():
-            self.assertIsNone(customer.date_purged)
-
     @patch("stripe.Subscription.create", autospec=True)
     @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->


Fixed Django 4.1 version compatibility issue. Fixed the issue that the stripe account id was not being retrieved due to Django 4.1 unifcation of m2m fields and the reverse related field model manager as mentioned
[here](https://docs.djangoproject.com/en/4.1/releases/4.1/#reverse-foreign-key-changes-for-unsaved-model-instances)

Fix: #1855 