### PR TITLE
Resolve LineItem and InvoiceItem ambiguity

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -877,35 +877,35 @@ class StripeModel(StripeBaseModel):
         instance.total_tax_amounts.exclude(pk__in=pks).delete()
 
     @classmethod
-    def _stripe_object_to_invoice_items(
+    def _stripe_object_to_line_items(
         cls, target_cls, data, invoice, api_key=djstripe_settings.STRIPE_SECRET_KEY
     ):
         """
-        Retrieves InvoiceItems for an invoice.
+        Retrieves LineItems for an invoice.
 
-        If the invoice item doesn't exist already then it is created.
+        If the line item doesn't exist already then it is created.
 
         If the invoice is an upcoming invoice that doesn't persist to the
-        database (i.e. ephemeral) then the invoice items are also not saved.
+        database (i.e. ephemeral) then the line items are also not saved.
 
-        :param target_cls: The target class to instantiate per invoice item.
-        :type target_cls:  Type[djstripe.models.InvoiceItem]
+        :param target_cls: The target class to instantiate per line item.
+        :type target_cls:  Type[djstripe.models.LineItem]
         :param data: The data dictionary received from the Stripe API.
         :type data: dict
-        :param invoice: The invoice object that should hold the invoice items.
+        :param invoice: The invoice object that should hold the line items.
         :type invoice: ``djstripe.models.Invoice``
         """
-
         lines = data.get("lines")
         if not lines:
             return []
 
-        invoiceitems = []
+        lineitems = []
         for line in lines.auto_paging_iter():
             if invoice.id:
                 save = True
                 line.setdefault("invoice", invoice.id)
 
+<<<<<<< HEAD
                 if line.get("type") == "subscription":
                     # Lines for subscriptions need to be keyed based on invoice and
                     # subscription, because their id is *just* the subscription
@@ -915,6 +915,8 @@ class StripeModel(StripeBaseModel):
                     line_id = line["id"]
                     if not line_id.startswith(invoice.id):
                         line["id"] = f"{invoice.id}-{line_id}"
+=======
+>>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
             else:
                 # Don't save invoice items for ephemeral invoices
                 save = False
@@ -925,9 +927,9 @@ class StripeModel(StripeBaseModel):
             item, _ = target_cls._get_or_create_from_stripe_object(
                 line, refetch=False, save=save, api_key=api_key
             )
-            invoiceitems.append(item)
+            lineitems.append(item)
 
-        return invoiceitems
+        return lineitems
 
     @classmethod
     def _stripe_object_to_subscription_items(

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -905,18 +905,6 @@ class StripeModel(StripeBaseModel):
                 save = True
                 line.setdefault("invoice", invoice.id)
 
-<<<<<<< HEAD
-                if line.get("type") == "subscription":
-                    # Lines for subscriptions need to be keyed based on invoice and
-                    # subscription, because their id is *just* the subscription
-                    # when received from Stripe. This means that future updates to
-                    # a subscription will change previously saved invoices - Doing
-                    # the composite key avoids this.
-                    line_id = line["id"]
-                    if not line_id.startswith(invoice.id):
-                        line["id"] = f"{invoice.id}-{line_id}"
-=======
->>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
             else:
                 # Don't save invoice items for ephemeral invoices
                 save = False

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -649,10 +649,10 @@ class BaseInvoice(StripeModel):
             cls, data, api_key=api_key, pending_relations=pending_relations
         )
 
-        # InvoiceItems need a saved invoice because they're associated via a
+        # LineItems need a saved invoice because they're associated via a
         # RelatedManager, so this must be done as part of the post save hook.
-        cls._stripe_object_to_invoice_items(
-            target_cls=InvoiceItem, data=data, invoice=self, api_key=api_key
+        cls._stripe_object_to_line_items(
+            target_cls=LineItem, data=data, invoice=self, api_key=api_key
         )
 
     @property
@@ -779,7 +779,8 @@ class UpcomingInvoice(BaseInvoice):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._invoiceitems = []
+
+        self._lineitems = []
         self._default_tax_rates = []
         self._total_tax_amounts = []
 
@@ -792,8 +793,9 @@ class UpcomingInvoice(BaseInvoice):
         super()._attach_objects_hook(
             cls, data, api_key=api_key, current_ids=current_ids
         )
-        self._invoiceitems = cls._stripe_object_to_invoice_items(
-            target_cls=InvoiceItem, data=data, invoice=self, api_key=api_key
+
+        self._lineitems = cls._stripe_object_to_line_items(
+            target_cls=LineItem, data=data, invoice=self, api_key=api_key
         )
 
     def _attach_objects_post_save_hook(
@@ -1029,10 +1031,13 @@ class InvoiceItem(StripeModel):
     def __str__(self):
         return self.description
 
+<<<<<<< HEAD
     @classmethod
     def is_valid_object(cls, data):
         return data and data.get("object") in ("invoiceitem", "line_item")
 
+=======
+>>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
     def get_stripe_dashboard_url(self):
         return self.invoice.get_stripe_dashboard_url()
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -844,8 +844,22 @@ class UpcomingInvoice(BaseInvoice):
         return a mock of a queryset, but with the data fetched from Stripe - It
         will act like a normal queryset, but mutation will silently fail.
         """
-
         return QuerySetMock.from_iterable(InvoiceItem, self._invoiceitems)
+
+    @property
+    def lineitems(self):
+        """
+        Gets the line items associated with this upcoming invoice.
+
+        This differs from normal (non-upcoming) invoices, in that upcoming
+        invoices are in-memory and do not persist to the database. Therefore,
+        all of the data comes from the Stripe API itself.
+
+        Instead of returning a normal queryset for the lineitems, this will
+        return a mock of a queryset, but with the data fetched from Stripe - It
+        will act like a normal queryset, but mutation will silently fail.
+        """
+        return QuerySetMock.from_iterable(LineItem, self._lineitems)
 
     @property
     def default_tax_rates(self):

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -844,7 +844,13 @@ class UpcomingInvoice(BaseInvoice):
         return a mock of a queryset, but with the data fetched from Stripe - It
         will act like a normal queryset, but mutation will silently fail.
         """
-        return QuerySetMock.from_iterable(InvoiceItem, self._invoiceitems)
+        # filter lineitems with type="invoice_item" and fetch all the actual InvoiceItem objects
+        items = []
+        for item in self._lineitems:
+            if item.type == "invoice_item":
+                items.append(item.invoice_item)
+
+        return QuerySetMock.from_iterable(InvoiceItem, items)
 
     @property
     def lineitems(self):

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1031,13 +1031,6 @@ class InvoiceItem(StripeModel):
     def __str__(self):
         return self.description
 
-<<<<<<< HEAD
-    @classmethod
-    def is_valid_object(cls, data):
-        return data and data.get("object") in ("invoiceitem", "line_item")
-
-=======
->>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
     def get_stripe_dashboard_url(self):
         return self.invoice.get_stripe_dashboard_url()
 

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -63,7 +63,7 @@ def get_friendly_currency_amount(amount, currency: str) -> str:
 class QuerySetMock(QuerySet):
     """
     A mocked QuerySet class that does not handle updates.
-    Used by UpcomingInvoice.invoiceitems.
+    Used by UpcomingInvoice.invoiceitems (deprecated) and UpcomingInvoice.lineitems.
     """
 
     @classmethod

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -18,6 +18,7 @@
     -   `djstripe.signals.webhook_post_process(instance, api_key)`: Fired after webhook successful processing.
 -   `djstripe.signals.webhook_processing_error` now also takes `instance` and `api_key` arguments
 -   `stripe.api_version` is no longer manipulated by dj-stripe.
+-   Resolved ambiguity between `LineItem` and `InvoiceItem` models. It was incorrectly assumed that the `lines` List object on `Invoice` and `UpcomingInvoice` models only return `InvoiceItem` objects. Moreover `LineItem` objects can also be of type `subscription` if the user adds a Subscription to their `Invoice` as a lineitem.
 
 ## Deprecated features
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1402,7 +1402,17 @@ class InvoiceDict(StripeItem):
         return self
 
 
-FAKE_INVOICE = InvoiceDict(load_fixture("invoice_in_fakefakefakefakefake0001.json"))
+FAKE_INVOICE = load_fixture("invoice_in_fakefakefakefakefake0001.json")
+FAKE_INVOICE["lines"] = {
+    "object": "list",
+    "data": [deepcopy(FAKE_LINE_ITEM)],
+    "has_more": False,
+    "total_count": 1,
+    "url": "/v1/invoices/in_fakefakefakefakefake0001/lines",
+}
+FAKE_INVOICE = InvoiceDict(FAKE_INVOICE)
+
+
 FAKE_INVOICE_IV = InvoiceDict(load_fixture("invoice_in_fakefakefakefakefake0004.json"))
 
 
@@ -1427,24 +1437,7 @@ FAKE_INVOICE_II = InvoiceDict(
         "due_date": None,
         "ending_balance": 0,
         "lines": {
-            "data": [
-                {
-                    "id": FAKE_SUBSCRIPTION_III["id"],
-                    "object": "line_item",
-                    "amount": 2000,
-                    "currency": "usd",
-                    "description": None,
-                    "discountable": True,
-                    "livemode": True,
-                    "metadata": {},
-                    "period": {"start": 1442469907, "end": 1445061907},
-                    "plan": deepcopy(FAKE_PLAN),
-                    "proration": False,
-                    "quantity": 1,
-                    "subscription": None,
-                    "type": "subscription",
-                }
-            ],
+            "data": [deepcopy(FAKE_LINE_ITEM_SUBSCRIPTION)],
             "total_count": 1,
             "object": "list",
             "url": "/v1/invoices/in_16af5A2eZvKYlo2CJjANLL81/lines",
@@ -1490,24 +1483,7 @@ FAKE_INVOICE_III = InvoiceDict(
         "due_date": None,
         "ending_balance": 20,
         "lines": {
-            "data": [
-                {
-                    "id": FAKE_SUBSCRIPTION["id"],
-                    "object": "line_item",
-                    "amount": 2000,
-                    "currency": "usd",
-                    "description": None,
-                    "discountable": True,
-                    "livemode": True,
-                    "metadata": {},
-                    "period": {"start": 1442111228, "end": 1444703228},
-                    "plan": deepcopy(FAKE_PLAN),
-                    "proration": False,
-                    "quantity": 1,
-                    "subscription": None,
-                    "type": "subscription",
-                }
-            ],
+            "data": [deepcopy(FAKE_LINE_ITEM_SUBSCRIPTION)],
             "total_count": 1,
             "object": "list",
             "url": "/v1/invoices/in_16Z9dP2eZvKYlo2CgFHgFx2Z/lines",
@@ -1572,25 +1548,7 @@ FAKE_INVOICE_METERED_SUBSCRIPTION = InvoiceDict(
         "due_date": None,
         "ending_balance": 0,
         "lines": {
-            "data": [
-                {
-                    "amount": 2000,
-                    "id": FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"],
-                    "object": "line_item",
-                    "currency": "usd",
-                    "description": None,
-                    "discountable": True,
-                    "livemode": True,
-                    "metadata": {},
-                    "period": {"start": 1442111228, "end": 1444703228},
-                    "plan": deepcopy(FAKE_PLAN_METERED),
-                    "proration": False,
-                    "quantity": 1,
-                    "subscription": FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"],
-                    "subscription_item": FAKE_SUBSCRIPTION_ITEM["id"],
-                    "type": "subscription",
-                }
-            ],
+            "data": [deepcopy(FAKE_LINE_ITEM_SUBSCRIPTION)],
             "total_count": 1,
             "object": "list",
             "url": "/v1/invoices/in_1JGGM6JSZQVUcJYgpWqfBOIl/lines",
@@ -1648,32 +1606,7 @@ FAKE_UPCOMING_INVOICE = InvoiceDict(
         "due_date": None,
         "ending_balance": None,
         "lines": {
-            "data": [
-                {
-                    "id": FAKE_SUBSCRIPTION["id"],
-                    "object": "line_item",
-                    "amount": 2000,
-                    "currency": "usd",
-                    "description": None,
-                    "discountable": True,
-                    "livemode": True,
-                    "metadata": {},
-                    "period": {"start": 1441907581, "end": 1444499581},
-                    "plan": deepcopy(FAKE_PLAN),
-                    "proration": False,
-                    "quantity": 1,
-                    "subscription": None,
-                    "tax_amounts": [
-                        {
-                            "amount": 261,
-                            "inclusive": True,
-                            "tax_rate": "txr_fakefakefakefakefake0001",
-                        }
-                    ],
-                    "tax_rates": [],
-                    "type": "subscription",
-                }
-            ],
+            "data": [deepcopy(FAKE_LINE_ITEM_SUBSCRIPTION)],
             "total_count": 1,
             "object": "list",
             "url": "/v1/invoices/in_fakefakefakefakefake0001/lines",
@@ -1748,8 +1681,8 @@ FAKE_EVENT_TAX_ID_DELETED["type"] = "customer.tax_id.deleted"
 
 FAKE_TAX_CODE = load_fixture("tax_code_txcd_fakefakefakefakefake0001.json")
 
-FAKE_INVOICEITEM = {
-    "id": "ii_16XVTY2eZvKYlo2Cxz5n3RaS",
+FAKE_INVOICEITEM_II = {
+    "id": "ii_fakefakefakefakefake0001",
     "object": "invoiceitem",
     "amount": 2000,
     "currency": "usd",
@@ -1773,8 +1706,8 @@ FAKE_INVOICEITEM = {
     "unit_amount_decimal": "2000",
 }
 
-FAKE_INVOICEITEM_II = {
-    "id": "ii_16XVTY2eZvKYlo2Cxz5n3RaS",
+FAKE_INVOICEITEM = {
+    "id": "ii_fakefakefakefakefake0001",  # todo make these ids unique as well
     "object": "invoiceitem",
     "amount": 2000,
     "currency": "usd",
@@ -1801,7 +1734,7 @@ FAKE_INVOICEITEM_II = {
 # Invoice item with tax_rates
 # TODO generate this
 FAKE_INVOICEITEM_III = {
-    "id": "ii_16XVTY2eZvKYlo2Cxz5n3RaS",
+    "id": "ii_fakefakefakefakefake0001",  # todo make these ids unique as well
     "object": "invoiceitem",
     "amount": 2000,
     "currency": "usd",

--- a/tests/fixtures/invoice_in_fakefakefakefakefake0001.json
+++ b/tests/fixtures/invoice_in_fakefakefakefakefake0001.json
@@ -26,114 +26,30 @@
     "customer_tax_ids": [],
     "default_payment_method": null,
     "default_source": null,
-    "default_tax_rates": [
-        {
-            "id": "txr_fakefakefakefakefake0001",
-            "object": "tax_rate",
-            "active": true,
-            "created": 1593225980,
-            "description": null,
-            "display_name": "VAT",
-            "inclusive": true,
-            "jurisdiction": "Example1",
-            "livemode": false,
-            "metadata": {
-                "djstripe_test_fake_id": "txr_fakefakefakefakefake0001"
-            },
-            "percentage": 15.0
-        }
-    ],
+    "default_tax_rates": [{
+        "id": "txr_fakefakefakefakefake0001",
+        "object": "tax_rate",
+        "active": true,
+        "created": 1593225980,
+        "description": null,
+        "display_name": "VAT",
+        "inclusive": true,
+        "jurisdiction": "Example1",
+        "livemode": false,
+        "metadata": {
+            "djstripe_test_fake_id": "txr_fakefakefakefakefake0001"
+        },
+        "percentage": 15.0
+    }],
     "description": null,
     "discount": null,
+    "discounts": [],
     "due_date": null,
     "ending_balance": 0,
     "footer": null,
     "hosted_invoice_url": "https://pay.stripe.com/invoice/invst_5Z1RsP0atfAS4t9CCnnEDTDyUG",
     "invoice_pdf": "https://pay.stripe.com/invoice/invst_5Z1RsP0atfAS4t9CCnnEDTDyUG/pdf",
-    "lines": {
-        "object": "list",
-        "data": [
-            {
-                "id": "il_1GyU3dCOCguPTL2Bow2th8zP",
-                "object": "line_item",
-                "amount": 2000,
-                "currency": "usd",
-                "description": "1 \u00d7 Fake Product (at $20.00 / month)",
-                "discountable": true,
-                "livemode": false,
-                "metadata": {
-                    "djstripe_test_fake_id": "sub_fakefakefakefakefake0001"
-                },
-                "period": {
-                    "end": 1595817981,
-                    "start": 1593225981
-                },
-                "plan": {
-                    "id": "gold21323",
-                    "object": "plan",
-                    "active": true,
-                    "aggregate_usage": null,
-                    "amount": 2000,
-                    "amount_decimal": "2000",
-                    "billing_scheme": "per_unit",
-                    "created": 1558230763,
-                    "currency": "usd",
-                    "interval": "month",
-                    "interval_count": 1,
-                    "livemode": false,
-                    "metadata": {},
-                    "nickname": "New plan name",
-                    "product": "prod_fake1",
-                    "tiers": null,
-                    "tiers_mode": null,
-                    "transform_usage": null,
-                    "trial_period_days": null,
-                    "usage_type": "licensed"
-                },
-                "price": {
-                    "id": "gold21323",
-                    "object": "price",
-                    "active": true,
-                    "billing_scheme": "per_unit",
-                    "created": 1593225979,
-                    "currency": "usd",
-                    "livemode": false,
-                    "lookup_key": null,
-                    "metadata": {},
-                    "nickname": "New plan name",
-                    "product": "prod_fake1",
-                    "recurring": {
-                        "aggregate_usage": null,
-                        "interval": "month",
-                        "interval_count": 1,
-                        "trial_period_days": null,
-                        "usage_type": "licensed"
-                    },
-                    "tiers_mode": null,
-                    "transform_quantity": null,
-                    "type": "recurring",
-                    "unit_amount": 2000,
-                    "unit_amount_decimal": "2000"
-                },
-                "proration": false,
-                "quantity": 1,
-                "subscription": "sub_fakefakefakefakefake0001",
-                "subscription_item": "si_HXZCDv9ixoUB5u",
-                "tax_amounts": [
-                    {
-                        "amount": 261,
-                        "inclusive": true,
-                        "tax_rate": "txr_fakefakefakefakefake0001"
-                    }
-                ],
-                "tax_rates": [],
-                "type": "subscription"
-            }
-        ],
-        "has_more": false,
-        "total_count": 1,
-        "url": "/v1/invoices/in_fakefakefakefakefake0001/lines"
-    },
+    "lines": {},
     "livemode": false,
     "metadata": {
         "djstripe_test_fake_id": "in_fakefakefakefakefake0001"
@@ -161,13 +77,11 @@
     "tax": 261,
     "tax_percent": null,
     "total": 2000,
-    "total_tax_amounts": [
-        {
-            "amount": 261,
-            "inclusive": true,
-            "tax_rate": "txr_fakefakefakefakefake0001"
-        }
-    ],
+    "total_tax_amounts": [{
+        "amount": 261,
+        "inclusive": true,
+        "tax_rate": "txr_fakefakefakefakefake0001"
+    }],
     "transfer_data": null,
     "webhooks_delivered_at": 1557995178
 }

--- a/tests/fixtures/invoice_in_fakefakefakefakefake0004.json
+++ b/tests/fixtures/invoice_in_fakefakefakefakefake0004.json
@@ -29,6 +29,7 @@
     "default_tax_rates": [],
     "description": null,
     "discount": null,
+    "discounts": [],
     "due_date": null,
     "ending_balance": 0,
     "footer": null,
@@ -36,100 +37,94 @@
     "invoice_pdf": "https://pay.stripe.com/invoice/invst_ttp3K5exxywlAI3cGqCDxEWfsM/pdf",
     "lines": {
         "object": "list",
-        "data": [
-            {
-                "id": "il_1GyU3gCOCguPTL2B69cIweEY",
-                "object": "line_item",
+        "data": [{
+            "id": "il_1GyU3gCOCguPTL2B69cIweEY",
+            "object": "line_item",
+            "amount": 4000,
+            "currency": "usd",
+            "description": "1 \u00d7 Fake Product (at $40.00 / month)",
+            "discountable": true,
+            "livemode": false,
+            "metadata": {
+                "djstripe_test_fake_id": "sub_fakefakefakefakefake0002"
+            },
+            "period": {
+                "end": 1595817984,
+                "start": 1593225984
+            },
+            "plan": {
+                "id": "silver41294",
+                "object": "plan",
+                "active": true,
+                "aggregate_usage": null,
                 "amount": 4000,
+                "amount_decimal": "4000",
+                "billing_scheme": "per_unit",
+                "created": 1570941587,
                 "currency": "usd",
-                "description": "1 \u00d7 Fake Product (at $40.00 / month)",
-                "discountable": true,
+                "interval": "month",
+                "interval_count": 1,
                 "livemode": false,
-                "metadata": {
-                    "djstripe_test_fake_id": "sub_fakefakefakefakefake0002"
-                },
-                "period": {
-                    "end": 1595817984,
-                    "start": 1593225984
-                },
-                "plan": {
-                    "id": "silver41294",
-                    "object": "plan",
-                    "active": true,
+                "metadata": {},
+                "nickname": "New plan name",
+                "product": "prod_fake1",
+                "tiers": null,
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": 12,
+                "usage_type": "licensed"
+            },
+            "price": {
+                "id": "silver41294",
+                "object": "price",
+                "active": true,
+                "billing_scheme": "per_unit",
+                "created": 1593225979,
+                "currency": "usd",
+                "livemode": false,
+                "lookup_key": null,
+                "metadata": {},
+                "nickname": "New plan name",
+                "product": "prod_fake1",
+                "recurring": {
                     "aggregate_usage": null,
-                    "amount": 4000,
-                    "amount_decimal": "4000",
-                    "billing_scheme": "per_unit",
-                    "created": 1570941587,
-                    "currency": "usd",
                     "interval": "month",
                     "interval_count": 1,
-                    "livemode": false,
-                    "metadata": {},
-                    "nickname": "New plan name",
-                    "product": "prod_fake1",
-                    "tiers": null,
-                    "tiers_mode": null,
-                    "transform_usage": null,
                     "trial_period_days": 12,
                     "usage_type": "licensed"
                 },
-                "price": {
-                    "id": "silver41294",
-                    "object": "price",
-                    "active": true,
-                    "billing_scheme": "per_unit",
-                    "created": 1593225979,
-                    "currency": "usd",
-                    "livemode": false,
-                    "lookup_key": null,
-                    "metadata": {},
-                    "nickname": "New plan name",
-                    "product": "prod_fake1",
-                    "recurring": {
-                        "aggregate_usage": null,
-                        "interval": "month",
-                        "interval_count": 1,
-                        "trial_period_days": 12,
-                        "usage_type": "licensed"
-                    },
-                    "tiers_mode": null,
-                    "transform_quantity": null,
-                    "type": "recurring",
-                    "unit_amount": 4000,
-                    "unit_amount_decimal": "4000"
+                "tiers_mode": null,
+                "transform_quantity": null,
+                "type": "recurring",
+                "unit_amount": 4000,
+                "unit_amount_decimal": "4000"
+            },
+            "proration": false,
+            "quantity": 1,
+            "subscription": "sub_fakefakefakefakefake0002",
+            "subscription_item": "si_HXZCuxDh3W7EQm",
+            "tax_amounts": [{
+                "amount": 522,
+                "inclusive": true,
+                "tax_rate": "txr_fakefakefakefakefake0001"
+            }],
+            "tax_rates": [{
+                "id": "txr_fakefakefakefakefake0001",
+                "object": "tax_rate",
+                "active": true,
+                "created": 1593225980,
+                "description": null,
+                "display_name": "VAT",
+                "inclusive": true,
+                "jurisdiction": "Example1",
+                "livemode": false,
+                "metadata": {
+                    "djstripe_test_fake_id": "txr_fakefakefakefakefake0001"
                 },
-                "proration": false,
-                "quantity": 1,
-                "subscription": "sub_fakefakefakefakefake0002",
-                "subscription_item": "si_HXZCuxDh3W7EQm",
-                "tax_amounts": [
-                    {
-                        "amount": 522,
-                        "inclusive": true,
-                        "tax_rate": "txr_fakefakefakefakefake0001"
-                    }
-                ],
-                "tax_rates": [
-                    {
-                        "id": "txr_fakefakefakefakefake0001",
-                        "object": "tax_rate",
-                        "active": true,
-                        "created": 1593225980,
-                        "description": null,
-                        "display_name": "VAT",
-                        "inclusive": true,
-                        "jurisdiction": "Example1",
-                        "livemode": false,
-                        "metadata": {
-                            "djstripe_test_fake_id": "txr_fakefakefakefakefake0001"
-                        },
-                        "percentage": 15.0
-                    }
-                ],
-                "type": "subscription"
-            }
-        ],
+                "percentage": 15.0
+            }],
+            "type": "subscription"
+        }],
         "has_more": false,
         "total_count": 1,
         "url": "/v1/invoices/in_fakefakefakefakefake0004/lines"
@@ -161,13 +156,11 @@
     "tax": 522,
     "tax_percent": null,
     "total": 4000,
-    "total_tax_amounts": [
-        {
-            "amount": 522,
-            "inclusive": true,
-            "tax_rate": "txr_fakefakefakefakefake0001"
-        }
-    ],
+    "total_tax_amounts": [{
+        "amount": 522,
+        "inclusive": true,
+        "tax_rate": "txr_fakefakefakefakefake0001"
+    }],
     "transfer_data": null,
     "webhooks_delivered_at": 1570941591
 }

--- a/tests/test_balance_transaction.py
+++ b/tests/test_balance_transaction.py
@@ -16,10 +16,12 @@ from . import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
 )
 
 pytestmark = pytest.mark.django_db
@@ -130,6 +132,11 @@ class TestBalanceTransaction(TestCase):
         assert balance_transaction.status == FAKE_BALANCE_TRANSACTION["status"]
 
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve",
         return_value=deepcopy(FAKE_INVOICE),
         autospec=True,
@@ -162,6 +169,11 @@ class TestBalanceTransaction(TestCase):
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -171,6 +183,7 @@ class TestBalanceTransaction(TestCase):
     def test_get_source_instance(
         self,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         charge_retrieve_mock,
@@ -179,6 +192,7 @@ class TestBalanceTransaction(TestCase):
         balance_transaction_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoiceitem_retrieve_mock,
     ):
 
         balance_transaction = models.BalanceTransaction.sync_from_stripe_data(
@@ -187,6 +201,11 @@ class TestBalanceTransaction(TestCase):
         charge = models.Charge.sync_from_stripe_data(deepcopy(FAKE_CHARGE))
         assert balance_transaction.get_source_instance() == charge
 
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     @patch(
         "stripe.Invoice.retrieve",
         return_value=deepcopy(FAKE_INVOICE),
@@ -222,6 +241,11 @@ class TestBalanceTransaction(TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -229,6 +253,7 @@ class TestBalanceTransaction(TestCase):
     def test_get_stripe_dashboard_url(
         self,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         charge_retrieve_mock,
@@ -237,6 +262,7 @@ class TestBalanceTransaction(TestCase):
         balance_transaction_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoiceitem_retrieve_mock,
     ):
 
         balance_transaction = models.BalanceTransaction.sync_from_stripe_data(

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -3,7 +3,7 @@ Customer Model Tests.
 """
 import decimal
 from copy import deepcopy
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -43,6 +43,7 @@ from . import (
     FAKE_INVOICE,
     FAKE_INVOICE_III,
     FAKE_INVOICEITEM,
+    FAKE_LINE_ITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PAYMENT_METHOD_I,
     FAKE_PLAN,
@@ -53,6 +54,7 @@ from . import (
     FAKE_SOURCE_II,
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_II,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_UPCOMING_INVOICE,
     AssertStripeFksMixin,
     StripeList,
@@ -1042,6 +1044,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
         autospec=True,
@@ -1058,9 +1065,19 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         return_value=deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
         autospec=True,
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     @patch("stripe.Invoice.retrieve", autospec=True)
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -1070,13 +1087,16 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     def test_charge_doesnt_require_invoice(
         self,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_create_mock,
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
+        customer_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
@@ -1237,6 +1257,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1259,23 +1284,40 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_INVOICE_III),
+    )
+    @patch(
         "stripe.Invoice.list",
         return_value=StripeList(
             data=[deepcopy(FAKE_INVOICE), deepcopy(FAKE_INVOICE_III)]
         ),
         autospec=True,
     )
+    @patch(
+        "stripe.LineItem.retrieve", return_value=deepcopy(FAKE_LINE_ITEM), autospec=True
+    )
     @patch("djstripe.models.Invoice.retry", autospec=True)
     def test_retry_unpaid_invoices(
         self,
         invoice_retry_mock,
+        line_item_retrieve_mock,
         invoice_list_mock,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1296,6 +1338,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1318,6 +1365,14 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
+    )
+    @patch(
         "stripe.Invoice.list",
         return_value=StripeList(data=[deepcopy(FAKE_INVOICE)]),
         autospec=True,
@@ -1327,12 +1382,15 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self,
         invoice_retry_mock,
         invoice_list_mock,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1347,6 +1405,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -1358,6 +1421,16 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_INVOICE_III),
+    )
+    @patch(
         "stripe.Invoice.list",
         return_value=StripeList(data=[deepcopy(FAKE_INVOICE_III)]),
     )
@@ -1366,10 +1439,13 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self,
         invoice_retry_mock,
         invoice_list_mock,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
@@ -1393,6 +1469,11 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -1404,18 +1485,35 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_INVOICE_III),
+    )
+    @patch(
         "stripe.Invoice.list",
         return_value=StripeList(data=[deepcopy(FAKE_INVOICE_III)]),
+    )
+    @patch(
+        "stripe.LineItem.retrieve", return_value=deepcopy(FAKE_LINE_ITEM), autospec=True
     )
     @patch("djstripe.models.Invoice.retry", autospec=True)
     def test_retry_unpaid_invoices_unexpected_exception(
         self,
         invoice_retry_mock,
+        line_item_retrieve_mock,
         invoice_list_mock,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
@@ -1971,8 +2069,17 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch(
@@ -1980,14 +2087,15 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Invoice.upcoming",
-        return_value=deepcopy(FAKE_UPCOMING_INVOICE),
         autospec=True,
     )
     def test_upcoming_invoice_plan(
         self,
         invoice_upcoming_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         payment_intent_retrieve_mock,
@@ -1995,32 +2103,62 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-        # create invoice for latest_invoice in subscription to work.
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+        fake_upcoming_invoice_data = deepcopy(FAKE_UPCOMING_INVOICE)
+        fake_upcoming_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_SUBSCRIPTION["id"]
+        invoice_upcoming_mock.return_value = fake_upcoming_invoice_data
+
+        fake_subscription_item_data = deepcopy(FAKE_SUBSCRIPTION_ITEM)
+        fake_subscription_item_data["plan"] = deepcopy(FAKE_PLAN)
+        fake_subscription_item_data["subscription"] = deepcopy(FAKE_SUBSCRIPTION)["id"]
+        subscription_item_retrieve_mock.return_value = fake_subscription_item_data
 
         invoice = self.customer.upcoming_invoice()
         self.assertIsNotNone(invoice)
         self.assertIsNone(invoice.id)
         self.assertIsNone(invoice.save())
 
+<<<<<<< HEAD
         subscription_retrieve_mock.assert_called_once_with(
             api_key=ANY,
             expand=ANY,
             id=FAKE_SUBSCRIPTION["id"],
             stripe_account=None,
             stripe_version=djstripe_settings.STRIPE_API_VERSION,
+=======
+        # one more because of creating the associated line item
+        subscription_retrieve_mock.assert_has_calls(
+            [
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+            ]
+>>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
         )
+
         plan_retrieve_mock.assert_not_called()
 
-        items = invoice.invoiceitems.all()
+        items = invoice.lineitems.all()
+
         self.assertEqual(1, len(items))
-        self.assertEqual(FAKE_SUBSCRIPTION["id"], items[0].id)
+        self.assertEqual("il_fakefakefakefakefake0002", items[0].id)
+        self.assertEqual(0, invoice.invoiceitems.count())
 
         self.assertIsNotNone(invoice.plan)
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
 
-        invoice._invoiceitems = []
-        items = invoice.invoiceitems.all()
+        invoice._lineitems = []
+        items = invoice.lineitems.all()
         self.assertEqual(0, len(items))
         self.assertIsNotNone(invoice.plan)
 
@@ -2365,8 +2503,17 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch(
@@ -2374,14 +2521,15 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Invoice.upcoming",
-        return_value=deepcopy(FAKE_UPCOMING_INVOICE),
         autospec=True,
     )
     def test_upcoming_invoice(
         self,
         invoice_upcoming_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         payment_intent_retrieve_mock,
@@ -2389,31 +2537,61 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-        # create invoice for latest_invoice in subscription to work.
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+        fake_upcoming_invoice_data = deepcopy(FAKE_UPCOMING_INVOICE)
+        fake_upcoming_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_SUBSCRIPTION["id"]
+        invoice_upcoming_mock.return_value = fake_upcoming_invoice_data
+
+        fake_subscription_item_data = deepcopy(FAKE_SUBSCRIPTION_ITEM)
+        fake_subscription_item_data["plan"] = deepcopy(FAKE_PLAN)
+        fake_subscription_item_data["subscription"] = deepcopy(FAKE_SUBSCRIPTION)["id"]
+        subscription_item_retrieve_mock.return_value = fake_subscription_item_data
 
         invoice = self.customer.upcoming_invoice()
         self.assertIsNotNone(invoice)
         self.assertIsNone(invoice.id)
         self.assertIsNone(invoice.save())
 
+<<<<<<< HEAD
         subscription_retrieve_mock.assert_called_once_with(
             api_key=ANY,
             expand=ANY,
             id=FAKE_SUBSCRIPTION["id"],
             stripe_account=None,
             stripe_version=djstripe_settings.STRIPE_API_VERSION,
+=======
+        # one more because of creating the associated line item
+        subscription_retrieve_mock.assert_has_calls(
+            [
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+            ]
+>>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
         )
+
         plan_retrieve_mock.assert_not_called()
 
-        items = invoice.invoiceitems.all()
+        items = invoice.lineitems.all()
+
         self.assertEqual(1, len(items))
-        self.assertEqual(FAKE_SUBSCRIPTION["id"], items[0].id)
+        self.assertEqual("il_fakefakefakefakefake0002", items[0].id)
+        self.assertEqual(0, invoice.invoiceitems.count())
 
         self.assertIsNotNone(invoice.plan)
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
 
-        invoice._invoiceitems = []
-        items = invoice.invoiceitems.all()
+        invoice._lineitems = []
+        items = invoice.lineitems.all()
         self.assertEqual(0, len(items))
         self.assertIsNotNone(invoice.plan)

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -2119,14 +2119,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
         self.assertIsNone(invoice.id)
         self.assertIsNone(invoice.save())
 
-<<<<<<< HEAD
-        subscription_retrieve_mock.assert_called_once_with(
-            api_key=ANY,
-            expand=ANY,
-            id=FAKE_SUBSCRIPTION["id"],
-            stripe_account=None,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
-=======
         # one more because of creating the associated line item
         subscription_retrieve_mock.assert_has_calls(
             [
@@ -2143,7 +2135,6 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
                     stripe_account=None,
                 ),
             ]
->>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
         )
 
         plan_retrieve_mock.assert_not_called()
@@ -2553,14 +2544,6 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
         self.assertIsNone(invoice.id)
         self.assertIsNone(invoice.save())
 
-<<<<<<< HEAD
-        subscription_retrieve_mock.assert_called_once_with(
-            api_key=ANY,
-            expand=ANY,
-            id=FAKE_SUBSCRIPTION["id"],
-            stripe_account=None,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
-=======
         # one more because of creating the associated line item
         subscription_retrieve_mock.assert_has_calls(
             [
@@ -2577,7 +2560,6 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
                     stripe_account=None,
                 ),
             ]
->>>>>>> 620ab159 (Updated the application code to resolve the ambiguity between LineItem and InvoiceItem)
         )
 
         plan_retrieve_mock.assert_not_called()

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -2127,12 +2127,14 @@ class TestCustomer(AssertStripeFksMixin, TestCase):
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
                 call(
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
             ]
         )
@@ -2552,12 +2554,14 @@ class TestCustomerLegacy(AssertStripeFksMixin, TestCase):
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
                 call(
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
             ]
         )

--- a/tests/test_event_handlers.py
+++ b/tests/test_event_handlers.py
@@ -145,6 +145,7 @@ from . import (
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_CANCELED,
     FAKE_SUBSCRIPTION_III,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_SUBSCRIPTION_SCHEDULE,
     FAKE_TAX_ID,
     FAKE_TAX_ID_UPDATED,
@@ -712,6 +713,11 @@ class TestChargeEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
     )
@@ -728,10 +734,20 @@ class TestChargeEvents(EventTestCase):
     )
     @patch("stripe.Event.retrieve", autospec=True)
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -741,13 +757,16 @@ class TestChargeEvents(EventTestCase):
     def test_charge_created(
         self,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         event_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
+        customer_retrieve_mock,
         account_mock,
     ):
         FAKE_CUSTOMER.create_for_user(self.user)
@@ -784,6 +803,11 @@ class TestCheckoutEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -796,6 +820,11 @@ class TestCheckoutEvents(EventTestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -815,10 +844,12 @@ class TestCheckoutEvents(EventTestCase):
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
@@ -840,6 +871,11 @@ class TestCheckoutEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -852,6 +888,11 @@ class TestCheckoutEvents(EventTestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -871,10 +912,12 @@ class TestCheckoutEvents(EventTestCase):
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
@@ -898,6 +941,11 @@ class TestCheckoutEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -910,6 +958,11 @@ class TestCheckoutEvents(EventTestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -929,10 +982,12 @@ class TestCheckoutEvents(EventTestCase):
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
@@ -954,6 +1009,11 @@ class TestCheckoutEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -966,6 +1026,11 @@ class TestCheckoutEvents(EventTestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -987,10 +1052,12 @@ class TestCheckoutEvents(EventTestCase):
         payment_intent_retrieve_mock,
         customer_modify_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         session_retrieve_mock,
     ):
@@ -1291,9 +1358,19 @@ class TestCustomerEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Plan.retrieve", return_value=deepcopy(FAKE_PLAN), autospec=True)
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
     @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
@@ -1310,8 +1387,10 @@ class TestCustomerEvents(EventTestCase):
         customer_retrieve_mock,
         product_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         plan_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
@@ -1729,6 +1808,11 @@ class TestInvoiceEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1740,6 +1824,11 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "stripe.PaymentIntent.retrieve",
         return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch(
@@ -1760,10 +1849,12 @@ class TestInvoiceEvents(EventTestCase):
         paymentmethod_card_retrieve_mock,
         event_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1791,6 +1882,11 @@ class TestInvoiceEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1802,6 +1898,11 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "stripe.PaymentIntent.retrieve",
         return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch("stripe.Invoice.retrieve", autospec=True)
@@ -1820,10 +1921,12 @@ class TestInvoiceEvents(EventTestCase):
         paymentmethod_card_retrieve_mock,
         event_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1856,6 +1959,11 @@ class TestInvoiceEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1864,6 +1972,11 @@ class TestInvoiceEvents(EventTestCase):
     @patch(
         "stripe.PaymentIntent.retrieve",
         return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch(
@@ -1882,9 +1995,11 @@ class TestInvoiceEvents(EventTestCase):
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1927,6 +2042,11 @@ class TestInvoiceItemEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -1966,6 +2086,7 @@ class TestInvoiceItemEvents(EventTestCase):
         paymentmethod_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1978,6 +2099,11 @@ class TestInvoiceItemEvents(EventTestCase):
         fake_subscription["latest_invoice"] = FAKE_INVOICE_II["id"]
         subscription_retrieve_mock.return_value = fake_subscription
 
+        fake_stripe_event = deepcopy(FAKE_EVENT_INVOICEITEM_CREATED)
+        event_retrieve_mock.return_value = fake_stripe_event
+
+        invoiceitem_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
+
         fake_card = deepcopy(FAKE_CARD_II)
         fake_card["customer"] = None
         # create Card for FAKE_CUSTOMER_III
@@ -1987,11 +2113,6 @@ class TestInvoiceItemEvents(EventTestCase):
         Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE_II))
 
         FAKE_CUSTOMER_II.create_for_user(self.user)
-
-        fake_stripe_event = deepcopy(FAKE_EVENT_INVOICEITEM_CREATED)
-        event_retrieve_mock.return_value = fake_stripe_event
-
-        invoiceitem_retrieve_mock.return_value = fake_stripe_event["data"]["object"]
 
         event = Event.sync_from_stripe_data(fake_stripe_event)
         event.invoke_webhook_handlers()
@@ -2012,6 +2133,11 @@ class TestInvoiceItemEvents(EventTestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -2056,6 +2182,7 @@ class TestInvoiceItemEvents(EventTestCase):
         paymentmethod_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -2435,6 +2562,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -2454,6 +2586,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     @patch(
@@ -2471,11 +2608,13 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         customer_retrieve_mock,
         schedule_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         # create latest invoice
@@ -2675,6 +2814,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -2694,6 +2838,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     @patch("stripe.SubscriptionSchedule.retrieve", autospec=True)
@@ -2707,11 +2856,13 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         customer_retrieve_mock,
         schedule_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_SUBSCRIPTION_SCHEDULE_CREATED)
@@ -2755,6 +2906,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -2771,6 +2927,11 @@ class TestSubscriptionScheduleEvents(EventTestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
@@ -2790,11 +2951,13 @@ class TestSubscriptionScheduleEvents(EventTestCase):
         customer_retrieve_mock,
         schedule_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_subscription = deepcopy(FAKE_SUBSCRIPTION)
@@ -2985,6 +3148,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3007,6 +3175,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3016,12 +3189,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_CREATED)
@@ -3043,6 +3218,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3065,6 +3245,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3074,12 +3259,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_UPDATED)
@@ -3102,6 +3289,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3124,6 +3316,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3133,12 +3330,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_SUBMITTED)
@@ -3161,6 +3360,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3183,6 +3387,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3192,12 +3401,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_PROCESSING)
@@ -3220,6 +3431,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3242,6 +3458,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3251,12 +3472,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_CANCELLED)
@@ -3279,6 +3502,11 @@ class TestOrderEvents(EventTestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -3301,6 +3529,11 @@ class TestOrderEvents(EventTestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch("stripe.Order.retrieve", autospec=True)
@@ -3310,12 +3543,14 @@ class TestOrderEvents(EventTestCase):
         event_retrieve_mock,
         order_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_stripe_event = deepcopy(FAKE_EVENT_ORDER_COMPLETED)

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -3,7 +3,7 @@ dj-stripe Invoice Model Tests.
 """
 from copy import deepcopy
 from decimal import Decimal
-from unittest.mock import ANY, patch
+from unittest.mock import call, patch
 
 import pytest
 import stripe
@@ -21,12 +21,15 @@ from . import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
-    FAKE_INVOICEITEM_II,
+    FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE,
+    FAKE_INVOICEITEM,
+    FAKE_LINE_ITEM_SUBSCRIPTION,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
     FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
     FAKE_TAX_RATE_EXAMPLE_2_SALES,
     FAKE_UPCOMING_INVOICE,
@@ -70,6 +73,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         }
 
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "djstripe.models.Account.get_default_account",
         autospec=True,
     )
@@ -97,8 +105,24 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
+    )
     def test_sync_from_stripe_data(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
@@ -106,6 +130,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         subscription_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
+        customer_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
         invoice = Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
@@ -137,12 +162,22 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         self.assert_fks(invoice, expected_blank_fks=self.default_expected_blank_fks)
 
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "djstripe.models.Account.get_default_account",
         autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -164,15 +199,27 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
+    )
     def test_sync_from_stripe_data_update_total_tax_amounts(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
+        customer_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
         invoice = Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
@@ -239,12 +286,22 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         )
 
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "djstripe.models.Account.get_default_account",
         autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -266,19 +323,34 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve",
+        autospec=True,
+    )
     def test_sync_from_stripe_data_default_payment_method(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
+        customer_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
         fake_invoice = deepcopy(FAKE_INVOICE)
         fake_invoice["default_payment_method"] = deepcopy(FAKE_CARD_AS_PAYMENT_METHOD)
+        invoice_retrieve_mock.return_value = fake_invoice
+
         invoice = Invoice.sync_from_stripe_data(fake_invoice)
 
         self.assertEqual(
@@ -301,6 +373,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -319,13 +396,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_billing_reason_enum(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -359,6 +443,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -377,13 +466,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_invoice_status_enum(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -405,6 +501,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
             # trigger model field validation (including enum value choices check)
             invoice.full_clean()
 
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     @patch("stripe.Invoice.retrieve", autospec=True)
     @patch(
         "djstripe.models.Account.get_default_account",
@@ -413,6 +514,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -441,9 +547,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
 
@@ -466,6 +574,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
         self.assert_fks(invoice, expected_blank_fks=self.default_expected_blank_fks)
 
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     @patch("stripe.Invoice.retrieve", autospec=True)
     @patch(
         "djstripe.models.Account.get_default_account",
@@ -474,6 +587,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -502,9 +620,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
 
@@ -529,6 +649,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -547,13 +672,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_status_draft(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -577,6 +709,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -595,13 +732,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_status_open(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -625,6 +769,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -643,13 +792,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_status_paid(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -671,6 +827,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -689,13 +850,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_status_uncollectible(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -719,6 +887,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -737,13 +910,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_status_void(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -757,6 +937,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
         self.assert_fks(invoice, expected_blank_fks=self.default_expected_blank_fks)
 
+    @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
     @patch(
         "djstripe.models.Account.get_default_account",
         autospec=True,
@@ -776,7 +961,25 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         return_value=deepcopy(FAKE_PLAN),
         autospec=True,
     )
-    @patch("stripe.Subscription.retrieve", autospec=True)
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve",
+        autospec=True,
+    )
+    @patch(
+        "stripe.Subscription.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+    )
     @patch("stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE), autospec=True)
     @patch(
         "stripe.PaymentIntent.retrieve",
@@ -792,26 +995,28 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        subscription_item_retrieve_mock,
         plan_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
+        customer_retrieve_mock,
     ):
         default_account_mock.return_value = self.account
 
         invoice_data = deepcopy(FAKE_INVOICE)
         invoice_data.update({"subscription": None})
         invoice_data["lines"]["data"][0]["subscription"] = None
+
+        invoice_retrieve_mock.return_value = invoice_data
         invoice = Invoice.sync_from_stripe_data(invoice_data)
 
         self.assertEqual(None, invoice.subscription)
 
         self.assertEqual(FAKE_CHARGE["id"], invoice.charge.id)
-        self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
-
-        # charge_retrieve_mock.assert_not_called()
         plan_retrieve_mock.assert_not_called()
-        subscription_retrieve_mock.assert_not_called()
 
         self.assert_fks(
             invoice,
@@ -826,6 +1031,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -847,13 +1057,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_invoice_with_subscription_invoice_items(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -865,13 +1082,8 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         items = invoice.invoiceitems.all()
         self.assertEqual(1, len(items))
 
-        # Previously the test asserted item_id="{invoice_id}-{subscription_id}",
-        # but this doesn't match what I'm seeing from Stripe
-        # I'm not sure if it's possible to predict the whole item id now,
-        # sli seems to not reference anything
-        item_id_prefix = f"{invoice.id}-il_"
-        self.assertTrue(items[0].id.startswith(item_id_prefix))
-        self.assertEqual(items[0].subscription.id, FAKE_SUBSCRIPTION["id"])
+        self.assertEqual(items[0].id, "ii_fakefakefakefakefake0001")
+        self.assertIsNone(items[0].subscription)
 
         self.assert_fks(invoice, expected_blank_fks=self.default_expected_blank_fks)
 
@@ -934,6 +1146,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -952,25 +1169,33 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_invoice_with_non_subscription_invoice_items(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
 
         invoice_data = deepcopy(FAKE_INVOICE)
-        invoice_data["lines"]["data"].append(deepcopy(FAKE_INVOICEITEM_II))
+        invoice_data["lines"]["data"].append(deepcopy(FAKE_LINE_ITEM_SUBSCRIPTION))
         invoice_data["lines"]["total_count"] += 1
         invoice = Invoice.sync_from_stripe_data(invoice_data)
 
         self.assertIsNotNone(invoice)
-        self.assertEqual(2, len(invoice.invoiceitems.all()))
+        # assert only 1 line item of type="invoice_item"
+        self.assertEqual(1, len(invoice.invoiceitems.all()))
 
         self.assert_fks(invoice, expected_blank_fks=self.default_expected_blank_fks)
 
@@ -984,6 +1209,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1002,13 +1232,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_invoice_plan_from_invoice_items(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1032,6 +1269,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -1050,13 +1292,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
     def test_invoice_plan_from_subscription(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1064,6 +1313,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
 
         invoice_data = deepcopy(FAKE_INVOICE)
         invoice_data["lines"]["data"][0]["plan"] = None
+
         invoice = Invoice.sync_from_stripe_data(invoice_data)
         self.assertIsNotNone(invoice.plan)  # retrieved from subscription
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
@@ -1077,6 +1327,11 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch("stripe.Subscription.retrieve", autospec=True)
@@ -1094,13 +1349,19 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        autospec=True,
+    )
     def test_invoice_without_plan(
         self,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         charge_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         payment_intent_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
@@ -1110,6 +1371,13 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         invoice_data["lines"]["data"][0]["plan"] = None
         invoice_data["lines"]["data"][0]["subscription"] = None
         invoice_data["subscription"] = None
+
+        fake_invoice_item = deepcopy(FAKE_INVOICEITEM)
+        fake_invoice_item["subscription"] = None
+        invoice_item_retrieve_mock.return_value = fake_invoice_item
+
+        subscription_retrieve_mock.return_value = deepcopy(FAKE_SUBSCRIPTION)
+
         invoice = Invoice.sync_from_stripe_data(invoice_data)
         self.assertIsNone(invoice.plan)
 
@@ -1136,11 +1404,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     @patch(
         "stripe.Plan.retrieve",
         return_value=deepcopy(FAKE_PLAN),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
         autospec=True,
     )
     @patch(
@@ -1150,7 +1427,6 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Invoice.upcoming",
-        return_value=deepcopy(FAKE_UPCOMING_INVOICE),
         autospec=True,
     )
     @patch(
@@ -1161,15 +1437,26 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         product_retrieve_mock,
         invoice_upcoming_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         plan_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-        # create invoice for latest_invoice in subscription to work.
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        fake_upcoming_invoice_data = deepcopy(FAKE_UPCOMING_INVOICE)
+        fake_upcoming_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_SUBSCRIPTION["id"]
+        invoice_upcoming_mock.return_value = fake_upcoming_invoice_data
+
+        fake_subscription_item_data = deepcopy(FAKE_SUBSCRIPTION_ITEM)
+        fake_subscription_item_data["plan"] = deepcopy(FAKE_PLAN)
+        fake_subscription_item_data["subscription"] = deepcopy(FAKE_SUBSCRIPTION)["id"]
+        subscription_item_retrieve_mock.return_value = fake_subscription_item_data
 
         invoice = UpcomingInvoice.upcoming()
         self.assertIsNotNone(invoice)
@@ -1180,28 +1467,40 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         invoice.id = "foo"
         self.assertIsNone(invoice.id)
 
-        subscription_retrieve_mock.assert_called_once_with(
-            api_key=ANY,
-            expand=ANY,
-            id=FAKE_SUBSCRIPTION["id"],
-            stripe_account=None,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
+        # one more because of creating the associated line item
+        subscription_retrieve_mock.assert_has_calls(
+            [
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+            ]
         )
+
         plan_retrieve_mock.assert_not_called()
 
-        items = invoice.invoiceitems.all()
+        items = invoice.lineitems.all()
         self.assertEqual(1, len(items))
-        self.assertEqual(FAKE_SUBSCRIPTION["id"], items[0].id)
+        self.assertEqual("il_fakefakefakefakefake0002", items[0].id)
+        self.assertEqual(0, invoice.invoiceitems.count())
 
         # delete/update should do nothing
-        self.assertEqual(invoice.invoiceitems.update(), 0)
-        self.assertEqual(invoice.invoiceitems.delete(), 0)
+        self.assertEqual(invoice.lineitems.update(), 0)
+        self.assertEqual(invoice.lineitems.delete(), 0)
 
         self.assertIsNotNone(invoice.plan)
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
 
-        invoice._invoiceitems = []
-        items = invoice.invoiceitems.all()
+        invoice._lineitems = []
+        items = invoice.lineitems.all()
         self.assertEqual(0, len(items))
         self.assertIsNotNone(invoice.plan)
 
@@ -1238,11 +1537,20 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     @patch("stripe.Plan.retrieve", autospec=True)
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -1251,23 +1559,33 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Invoice.upcoming",
-        return_value=deepcopy(FAKE_UPCOMING_INVOICE),
         autospec=True,
     )
     def test_upcoming_invoice_with_subscription(
         self,
         invoice_upcoming_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-        # create invoice for latest_invoice in subscription to work.
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+
+        fake_upcoming_invoice_data = deepcopy(FAKE_UPCOMING_INVOICE)
+        fake_upcoming_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_SUBSCRIPTION["id"]
+        invoice_upcoming_mock.return_value = fake_upcoming_invoice_data
+
+        fake_subscription_item_data = deepcopy(FAKE_SUBSCRIPTION_ITEM)
+        fake_subscription_item_data["plan"] = deepcopy(FAKE_PLAN)
+        fake_subscription_item_data["subscription"] = deepcopy(FAKE_SUBSCRIPTION)["id"]
+        subscription_item_retrieve_mock.return_value = fake_subscription_item_data
 
         invoice = Invoice.upcoming(
             subscription=Subscription(id=FAKE_SUBSCRIPTION["id"])
@@ -1276,18 +1594,34 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         self.assertIsNone(invoice.id)
         self.assertIsNone(invoice.save())
 
-        subscription_retrieve_mock.assert_called_once_with(
-            api_key=ANY,
-            expand=ANY,
-            id=FAKE_SUBSCRIPTION["id"],
-            stripe_account=None,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
+        # one more because of creating the associated line item
+        subscription_retrieve_mock.assert_has_calls(
+            [
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+                call(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    id=FAKE_SUBSCRIPTION["id"],
+                    stripe_account=None,
+                ),
+            ]
         )
+
         plan_retrieve_mock.assert_not_called()
 
         self.assertIsNotNone(invoice.plan)
         self.assertEqual(FAKE_PLAN["id"], invoice.plan.id)
 
+    @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
@@ -1305,17 +1639,22 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
-        "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
+    @patch("stripe.Invoice.retrieve", autospec=True)
     @patch("stripe.Plan.retrieve", autospec=True)
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
-        return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
     )
     @patch(
         "stripe.Invoice.upcoming",
-        return_value=deepcopy(FAKE_UPCOMING_INVOICE),
         autospec=True,
     )
     @patch(
@@ -1326,15 +1665,38 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         product_retrieve_mock,
         invoice_upcoming_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         plan_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         balance_transaction_retrieve_mock,
+        customer_retrieve_mock,
     ):
-        # create invoice for latest_invoice in subscription to work.
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
+        fake_upcoming_invoice_data = deepcopy(FAKE_UPCOMING_INVOICE)
+        fake_upcoming_invoice_data[
+            "subscription"
+        ] = FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"]
+        invoice_upcoming_mock.return_value = fake_upcoming_invoice_data
+
+        fake_invoice_data = deepcopy(FAKE_INVOICE)
+        fake_invoice_data["subscription"] = FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE[
+            "id"
+        ]
+        fake_invoice_data["lines"]["data"][0][
+            "subscription"
+        ] = FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"]
+        invoice_retrieve_mock.return_value = fake_invoice_data
+
+        fake_subscription_item_data = deepcopy(FAKE_SUBSCRIPTION_ITEM)
+        fake_subscription_item_data["plan"] = deepcopy(FAKE_PLAN)
+        subscription_item_retrieve_mock.return_value = fake_subscription_item_data
+
+        fake_subscription_data = deepcopy(FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE)
+        fake_subscription_data["plan"] = deepcopy(FAKE_PLAN)
+        subscription_retrieve_mock.return_value = fake_subscription_data
 
         invoice = Invoice.upcoming(subscription_plan=Plan(id=FAKE_PLAN["id"]))
         self.assertIsNotNone(invoice)
@@ -1342,11 +1704,10 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
         self.assertIsNone(invoice.save())
 
         subscription_retrieve_mock.assert_called_once_with(
-            api_key=ANY,
-            expand=ANY,
-            id=FAKE_SUBSCRIPTION["id"],
+            api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            expand=[],
+            id=FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"],
             stripe_account=None,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
         )
         plan_retrieve_mock.assert_not_called()
 
@@ -1388,12 +1749,15 @@ class TestInvoiceDecimal:
             (23.2345678, Decimal("23.24")),
         ],
     )
-    def test_decimal_tax_percent(self, inputted, expected, monkeypatch):
+    def test_decimal_tax_percent(self, inputted, expected, monkeypatch):  # noqa: C901
         fake_invoice = deepcopy(FAKE_INVOICE)
         fake_invoice["tax_percent"] = inputted
 
         def mock_invoice_get(*args, **kwargs):
             return fake_invoice
+
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
 
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
@@ -1410,6 +1774,9 @@ class TestInvoiceDecimal:
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
 
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
+
         def mock_balance_transaction_get(*args, **kwargs):
             return FAKE_BALANCE_TRANSACTION
 
@@ -1419,11 +1786,15 @@ class TestInvoiceDecimal:
         # monkeypatch stripe retrieve calls to return
         # the desired json response.
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
         monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -1475,12 +1475,14 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
                 call(
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
             ]
         )
@@ -1602,12 +1604,14 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
                 call(
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     id=FAKE_SUBSCRIPTION["id"],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
             ]
         )
@@ -1708,6 +1712,7 @@ class InvoiceTest(AssertStripeFksMixin, TestCase):
             expand=[],
             id=FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE["id"],
             stripe_account=None,
+            stripe_version="2020-08-27",
         )
         plan_retrieve_mock.assert_not_called()
 

--- a/tests/test_invoiceitem.py
+++ b/tests/test_invoiceitem.py
@@ -32,6 +32,7 @@ from . import (
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_III,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_TAX_RATE_EXAMPLE_1_VAT,
     AssertStripeFksMixin,
 )
@@ -69,10 +70,6 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         }
 
     @patch(
-        "djstripe.models.Account.get_default_account",
-        autospec=True,
-    )
-    @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
         autospec=True,
@@ -82,77 +79,71 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
-        "stripe.Subscription.retrieve",
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
+        "stripe.Subscription.retrieve",
+        autospec=True,
+        return_value=deepcopy(FAKE_SUBSCRIPTION),
+    )
+    @patch(
         "stripe.PaymentMethod.retrieve",
-        side_effect=[
-            deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
-            deepcopy(FAKE_PAYMENT_METHOD_II),
-        ],
+        return_value=deepcopy(FAKE_CARD_AS_PAYMENT_METHOD),
         autospec=True,
     )
     @patch(
         "stripe.PaymentIntent.retrieve",
-        side_effect=[deepcopy(FAKE_PAYMENT_INTENT_I), deepcopy(FAKE_PAYMENT_INTENT_II)],
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
         autospec=True,
     )
     @patch(
         "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
         autospec=True,
     )
     @patch(
         "stripe.Charge.retrieve",
-        side_effect=[deepcopy(FAKE_CHARGE), deepcopy(FAKE_CHARGE_II)],
+        return_value=deepcopy(FAKE_CHARGE),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
         autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve",
-        side_effect=[deepcopy(FAKE_INVOICE), deepcopy(FAKE_INVOICE_II)],
+        return_value=deepcopy(FAKE_INVOICE),
         autospec=True,
     )
     def test___str__(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         paymentintent_retrieve_mock,
         paymentmethod_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         balance_transaction_retrieve_mock,
-        default_account_mock,
     ):
-
-        fake_subscription = deepcopy(FAKE_SUBSCRIPTION_III)
-        fake_subscription["latest_invoice"] = FAKE_INVOICE["id"]
-        subscription_retrieve_mock.side_effect = [
-            deepcopy(FAKE_SUBSCRIPTION),
-            fake_subscription,
-        ]
-
-        fake_customer = deepcopy(FAKE_CUSTOMER_II)
-        customer_retrieve_mock.side_effect = [deepcopy(FAKE_CUSTOMER), fake_customer]
 
         fake_card = deepcopy(FAKE_CARD_II)
         fake_card["customer"] = None
+
         # create Card for FAKE_CUSTOMER_III
         Card.sync_from_stripe_data(fake_card)
 
         # create invoice for latest_invoice in subscription to work.
         Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
-        # create invoice
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE_II))
+        invoiceitem = InvoiceItem.sync_from_stripe_data(deepcopy(FAKE_INVOICEITEM))
 
-        default_account_mock.return_value = self.account
-
-        invoiceitem_data = deepcopy(FAKE_INVOICEITEM)
-        invoiceitem_data["plan"] = FAKE_PLAN_II
-        invoiceitem_data["price"] = FAKE_PRICE_II
-        invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
         self.assertEqual(
             invoiceitem.get_stripe_dashboard_url(),
             invoiceitem.invoice.get_stripe_dashboard_url(),
@@ -171,6 +162,11 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -195,6 +191,10 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve",
         return_value=deepcopy(FAKE_INVOICE_II),
         autospec=True,
@@ -202,11 +202,13 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     def test_sync_with_subscription(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         paymentintent_retrieve_mock,
         paymentmethod_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
@@ -225,15 +227,17 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         fake_card = deepcopy(FAKE_CARD_II)
         fake_card["customer"] = None
 
-        # create Card for FAKE_CUSTOMER_III
+        # create Card for FAKE_CUSTOMER_II
         Card.sync_from_stripe_data(fake_card)
 
         default_account_mock.return_value = self.account
 
         invoiceitem_data = deepcopy(FAKE_INVOICEITEM)
         invoiceitem_data.update({"subscription": fake_subscription["id"]})
-        invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
+        invoiceitem_data.update({"invoice": FAKE_INVOICE_II["id"]})
+        invoice_item_retrieve_mock.return_value = invoiceitem_data
 
+        invoiceitem = InvoiceItem.sync_from_stripe_data(invoiceitem_data)
         expected_blank_fks = self.default_expected_blank_fks | {
             "djstripe.InvoiceItem.plan",
             "djstripe.InvoiceItem.price",
@@ -273,6 +277,11 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -294,16 +303,23 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
     )
     def test_sync_expanded_invoice_with_subscription(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         paymentintent_retrieve_mock,
         paymentmethod_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
@@ -369,6 +385,11 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         autospec=True,
     )
@@ -390,16 +411,23 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Charge.retrieve", return_value=deepcopy(FAKE_CHARGE_II), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
     )
     def test_sync_proration(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         paymentintent_retrieve_mock,
         paymentmethod_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         plan_retrieve_mock,
         price_retrieve_mock,
@@ -505,7 +533,11 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         self.assert_fks(
             invoiceitem,
             expected_blank_fks=self.default_expected_blank_fks
-            | {"djstripe.InvoiceItem.invoice", "djstripe.InvoiceItem.subscription"},
+            | {
+                "djstripe.InvoiceItem.invoice",
+                "djstripe.InvoiceItem.subscription",
+                "djstripe.Customer.default_source",
+            },
         )
 
     @patch(
@@ -519,6 +551,11 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Subscription.retrieve",
@@ -542,16 +579,23 @@ class InvoiceItemTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE_II), autospec=True
     )
     def test_sync_with_taxes(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         paymentintent_retrieve_mock,
         paymentmethod_retrieve_mock,
         charge_retrieve_mock,
         customer_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         product_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -18,6 +18,8 @@ from . import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
+    FAKE_LINE_ITEM,
     FAKE_ORDER_WITH_CUSTOMER_WITH_PAYMENT_INTENT,
     FAKE_ORDER_WITH_CUSTOMER_WITHOUT_PAYMENT_INTENT,
     FAKE_ORDER_WITHOUT_CUSTOMER_WITH_PAYMENT_INTENT,
@@ -27,6 +29,7 @@ from . import (
     FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     AssertStripeFksMixin,
 )
 
@@ -37,6 +40,11 @@ class TestOrder(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -62,17 +70,24 @@ class TestOrder(AssertStripeFksMixin, TestCase):
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     def test_sync_from_stripe_data(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         default_expected_blank_fks = {
@@ -210,9 +225,18 @@ class TestOrderStr:
             """Monkeypatched stripe.Invoice.retrieve"""
             return deepcopy(FAKE_INVOICE)
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_subscription_get(*args, **kwargs):
             """Monkeypatched stripe.Subscription.retrieve"""
             return deepcopy(FAKE_SUBSCRIPTION)
+
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
 
         def mock_balance_transaction_get(*args, **kwargs):
             """Monkeypatched stripe.BalanceTransaction.retrieve"""
@@ -235,7 +259,12 @@ class TestOrderStr:
 
         # because of Reverse o2o field sync due to PaymentIntent.sync_from_stripe_data..
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
@@ -274,6 +303,11 @@ class TestOrderMethods:
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -296,6 +330,11 @@ class TestOrderMethods:
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
@@ -305,12 +344,14 @@ class TestOrderMethods:
         self,
         order_cancel_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         api_key,
         expected_api_key,
@@ -356,6 +397,11 @@ class TestOrderMethods:
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -378,6 +424,11 @@ class TestOrderMethods:
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
@@ -387,12 +438,14 @@ class TestOrderMethods:
         self,
         order_reopen_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         api_key,
         expected_api_key,
@@ -438,6 +491,11 @@ class TestOrderMethods:
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -460,6 +518,11 @@ class TestOrderMethods:
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
@@ -469,12 +532,14 @@ class TestOrderMethods:
         self,
         order_submit_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         api_key,
         expected_api_key,

--- a/tests/test_payment_intent.py
+++ b/tests/test_payment_intent.py
@@ -9,6 +9,7 @@ import stripe
 from django.test import TestCase
 
 from djstripe.models import PaymentIntent
+from djstripe.models.billing import Invoice
 
 from . import (
     FAKE_ACCOUNT,
@@ -16,11 +17,13 @@ from . import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_DESTINATION_CHARGE,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PAYMENT_METHOD_I,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     AssertStripeFksMixin,
 )
 
@@ -76,9 +79,15 @@ class TestStrPaymentIntent:
             """Monkeypatched stripe.Invoice.retrieve"""
             return deepcopy(FAKE_INVOICE)
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
         def mock_subscription_get(*args, **kwargs):
             """Monkeypatched stripe.Subscription.retrieve"""
             return deepcopy(FAKE_SUBSCRIPTION)
+
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
 
         def mock_balance_transaction_get(*args, **kwargs):
             """Monkeypatched stripe.BalanceTransaction.retrieve"""
@@ -100,6 +109,10 @@ class TestStrPaymentIntent:
 
         # because of Reverse o2o field sync due to PaymentIntent.sync_from_stripe_data..
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
@@ -144,6 +157,11 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -158,7 +176,17 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.PaymentIntent.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
+        autospec=True,
+    )
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -166,14 +194,16 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     def test_sync_from_stripe_data(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
+        paymentintent_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
-
         payment_intent = PaymentIntent.sync_from_stripe_data(
             deepcopy(FAKE_PAYMENT_INTENT_I)
         )
@@ -212,6 +242,11 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -226,7 +261,17 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.PaymentIntent.retrieve",
+        return_value=deepcopy(FAKE_PAYMENT_INTENT_I),
+        autospec=True,
+    )
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -234,11 +279,14 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     def test_status_enum(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
+        paymentintent_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
@@ -265,6 +313,11 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -279,7 +332,16 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.PaymentIntent.retrieve",
+        autospec=True,
+    )
+    @patch(
         "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -287,11 +349,14 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
     def test_canceled_intent(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         customer_retrieve_mock,
+        paymentintent_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
         fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
@@ -310,6 +375,8 @@ class PaymentIntentTest(AssertStripeFksMixin, TestCase):
             "automatic",
         ):
             fake_payment_intent["cancellation_reason"] = reason
+            paymentintent_retrieve_mock.return_value = fake_payment_intent
+
             payment_intent = PaymentIntent.sync_from_stripe_data(fake_payment_intent)
             assert payment_intent
 

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -8,20 +8,21 @@ from django.contrib.auth import get_user_model
 from django.test.testcases import TestCase
 
 from djstripe import enums
-from djstripe.models import Invoice, Refund
+from djstripe.models import Refund
 
 from . import (
-    FAKE_BALANCE_TRANSACTION,
     FAKE_BALANCE_TRANSACTION_REFUND,
     FAKE_CARD_AS_PAYMENT_METHOD,
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLATFORM_ACCOUNT,
     FAKE_PRODUCT,
     FAKE_REFUND,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     AssertStripeFksMixin,
 )
 
@@ -67,7 +68,11 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
-        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -89,19 +94,32 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     def test_sync_from_stripe_data(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
-        # TODO - remove invoice sync
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
         fake_refund = deepcopy(FAKE_REFUND)
 
@@ -119,7 +137,11 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
-        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -141,19 +163,32 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     def test___str__(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
-        # TODO - remove invoice sync
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
         fake_refund = deepcopy(FAKE_REFUND)
         fake_refund["reason"] = enums.RefundReason.requested_by_customer
@@ -168,14 +203,17 @@ class RefundTest(AssertStripeFksMixin, TestCase):
 
         self.assert_fks(refund, expected_blank_fks=self.default_expected_blank_fks)
 
-    # TODO Move to test_enums module
     @patch(
         "djstripe.models.Account.get_default_account",
         autospec=True,
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
-        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -197,19 +235,32 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     def test_reason_enum(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
-        # TODO - remove invoice sync
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
         balance_transaction_retrieve_mock.return_value = deepcopy(
             FAKE_BALANCE_TRANSACTION_REFUND
@@ -240,7 +291,11 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.BalanceTransaction.retrieve",
-        return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -262,19 +317,32 @@ class RefundTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
+    @patch(
+        "stripe.Customer.retrieve", return_value=deepcopy(FAKE_CUSTOMER), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
+    )
     def test_status_enum(
         self,
+        invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        customer_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
         default_account_mock,
     ):
         default_account_mock.return_value = self.account
-        # TODO - remove invoice sync
-        Invoice.sync_from_stripe_data(deepcopy(FAKE_INVOICE))
 
         balance_transaction_retrieve_mock.return_value = deepcopy(
             FAKE_BALANCE_TRANSACTION_REFUND

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,11 +15,13 @@ from tests import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PAYMENT_METHOD_I,
     FAKE_PRODUCT,
     FAKE_SESSION_I,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     AssertStripeFksMixin,
 )
 
@@ -30,6 +32,11 @@ class SessionTest(AssertStripeFksMixin, TestCase):
     @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -47,6 +54,11 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
     )
     @patch(
@@ -62,10 +74,12 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
 
@@ -103,6 +117,11 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Subscription.retrieve",
         return_value=deepcopy(FAKE_SUBSCRIPTION),
         autospec=True,
@@ -115,6 +134,11 @@ class SessionTest(AssertStripeFksMixin, TestCase):
     )
     @patch(
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
     )
     @patch(
         "stripe.Invoice.retrieve", return_value=deepcopy(FAKE_INVOICE), autospec=True
@@ -132,10 +156,12 @@ class SessionTest(AssertStripeFksMixin, TestCase):
         payment_intent_retrieve_mock,
         customer_retrieve_mock,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
     ):
 
@@ -177,30 +203,33 @@ class TestSession:
 
         def mock_checkout_session_get(*args, **kwargs):
             """Monkeypatched stripe.Session.retrieve"""
-            return fake_stripe_session
+            return deepcopy(fake_stripe_session)
 
         def mock_customer_get(*args, **kwargs):
             """Monkeypatched stripe.Customer.retrieve"""
-            fake_customer = deepcopy(FAKE_CUSTOMER)
-            return fake_customer
+            return deepcopy(FAKE_CUSTOMER)
 
         def mock_payment_intent_get(*args, **kwargs):
             """Monkeypatched stripe.PaymentIntent.retrieve"""
-            fake_payment_intent = deepcopy(FAKE_PAYMENT_INTENT_I)
-            return fake_payment_intent
+            return deepcopy(FAKE_PAYMENT_INTENT_I)
 
         def mock_invoice_get(*args, **kwargs):
             """Monkeypatched stripe.Invoice.retrieve"""
             return deepcopy(FAKE_INVOICE)
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return deepcopy(FAKE_INVOICEITEM)
+
         def mock_payment_method_get(*args, **kwargs):
             """Monkeypatched stripe.PaymentMethod.retrieve"""
-            fake_payment_intent = deepcopy(FAKE_PAYMENT_METHOD_I)
-            return fake_payment_intent
+            return deepcopy(FAKE_PAYMENT_METHOD_I)
 
         def mock_subscription_get(*args, **kwargs):
             """Monkeypatched stripe.Subscription.retrieve"""
             return deepcopy(FAKE_SUBSCRIPTION)
+
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return deepcopy(FAKE_SUBSCRIPTION_ITEM)
 
         def mock_balance_transaction_get(*args, **kwargs):
             """Monkeypatched stripe.BalanceTransaction.retrieve"""
@@ -218,13 +247,18 @@ class TestSession:
         monkeypatch.setattr(
             stripe.checkout.Session, "retrieve", mock_checkout_session_get
         )
+        monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
         monkeypatch.setattr(stripe.Customer, "modify", mock_customer_get)
         monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
 
         # because of Reverse o2o field sync due to PaymentIntent.sync_from_stripe_data..
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )

--- a/tests/test_subscription_item.py
+++ b/tests/test_subscription_item.py
@@ -17,6 +17,7 @@ from . import (
     FAKE_CUSTOMER,
     FAKE_CUSTOMER_II,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
     FAKE_PLAN_II,
@@ -27,6 +28,7 @@ from . import (
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
     FAKE_SUBSCRIPTION_II,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_SUBSCRIPTION_ITEM_METERED,
     FAKE_SUBSCRIPTION_ITEM_MULTI_PLAN,
     FAKE_SUBSCRIPTION_ITEM_TAX_RATES,
@@ -39,8 +41,18 @@ from . import (
 
 class SubscriptionItemTest(AssertStripeFksMixin, TestCase):
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -63,17 +75,25 @@ class SubscriptionItemTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     def setUp(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
+        customer_retrieve_mock,
     ):
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"

--- a/tests/test_subscription_schedule.py
+++ b/tests/test_subscription_schedule.py
@@ -18,10 +18,12 @@ from . import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_SUBSCRIPTION_SCHEDULE,
     AssertStripeFksMixin,
     datetime_to_unix,
@@ -30,8 +32,18 @@ from . import (
 
 class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
     @patch(
+        "stripe.Customer.retrieve",
+        return_value=deepcopy(FAKE_CUSTOMER),
+        autospec=True,
+    )
+    @patch(
         "stripe.BalanceTransaction.retrieve",
         return_value=deepcopy(FAKE_BALANCE_TRANSACTION),
+        autospec=True,
+    )
+    @patch(
+        "stripe.SubscriptionItem.retrieve",
+        return_value=deepcopy(FAKE_SUBSCRIPTION_ITEM),
         autospec=True,
     )
     @patch(
@@ -54,17 +66,25 @@ class SubscriptionScheduleTest(AssertStripeFksMixin, TestCase):
         "stripe.Product.retrieve", return_value=deepcopy(FAKE_PRODUCT), autospec=True
     )
     @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve", autospec=True, return_value=deepcopy(FAKE_INVOICE)
     )
     def setUp(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
         product_retrieve_mock,
         payment_intent_retrieve_mock,
         paymentmethod_card_retrieve_mock,
         charge_retrieve_mock,
         subscription_retrieve_mock,
+        subscription_item_retrieve_mock,
         balance_transaction_retrieve_mock,
+        customer_retrieve_mock,
     ):
         self.user = get_user_model().objects.create_user(
             username="pydanny", email="pydanny@gmail.com"

--- a/tests/test_usage_record_summary.py
+++ b/tests/test_usage_record_summary.py
@@ -2,7 +2,7 @@
 dj-stripe UsageRecordSummary model tests
 """
 from copy import deepcopy
-from unittest.mock import PropertyMock, patch
+from unittest.mock import PropertyMock, call, patch
 
 import pytest
 from django.test.testcases import TestCase
@@ -14,6 +14,9 @@ from . import (
     FAKE_CUSTOMER_II,
     FAKE_INVOICE_METERED_SUBSCRIPTION,
     FAKE_INVOICE_METERED_SUBSCRIPTION_USAGE,
+    FAKE_INVOICEITEM,
+    FAKE_INVOICEITEM_II,
+    FAKE_LINE_ITEM,
     FAKE_PLAN_METERED,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION_ITEM,
@@ -104,6 +107,16 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.LineItem.retrieve",
+        return_value=deepcopy(FAKE_LINE_ITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM_II),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve",
         return_value=deepcopy(FAKE_INVOICE_METERED_SUBSCRIPTION),
         autospec=True,
@@ -111,6 +124,8 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
     def test_sync_from_stripe_data(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        line_item_retrieve_mock,
         subscription_retrieve_mock,
         subscription_item_retrieve_mock,
         customer_retrieve_mock,
@@ -148,13 +163,22 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
             },
         )
 
-        # assert invoice_retrieve_mock was called once
-        invoice_retrieve_mock.assert_called_once_with(
-            id=FAKE_INVOICE_METERED_SUBSCRIPTION["id"],
-            api_key=djstripe_settings.STRIPE_SECRET_KEY,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
-            expand=[],
-            stripe_account=None,
+        # assert invoice_retrieve_mock was called like so:
+        invoice_retrieve_mock.assert_has_calls(
+            [
+                call(
+                    id=FAKE_INVOICE_METERED_SUBSCRIPTION["id"],
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    stripe_account=None,
+                ),
+                call(
+                    id="in_16af5A2eZvKYlo2CJjANLL81",
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    expand=[],
+                    stripe_account=None,
+                ),
+            ]
         )
 
     @patch(
@@ -179,6 +203,16 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
         autospec=True,
     )
     @patch(
+        "stripe.LineItem.retrieve",
+        return_value=deepcopy(FAKE_LINE_ITEM),
+        autospec=True,
+    )
+    @patch(
+        "stripe.InvoiceItem.retrieve",
+        return_value=deepcopy(FAKE_INVOICEITEM),
+        autospec=True,
+    )
+    @patch(
         "stripe.Invoice.retrieve",
         return_value=deepcopy(FAKE_INVOICE_METERED_SUBSCRIPTION),
         autospec=True,
@@ -186,6 +220,8 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
     def test___str__(
         self,
         invoice_retrieve_mock,
+        invoice_item_retrieve_mock,
+        line_item_retrieve_mock,
         subscription_retrieve_mock,
         subscription_item_retrieve_mock,
         customer_retrieve_mock,

--- a/tests/test_usage_record_summary.py
+++ b/tests/test_usage_record_summary.py
@@ -171,12 +171,14 @@ class TestUsageRecordSummary(AssertStripeFksMixin, TestCase):
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
                 call(
                     id="in_16af5A2eZvKYlo2CJjANLL81",
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     expand=[],
                     stripe_account=None,
+                    stripe_version="2020-08-27",
                 ),
             ]
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,10 +22,13 @@ from tests import (
     FAKE_CHARGE,
     FAKE_CUSTOMER,
     FAKE_INVOICE,
+    FAKE_INVOICEITEM,
+    FAKE_LINE_ITEM,
     FAKE_PAYMENT_INTENT_I,
     FAKE_PLAN,
     FAKE_PRODUCT,
     FAKE_SUBSCRIPTION,
+    FAKE_SUBSCRIPTION_ITEM,
     FAKE_SUBSCRIPTION_SCHEDULE,
 )
 
@@ -468,6 +471,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -479,6 +488,9 @@ class TestConfirmCustomActionView:
 
         def mock_payment_intent_get(*args, **kwargs):
             return FAKE_PAYMENT_INTENT_I
+
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
 
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
@@ -495,11 +507,18 @@ class TestConfirmCustomActionView:
         # monkeypatch stripe retrieve calls to return
         # the desired json response.
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
+        # si_HXZCDv9ixoUB5u
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
         monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
@@ -560,6 +579,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -571,6 +596,9 @@ class TestConfirmCustomActionView:
 
         def mock_payment_intent_get(*args, **kwargs):
             return FAKE_PAYMENT_INTENT_I
+
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
 
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
@@ -587,11 +615,17 @@ class TestConfirmCustomActionView:
         # monkeypatch stripe retrieve calls to return
         # the desired json response.
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
         monkeypatch.setattr(
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
         monkeypatch.setattr(stripe.PaymentIntent, "retrieve", mock_payment_intent_get)
@@ -642,6 +676,9 @@ class TestConfirmCustomActionView:
         def mock_balance_transaction_get(*args, **kwargs):
             return FAKE_BALANCE_TRANSACTION
 
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
+
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
 
@@ -660,6 +697,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -672,6 +715,9 @@ class TestConfirmCustomActionView:
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
 
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
@@ -679,6 +725,9 @@ class TestConfirmCustomActionView:
         monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
 
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
 
         monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
@@ -739,6 +788,9 @@ class TestConfirmCustomActionView:
         def mock_balance_transaction_get(*args, **kwargs):
             return FAKE_BALANCE_TRANSACTION
 
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
+
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
 
@@ -757,6 +809,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -769,6 +827,9 @@ class TestConfirmCustomActionView:
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
 
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
@@ -776,6 +837,9 @@ class TestConfirmCustomActionView:
         monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
 
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
 
         monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
@@ -836,6 +900,9 @@ class TestConfirmCustomActionView:
         def mock_balance_transaction_get(*args, **kwargs):
             return FAKE_BALANCE_TRANSACTION
 
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
+
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
 
@@ -854,6 +921,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -866,6 +939,9 @@ class TestConfirmCustomActionView:
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
 
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
@@ -873,6 +949,9 @@ class TestConfirmCustomActionView:
         monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
 
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
 
         monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)
@@ -923,6 +1002,9 @@ class TestConfirmCustomActionView:
         def mock_balance_transaction_get(*args, **kwargs):
             return FAKE_BALANCE_TRANSACTION
 
+        def mock_subscriptionitem_get(*args, **kwargs):
+            return FAKE_SUBSCRIPTION_ITEM
+
         def mock_subscription_get(*args, **kwargs):
             return FAKE_SUBSCRIPTION
 
@@ -941,6 +1023,12 @@ class TestConfirmCustomActionView:
         def mock_invoice_get(*args, **kwargs):
             return FAKE_INVOICE
 
+        def mock_invoice_item_get(*args, **kwargs):
+            return FAKE_INVOICEITEM
+
+        def mock_line_item_get(*args, **kwargs):
+            return FAKE_LINE_ITEM
+
         def mock_customer_get(*args, **kwargs):
             return FAKE_CUSTOMER
 
@@ -953,6 +1041,9 @@ class TestConfirmCustomActionView:
             stripe.BalanceTransaction, "retrieve", mock_balance_transaction_get
         )
         monkeypatch.setattr(stripe.Subscription, "retrieve", mock_subscription_get)
+        monkeypatch.setattr(
+            stripe.SubscriptionItem, "retrieve", mock_subscriptionitem_get
+        )
         monkeypatch.setattr(stripe.Charge, "retrieve", mock_charge_get)
 
         monkeypatch.setattr(stripe.PaymentMethod, "retrieve", mock_payment_method_get)
@@ -960,6 +1051,9 @@ class TestConfirmCustomActionView:
         monkeypatch.setattr(stripe.Product, "retrieve", mock_product_get)
 
         monkeypatch.setattr(stripe.Invoice, "retrieve", mock_invoice_get)
+        monkeypatch.setattr(stripe.InvoiceItem, "retrieve", mock_invoice_item_get)
+        monkeypatch.setattr(stripe.LineItem, "retrieve", mock_line_item_get)
+
         monkeypatch.setattr(stripe.Customer, "retrieve", mock_customer_get)
 
         monkeypatch.setattr(stripe.Plan, "retrieve", mock_plan_get)


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

Please merge #1873 before merging this. Please note the tests should also stop failing after #1873 gets merged.



This PR contains the following changes:

1.  Added `lineitems` property to `UpcomingInvoice` model. `Invoice` and `UpcomingInvoice` both have `lines` (LineItem model instances) where each of the `LineItem` instance can be of type `invoice_item` or `subscription` and is a different but related model to InvoiceItem. This property is meant to resolve this ambiguity between `LineItem` and `InvoiceItem`
models.
2. Updated `UpcomingInvoice.invoiceitems` property. It was incorrectly assuming that every `LineItem` instance is an
`InvoiceItem` whereas in reality they are different Stripe Objects altogether. Updated the property keeping the goal in mind to only return `LineItems` of type "invoice_item" on the passed in `UpcomingInvoice`.
3. Updated the application code to resolve the ambiguity between` LineItem` and `InvoiceItem` models. It was incorrectly assumed that the `lines` List object on `Invoice` and `UpcomingInvoice` model only return `InvoiceItem`s where as in reality not only `LineItem` and `InvoiceItem` are different Stripe objects but `LineItem` can also be of type "subscription" if the user adds a Subscription to their "Invoice".
