### PR TITLE
Invoke and manage pre-commit using poetry

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,4 +42,4 @@ jobs:
         run: poetry install --with dev
 
       - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
+        run: poetry run pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,17 +7,39 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
 
+
+env:
+  POETRY_VERSION: "1.2.2"
+  POETRY_VIRTUALENVS_IN_PROJECT: "1"
+
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install poetry
+        run: |
+          curl -sL https://install.python-poetry.org | python - --version ${{ env.POETRY_VERSION }}
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: .venv
+          key: venv-3.11
+
+      - name: Ensure cache is healthy
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: timeout 10s poetry run pip --version || rm -rf .venv
+
+      - name: Install dependencies
+        run: poetry install --with dev
 
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ mypy = ">=0.971"
 # I'm grateful flake8 exists. But it's not a useful enough tool to allow it to
 # waste our time like this, and it's largely been displaced by the other tools:
 # mypy, isort, and black. So let's stick to those instead.
+pre-commit = "^3.0.4"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

It didn't make sense to use `pip` to install poetry in `linting.yml` when we use `poetry` as the default dependency manager in `dj-stripe`. So refactored the code to use `poetry` as the one means of installing and executing `pre-commit`.

This PR along with #1883 will greatly simplify code and logic duplication.
