### PR TITLE
Remove incorrect check to not allow uncollectible invoices to be retried

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -627,11 +627,10 @@ class BaseInvoice(StripeModel):
         )
 
     def retry(self):
-        """Retry payment on this invoice if it isn't paid or uncollectible."""
+        """Retry payment on this invoice if it isn't paid."""
 
         if (
             self.status != enums.InvoiceStatus.paid
-            and self.status != enums.InvoiceStatus.uncollectible
             and self.auto_advance
         ):
             stripe_invoice = self.api_retrieve()

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -629,10 +629,7 @@ class BaseInvoice(StripeModel):
     def retry(self):
         """Retry payment on this invoice if it isn't paid."""
 
-        if (
-            self.status != enums.InvoiceStatus.paid
-            and self.auto_advance
-        ):
+        if self.status != enums.InvoiceStatus.paid and self.auto_advance:
             stripe_invoice = self.api_retrieve()
             updated_stripe_invoice = (
                 stripe_invoice.pay()


### PR DESCRIPTION
Stripe allows uncollectible invoices to also be retried and can be transitioned to Paid or Void statues. And hence users should be allowed to also retry [uncollectible invoices.](https://stripe.com/docs/invoicing/integration/workflow-transitions)

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
