### PR TITLE
Pass down kwargs to `Invoice.pay()`

### DIFF
--- a/djstripe/apps.py
+++ b/djstripe/apps.py
@@ -2,6 +2,7 @@
 dj-stripe - Django + Stripe Made Easy
 """
 from importlib.metadata import version
+
 from django.apps import AppConfig
 
 __version__ = version("dj-stripe")

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -800,13 +800,13 @@ class BaseInvoice(StripeModel):
             api_key=api_key,
         )
 
-    def retry(self):
+    def retry(self, **kwargs):
         """Retry payment on this invoice if it isn't paid."""
 
         if self.status != enums.InvoiceStatus.paid and self.auto_advance:
             stripe_invoice = self.api_retrieve()
-            updated_stripe_invoice = (
-                stripe_invoice.pay()
+            updated_stripe_invoice = stripe_invoice.pay(
+                **kwargs
             )  # pay() throws an exception if the charge is not successful.
             type(self).sync_from_stripe_data(
                 updated_stripe_invoice, api_key=self.default_api_key

--- a/djstripe/models/core.py
+++ b/djstripe/models/core.py
@@ -1297,7 +1297,7 @@ class Customer(StripeModel):
         else:
             return subscriptions.first()
 
-    def send_invoice(self):
+    def send_invoice(self, **kwargs):
         """
         Pay and send the customer's latest invoice.
 
@@ -1308,19 +1308,19 @@ class Customer(StripeModel):
 
         try:
             invoice = Invoice._api_create(customer=self.id)
-            invoice.pay()
+            invoice.pay(**kwargs)
             return True
         except InvalidRequestError:  # TODO: Check this for a more
             #                           specific error message.
             return False  # There was nothing to invoice
 
-    def retry_unpaid_invoices(self):
+    def retry_unpaid_invoices(self, **kwargs):
         """Attempt to retry collecting payment on the customer's unpaid invoices."""
 
         self._sync_invoices()
         for invoice in self.invoices.filter(auto_advance=True).exclude(status="paid"):
             try:
-                invoice.retry()  # Always retry unpaid invoices
+                invoice.retry(**kwargs)  # Always retry unpaid invoices
             except InvalidRequestError as exc:
                 if str(exc) != "Invoice is already paid":
                     raise

--- a/docs/history/2_8_0.md
+++ b/docs/history/2_8_0.md
@@ -62,3 +62,4 @@ significant, backwards-incompatible changes.
     -   `djstripe.signals.webhook_post_process(instance, api_key)`: Fired after webhook successful processing.
 -   `djstripe.signals.webhook_processing_error` now also takes `instance` and `api_key` arguments
 -   Updated deprecated `pkg_resources` to `importlib`.
+-   One can now retry invoices with specific kwargs as mentioned [here](https://stripe.com/docs/api/invoices/pay)

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -199,6 +199,7 @@ class TestCustomer(CreateAccountMixin, AssertStripeFksMixin, TestCase):
         customer_mock.assert_called_once_with(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             email="",
+            name="",
             idempotency_key=None,
             metadata={},
             stripe_account=None,


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

Fix: #1959


One can now retry invoices with specific kwargs if they wish to do so.