### PR TITLE
Add Stripe Server Checkout Example

### DIFF
--- a/tests/apps/example/urls.py
+++ b/tests/apps/example/urls.py
@@ -7,7 +7,7 @@ app_name = "djstripe_example"
 urlpatterns = [
     path(
         "checkout/",
-        views.CreateCheckoutSessionView.as_view(),
+        views.CreateCheckoutSessionClientView.as_view(),
         name="checkout",
     ),
     path(

--- a/tests/apps/example/urls.py
+++ b/tests/apps/example/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
         views.CreateCheckoutSessionView.as_view(),
         name="checkout",
     ),
+    path(
+        "checkout/server/",
+        views.CreateCheckoutSessionServerView.as_view(),
+        name="checkout",
+    ),
     path("success/", views.CheckoutSessionSuccessView.as_view(), name="success"),
     path(
         "purchase-subscription",

--- a/tests/apps/example/views.py
+++ b/tests/apps/example/views.py
@@ -127,7 +127,7 @@ class CreateCheckoutSessionServerView(LoginRequiredMixin, RedirectView):
         return session.url
 
 
-class CreateCheckoutSessionView(LoginRequiredMixin, TemplateView):
+class CreateCheckoutSessionClientView(LoginRequiredMixin, TemplateView):
     """
     Example View to demonstrate how to use dj-stripe to:
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your contribution means a great deal to the project and the community as a whole! -->


## Description

<!-- What are you proposing? -->

This PR contains the following changes:

2. Added `CreateCheckoutServerSessionView` to show how can `Stripe Checkout` Server Sessions can be created using `dj-stripe` for both `new` and `returning` customers.


## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

This should make the `examples` more clear.