### PR TITLE
Fixed bug in issuing Customer Refunds

### DIFF
--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -40,6 +40,10 @@
 -   Remove undocumented `set_stripe_api_version()` helper function
     and context manager `stripe_temporary_api_version()`.
     The API version is now set on each request individually.
+-   Updated `Charge.refund(...)` helper function
+    to correctly create the desired refund. Note that the
+    created `Refund` object is now returned as opposed to
+    the `Charge` object.
 
 
 ## Other changes


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

1) Updated `Customer.refund()` to correctly create and return the `Refund` object,
2) Updated changelog with the breaking change.

Fix: #1890 