### PR TITLE
Installation.md removed as linked and replaced

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ The full documentation is available [on Read the Docs](https://dj-stripe.github.
 
 ## Installation
 
-See [installation](installation.md) instructions.
+See [installation](https://dj-stripe.dev/dj-stripe/2.7/installation/) instructions.
 
 ## Changelog
 


### PR DESCRIPTION
Installation.md is not workable in the dj-stripe.dev docs, and replaced with full path https://dj-stripe.dev/dj-stripe/2.7/installation/

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
