### PR TITLE
Restricted Keys can be added from the admin just like secret keys

### DIFF
--- a/djstripe/models/api.py
+++ b/djstripe/models/api.py
@@ -86,7 +86,10 @@ class APIKey(StripeModel):
     def refresh_account(self, commit=True):
         from .account import Account
 
-        if self.type != APIKeyType.secret:
+        if self.type not in (
+            APIKeyType.secret,
+            APIKeyType.restricted,
+        ):
             return
 
         account_data = Account.stripe_class.retrieve(

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -99,6 +99,15 @@ class APIKeyTest(CreateAccountMixin, TestCase):
             livemode=False,
             djstripe_owner_account=self.account,
         )
+
+        self.apikey_restricted_test = APIKey.objects.create(
+            type=APIKeyType.secret,
+            name="Test Restricted Secret Key",
+            secret=RK_TEST,
+            livemode=False,
+            djstripe_owner_account=self.account,
+        )
+
         self.apikey_live = APIKey.objects.create(
             type=APIKeyType.secret,
             name="Live Secret Key",
@@ -150,10 +159,15 @@ class APIKeyTest(CreateAccountMixin, TestCase):
         autospec=True,
     )
     def test_refresh_account(self, fileupload_retrieve_mock, account_retrieve_mock):
-        # remove djstripe_owner_account field
-        self.apikey_test.djstripe_owner_account = None
-        self.apikey_test.save()
+        for key in (
+            "apikey_test",
+            "apikey_restricted_test",
+        ):
+            # remove djstripe_owner_account field
+            instance = getattr(self, key)
+            instance.djstripe_owner_account = None
+            instance.save()
 
-        # invoke refresh_Account()
-        self.apikey_test.refresh_account()
-        assert self.apikey_test.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]
+            # invoke refresh_Account()
+            instance.refresh_account()
+            assert instance.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -80,9 +80,8 @@ class TestAPIKeyAdminCreateForm(CreateAccountMixin):
 
         if secret.startswith("sk_"):
             assert form.instance.type == enums.APIKeyType.secret
-            assert (
-                form.instance.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]
-            )
+
         elif secret.startswith("rk_"):
             assert form.instance.type == enums.APIKeyType.restricted
-            assert form.instance.djstripe_owner_account is None
+
+        assert form.instance.djstripe_owner_account.id == FAKE_PLATFORM_ACCOUNT["id"]


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

This PR contains the following changes:

1. Restricted keys with the correct permissions can be added from the admin and is used to populate the platform account just like secret keys. The requirement is that the key must allow for retrieval of the platform account. If not user is unable to add the key and a helpful error message is displayed.

Partially fixes: PR #1908 