### PR TITLE
Fix tolerance error

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -83,7 +83,7 @@ class WebhookEndpoint(StripeModel):
         )
 
         self.djstripe_uuid = data.get("metadata", {}).get("djstripe_uuid")
-        self.tolerance = data.get("tolerance", djstripe_settings.WEBHOOK_TOLERANCE)
+        self.tolerance = data.get("tolerance", stripe.Webhook.DEFAULT_TOLERANCE)
 
 
 def _get_version():


### PR DESCRIPTION
djstripe_settings.WEBHOOK_TOLERANCE removed now, has error when tried to add webhook, probably we must use stripe.Webhook.DEFAULT_TOLERANCE