### PR TITLE
fix(enums): Adds paused as a valid SubscriptionStatus.

### DIFF
--- a/djstripe/enums.py
+++ b/djstripe/enums.py
@@ -776,6 +776,7 @@ class SubscriptionStatus(Enum):
     past_due = _("Past due")
     canceled = _("Canceled")
     unpaid = _("Unpaid")
+    paused = _("Paused")
 
 
 class SubscriptionProrationBehavior(Enum):

--- a/docs/history/3_0_0.md
+++ b/docs/history/3_0_0.md
@@ -38,3 +38,4 @@
 - Added missing model fields to Checkout Sessions.
 - `LineItem` instances can also get synced using the `djstripe_sync_models` management command.
 -  Updated `check_stripe_api_key` django system check to not be a blocker for new dj-stripe users by raising Info warnings on the console. If the Stripe keys were not defined in the settings file, the `Critical` warning was preventing users to add them directly from the admin as mentioned in the docs. This was creating a chicken-egg situation where one could only add keys in the admin before they were defined in settings.
+- Added `paused` as a valid status to the SubscriptionStatus enum


### PR DESCRIPTION
Depending on the `trial_settings.end_behavior`, a subscription can be moved into a paused status if a payment method is not on file.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
