### PR TITLE
Fix AttributeError in PaymentMethod class by implementing api_retrieve method

### DIFF
--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -1008,6 +1008,26 @@ class PaymentMethod(StripeModel):
         else:
             self.customer = None
 
+    def api_retrieve(self, api_key=None, stripe_account=None):
+        # PaymentMethod manipulated through a customer or account.
+
+        api_key = api_key or self.default_api_key
+
+        if self.customer:
+            return stripe.Customer.retrieve_payment_method(
+                self.customer.id,
+                self.id,
+                expand=self.expand_fields,
+                stripe_account=stripe_account,
+                api_key=api_key,
+            )
+
+        raise ImpossibleAPIRequest(
+            f"Can't retrieve {self.__class__} without a customer object."
+            " This may happen if not all customer objects are in the db."
+            ' Please run "python manage.py djstripe_sync_models Account Customer" as a potential fix.'
+        )
+
     @classmethod
     def attach(
         cls,


### PR DESCRIPTION
Previously, an ```AttributeError: 'PaymentMethod' object has no attribute 'api_retrieve'``` was being raised when attempting to update a customer's default payment method or retrieve the payment method itself. The error message stated that 'PaymentMethod' object has no attribute 'api_retrieve'.

This issue was caused by a missing method, api_retrieve, in the PaymentMethod class. To resolve the issue, I implemented the api_retrieve method inside the PaymentMethod class. Now, when syncing a customer to update their default payment method or when retrieving a payment method, the api_retrieve method is correctly called and the operation is successful.

This commit resolves the AttributeError issue and ensures that updating a customer's default payment method and retrieving payment methods now function as expected.
 this commit resolves issue #1904

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
