### PR TITLE
Add stripe support contact link to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Stripe support
+    url: https://support.stripe.com/
+    about: |
+      Please only file issues here that you believe represent actual bugs or feature requests for the dj-stripe library.
+
+      If you're having general trouble with your Stripe integration, please reach out to support.


### PR DESCRIPTION
@mfix-stripe sent us an email back in 2022 about a way to add a stripe support contact link to the issue templates so that we don't mistakenly get stripe support requests in issues.

I was cleaning up my inbox, found the email, and am proposing we add it in via this PR.

Here's what this is modeled after: https://github.com/stripe/stripe-php/blob/master/.github/ISSUE_TEMPLATE/config.yml

I added the contact link and also included the `blank_issues_enabled`, since it seems valid.