### PR TITLE
Making tests.__init__.py module Django 4+ compatible

### DIFF
--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -44,7 +44,7 @@ def convert_tstamp(response) -> Optional[datetime.datetime]:
         return response
 
     # Overrides the set timezone to UTC - I think...
-    tz = timezone.utc if settings.USE_TZ else None
+    tz = get_timezone_utc() if settings.USE_TZ else None
 
     return datetime.datetime.fromtimestamp(response, tz)
 
@@ -108,3 +108,17 @@ def get_model(model_name):
 def get_queryset(pks, model_name):
     model = get_model(model_name)
     return model.objects.filter(pk__in=pks)
+
+
+def get_timezone_utc():
+    """
+    Returns UTC attribute in a backwards compatible way.
+
+    UTC attribute has been moved from django.utils.timezone module to
+    datetime.timezone class
+    """
+    try:
+        # Django 4+
+        return datetime.timezone.utc
+    except AttributeError:
+        return timezone.utc

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,24 +6,25 @@ Updated to API VERSION 2016-03-07 with bogus fields.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
 import json
 import logging
 import os
 from copy import deepcopy
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.utils import dateformat, timezone
+from django.utils import dateformat
 
+from djstripe.utils import get_timezone_utc
 from djstripe.webhooks import TEST_EVENT_ID
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
 logger = logging.getLogger(__name__)
 
-FUTURE_DATE = datetime(2100, 4, 30, tzinfo=timezone.utc)
+FUTURE_DATE = datetime.datetime(2100, 4, 30, tzinfo=get_timezone_utc())
 
 FIXTURE_DIR_PATH = Path(__file__).parent.joinpath("fixtures")
 
@@ -1077,7 +1078,7 @@ class SubscriptionDict(StripeItem):
         self["items"] = StripeList(self["items"])
 
     def __setattr__(self, name, value):
-        if type(value) == datetime:
+        if type(value) == datetime.datetime:
             value = datetime_to_unix(value)
 
         # Special case for price and plan

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,9 +1,15 @@
+from copy import deepcopy
+from unittest.mock import patch
+
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
 from djstripe import models
+from djstripe.enums import APIKeyType
 from djstripe.settings import djstripe_settings
+
+from . import FAKE_ACCOUNT, FAKE_FILEUPLOAD_LOGO
 
 
 class TestCheckApiKeySettings(TestCase):
@@ -12,22 +18,72 @@ class TestCheckApiKeySettings(TestCase):
         STRIPE_LIVE_PUBLIC_KEY="sk_live_foo",
         STRIPE_LIVE_MODE=True,
     )
-    def test_global_api_keys_live_mode(self):
+    @patch("stripe.Account.retrieve", autospec=True)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test_global_api_keys_live_mode(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+    ):
+
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"]["branding"]["icon"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        with patch.object(
+            models.api,
+            "get_api_key_details_by_prefix",
+            return_value=(APIKeyType.secret, True),
+        ):
+
+            account = models.Account.sync_from_stripe_data(
+                fake_account, api_key=djstripe_settings.STRIPE_SECRET_KEY
+            )
+            self.assertEqual(account.default_api_key, "sk_live_foo")
+
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, True)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_live_foo")
         self.assertEqual(djstripe_settings.LIVE_API_KEY, "sk_live_foo")
-        self.assertEqual(models.Account(livemode=True).default_api_key, "sk_live_foo")
 
     @override_settings(
         STRIPE_TEST_SECRET_KEY="sk_test_foo",
         STRIPE_TEST_PUBLIC_KEY="pk_test_foo",
         STRIPE_LIVE_MODE=False,
     )
-    def test_global_api_keys_test_mode(self):
+    @patch("stripe.Account.retrieve", autospec=True)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test_global_api_keys_test_mode(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+    ):
+
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"]["branding"]["icon"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        with patch.object(
+            models.api,
+            "get_api_key_details_by_prefix",
+            return_value=(APIKeyType.secret, False),
+        ):
+
+            account = models.Account.sync_from_stripe_data(
+                fake_account, api_key=djstripe_settings.STRIPE_SECRET_KEY
+            )
+            self.assertEqual(account.default_api_key, "sk_test_foo")
+
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, False)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_test_foo")
         self.assertEqual(djstripe_settings.TEST_API_KEY, "sk_test_foo")
-        self.assertEqual(models.Account(livemode=False).default_api_key, "sk_test_foo")
 
     @override_settings(
         STRIPE_TEST_SECRET_KEY="sk_test_foo",
@@ -36,14 +92,37 @@ class TestCheckApiKeySettings(TestCase):
         STRIPE_LIVE_PUBLIC_KEY="pk_live_foo",
         STRIPE_LIVE_MODE=True,
     )
-    def test_api_key_live_mode(self):
+    @patch("stripe.Account.retrieve", autospec=True)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test_api_key_live_mode(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+    ):
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"]["branding"]["icon"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        with patch.object(
+            models.api,
+            "get_api_key_details_by_prefix",
+            return_value=(APIKeyType.secret, True),
+        ):
+
+            account = models.Account.sync_from_stripe_data(
+                fake_account, api_key=djstripe_settings.STRIPE_SECRET_KEY
+            )
+            self.assertEqual(account.default_api_key, "sk_live_foo")
+
         del settings.STRIPE_SECRET_KEY, settings.STRIPE_TEST_SECRET_KEY
         del settings.STRIPE_PUBLIC_KEY, settings.STRIPE_TEST_PUBLIC_KEY
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, True)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_live_foo")
         self.assertEqual(djstripe_settings.STRIPE_PUBLIC_KEY, "pk_live_foo")
-        self.assertEqual(djstripe_settings.LIVE_API_KEY, "sk_live_foo")
-        self.assertEqual(models.Account(livemode=True).default_api_key, "sk_live_foo")
 
     @override_settings(
         STRIPE_TEST_SECRET_KEY="sk_test_foo",
@@ -52,11 +131,36 @@ class TestCheckApiKeySettings(TestCase):
         STRIPE_LIVE_PUBLIC_KEY="pk_live_foo",
         STRIPE_LIVE_MODE=False,
     )
-    def test_secret_key_test_mode(self):
+    @patch("stripe.Account.retrieve", autospec=True)
+    @patch(
+        "stripe.File.retrieve",
+        return_value=deepcopy(FAKE_FILEUPLOAD_LOGO),
+        autospec=True,
+    )
+    def test_secret_key_test_mode(
+        self,
+        fileupload_retrieve_mock,
+        account_retrieve_mock,
+    ):
+
+        fake_account = deepcopy(FAKE_ACCOUNT)
+        fake_account["settings"]["branding"]["icon"] = None
+        account_retrieve_mock.return_value = fake_account
+
+        with patch.object(
+            models.api,
+            "get_api_key_details_by_prefix",
+            return_value=(APIKeyType.secret, False),
+        ):
+
+            account = models.Account.sync_from_stripe_data(
+                fake_account, api_key=djstripe_settings.STRIPE_SECRET_KEY
+            )
+            self.assertEqual(account.default_api_key, "sk_test_foo")
+
         del settings.STRIPE_SECRET_KEY
         del settings.STRIPE_PUBLIC_KEY
         self.assertEqual(djstripe_settings.STRIPE_LIVE_MODE, False)
         self.assertEqual(djstripe_settings.STRIPE_SECRET_KEY, "sk_test_foo")
         self.assertEqual(djstripe_settings.STRIPE_PUBLIC_KEY, "pk_test_foo")
         self.assertEqual(djstripe_settings.TEST_API_KEY, "sk_test_foo")
-        self.assertEqual(models.Account(livemode=False).default_api_key, "sk_test_foo")

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 """
 dj-stripe Custom Field Tests.
 """
-from datetime import datetime, timezone
+from datetime import datetime
 from decimal import Decimal
 
 import pytest
@@ -9,6 +9,7 @@ from django.test.testcases import TestCase
 from django.test.utils import override_settings
 
 from djstripe.fields import StripeDateTimeField, StripeDecimalCurrencyAmountField
+from djstripe.utils import get_timezone_utc
 from tests.fields.models import ExampleDecimalModel
 
 pytestmark = pytest.mark.django_db
@@ -32,7 +33,7 @@ class TestStripeDecimalCurrencyAmountField:
         assert expected == self.noval.stripe_to_db({"noval": inputted})
 
 
-@override_settings(USE_TZ=timezone.utc)
+@override_settings(USE_TZ=get_timezone_utc())
 class TestStripeDateTimeField(TestCase):
     noval = StripeDateTimeField(name="noval")
 
@@ -41,7 +42,7 @@ class TestStripeDateTimeField(TestCase):
 
     def test_stripe_to_db_datetime_val(self):
         self.assertEqual(
-            datetime(1997, 9, 18, 7, 48, 35, tzinfo=timezone.utc),
+            datetime(1997, 9, 18, 7, 48, 35, tzinfo=get_timezone_utc()),
             self.noval.stripe_to_db({"noval": 874568915}),
         )
 

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from django.utils import timezone
 
 from djstripe.models import Charge, Customer, Plan, Subscription, Transfer
+from djstripe.utils import get_timezone_utc
 
 from . import (
     FAKE_PLAN,
@@ -25,10 +25,10 @@ class SubscriptionManagerTest(TestCase):
     def setUp(self):
 
         # create customers and current subscription records
-        period_start = datetime.datetime(2013, 4, 1, tzinfo=timezone.utc)
-        period_end = datetime.datetime(2013, 4, 30, tzinfo=timezone.utc)
+        period_start = datetime.datetime(2013, 4, 1, tzinfo=get_timezone_utc())
+        period_end = datetime.datetime(2013, 4, 30, tzinfo=get_timezone_utc())
         start = datetime.datetime(
-            2013, 1, 1, 0, 0, 1, tzinfo=timezone.utc
+            2013, 1, 1, 0, 0, 1, tzinfo=get_timezone_utc()
         )  # more realistic start
 
         with patch(
@@ -192,7 +192,7 @@ class ChargeManagerTest(TestCase):
         self.march_charge = Charge.objects.create(
             id="ch_XXXXMAR1",
             customer=customer,
-            created=datetime.datetime(2015, 3, 31, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 3, 31, tzinfo=get_timezone_utc()),
             amount=0,
             amount_refunded=0,
             currency="usd",
@@ -202,7 +202,7 @@ class ChargeManagerTest(TestCase):
         self.april_charge_1 = Charge.objects.create(
             id="ch_XXXXAPR1",
             customer=customer,
-            created=datetime.datetime(2015, 4, 1, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 4, 1, tzinfo=get_timezone_utc()),
             amount=decimal.Decimal("20.15"),
             amount_refunded=0,
             currency="usd",
@@ -213,7 +213,7 @@ class ChargeManagerTest(TestCase):
         self.april_charge_2 = Charge.objects.create(
             id="ch_XXXXAPR2",
             customer=customer,
-            created=datetime.datetime(2015, 4, 18, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 4, 18, tzinfo=get_timezone_utc()),
             amount=decimal.Decimal("10.35"),
             amount_refunded=decimal.Decimal("5.35"),
             currency="usd",
@@ -224,7 +224,7 @@ class ChargeManagerTest(TestCase):
         self.april_charge_3 = Charge.objects.create(
             id="ch_XXXXAPR3",
             customer=customer,
-            created=datetime.datetime(2015, 4, 30, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 4, 30, tzinfo=get_timezone_utc()),
             amount=decimal.Decimal("100.00"),
             amount_refunded=decimal.Decimal("80.00"),
             currency="usd",
@@ -235,7 +235,7 @@ class ChargeManagerTest(TestCase):
         self.may_charge = Charge.objects.create(
             id="ch_XXXXMAY1",
             customer=customer,
-            created=datetime.datetime(2015, 5, 1, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 5, 1, tzinfo=get_timezone_utc()),
             amount=0,
             amount_refunded=0,
             currency="usd",
@@ -245,7 +245,7 @@ class ChargeManagerTest(TestCase):
         self.november_charge = Charge.objects.create(
             id="ch_XXXXNOV1",
             customer=customer,
-            created=datetime.datetime(2015, 11, 16, tzinfo=timezone.utc),
+            created=datetime.datetime(2015, 11, 16, tzinfo=get_timezone_utc()),
             amount=0,
             amount_refunded=0,
             currency="usd",
@@ -255,7 +255,7 @@ class ChargeManagerTest(TestCase):
         self.charge_2014 = Charge.objects.create(
             id="ch_XXXX20141",
             customer=customer,
-            created=datetime.datetime(2014, 12, 31, tzinfo=timezone.utc),
+            created=datetime.datetime(2014, 12, 31, tzinfo=get_timezone_utc()),
             amount=0,
             amount_refunded=0,
             currency="usd",
@@ -265,7 +265,7 @@ class ChargeManagerTest(TestCase):
         self.charge_2016 = Charge.objects.create(
             id="ch_XXXX20161",
             customer=customer,
-            created=datetime.datetime(2016, 1, 1, tzinfo=timezone.utc),
+            created=datetime.datetime(2016, 1, 1, tzinfo=get_timezone_utc()),
             amount=0,
             amount_refunded=0,
             currency="usd",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,12 +9,12 @@ from unittest.mock import patch
 
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import timezone
 
 from djstripe.utils import (
     convert_tstamp,
     get_friendly_currency_amount,
     get_supported_currency_choices,
+    get_timezone_utc,
 )
 
 TZ_IS_UTC = time.tzname == ("UTC", "UTC")
@@ -23,7 +23,9 @@ TZ_IS_UTC = time.tzname == ("UTC", "UTC")
 class TestTimestampConversion(TestCase):
     def test_conversion(self):
         stamp = convert_tstamp(1365567407)
-        self.assertEqual(stamp, datetime(2013, 4, 10, 4, 16, 47, tzinfo=timezone.utc))
+        self.assertEqual(
+            stamp, datetime(2013, 4, 10, 4, 16, 47, tzinfo=get_timezone_utc())
+        )
 
     # NOTE: These next two tests will fail if your system clock is not in UTC
     # Travis CI is, and coverage is good, so...


### PR DESCRIPTION
`utc` attribute was moved from `django.utils` module to `datetime.timezone` in Django 4+.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
