### PR TITLE
Updated APIKeyAdmin.save_model() to correctly populate key name

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -155,7 +155,16 @@ class APIKeyAdmin(admin.ModelAdmin):
             with transaction.atomic():
                 obj.save()
         except IntegrityError:
-            pass
+            # APIKey has already been created
+
+            # Get the name from the form
+            name = form.cleaned_data.get("name", "")
+            # Get APIKey from DB
+            instance = self.model.objects.get(secret=obj.secret)
+
+            # Update name of APIKey
+            instance.name = name
+            instance.save()
 
 
 @admin.register(models.BalanceTransaction)


### PR DESCRIPTION
In case the key was added before the account was created, we end up creating the key before the Admin form gets created due to how the sync algorithm works. This commit will not correctly handle creation of APIKeys.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
