### PR TITLE
Added cancellation kwargs to Subscription cancel at period end logic.

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1610,7 +1610,7 @@ class Subscription(StripeModel):
             at_period_end = False
 
         if at_period_end:
-            stripe_subscription = self._api_update(cancel_at_period_end=True)
+            stripe_subscription = self._api_update(cancel_at_period_end=True, **kwargs)
         else:
             try:
                 stripe_subscription = self._api_delete(**kwargs)


### PR DESCRIPTION
I found myself unable to add cancellation details when cancelling a subscription at period end.

This change sends `**kwargs` from the cancel call to the underlying `_api_update` call, aligning it with the `_api_delete` call in the not-at-period-end logic branch.