### PR TITLE
docs: docker-compose enhancement to pass CLI tool's generated secret on startup

### DIFF
--- a/docs/usage/using_with_docker.md
+++ b/docs/usage/using_with_docker.md
@@ -52,8 +52,9 @@ services:
 
   stripe:
     image: stripe/stripe-cli:v1.7.4
-    # In case Stripe CLI is used to perform local webhook testing, set x-djstripe-webhook-secret custom header to output of Stripe CLI.
-    command: ["listen", "-H", "x-djstripe-webhook-secret: whsec_******", "--forward-to", "http://web:8000/djstripe/webhook/"]
+    
+    entrypoint: "sh -c"
+    command: [ "stripe listen --forward-to \"http://web:8000/stripe/webhook/\" -H \"x-djstripe-webhook-secret: `stripe listen --print-secret`\"" ]
     depends_on:
       - web
     environment:


### PR DESCRIPTION
changed the entrypoint and command format to allow shell backticks to work

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
