### PR TITLE
Update deprecated pkg_resources

### DIFF
--- a/djstripe/apps.py
+++ b/djstripe/apps.py
@@ -1,10 +1,10 @@
 """
 dj-stripe - Django + Stripe Made Easy
 """
-import pkg_resources
+from importlib.metadata import version
 from django.apps import AppConfig
 
-__version__ = pkg_resources.get_distribution("dj-stripe").version
+__version__ = version("dj-stripe")
 
 
 class DjstripeAppConfig(AppConfig):

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -54,3 +54,4 @@
     -   `djstripe.signals.webhook_pre_process(instance, api_key)`: Fired before webhook processing. Not fired if the validation failed.
     -   `djstripe.signals.webhook_post_process(instance, api_key)`: Fired after webhook successful processing.
 -   `djstripe.signals.webhook_processing_error` now also takes `instance` and `api_key` arguments
+-   Updated deprecated `pkg_resources` to `importlib`.


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

Locally, I'm running tests and getting deprecation warnings for the use of `pkg_resources`. According to [this post](https://setuptools.pypa.io/en/latest/pkg_resources.html):

---

Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.

---

This PR makes the changes to follow the deprecation notice.
