### PR TITLE
Prettify JSON Fields

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from stripe.error import InvalidRequestError
 
 from djstripe import models
+from djstripe.fields import JSONField
 
 from .actions import CustomActionMixin
 from .admin_inline import (
@@ -27,6 +28,7 @@ from .forms import (
     WebhookEndpointAdminEditForm,
 )
 from .utils import ReadOnlyMixin, get_forward_relation_fields_for_model
+from .widgets import CustomTextAreaWidget
 
 
 @admin.register(models.IdempotencyKey)
@@ -75,6 +77,9 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
     change_form_template = "djstripe/admin/change_form.html"
     add_form_template = "djstripe/admin/add_form.html"
     actions = ("_resync_instances", "_sync_all_instances")
+    formfield_overrides = {
+        JSONField: {"widget": CustomTextAreaWidget},
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/djstripe/admin/widgets.py
+++ b/djstripe/admin/widgets.py
@@ -1,0 +1,17 @@
+"""
+Django Administration interface custom widget definitions
+"""
+
+import json
+
+from django.forms.widgets import Textarea
+
+
+class CustomTextAreaWidget(Textarea):
+    def format_value(self, value):
+        """
+        Return a value as it should appear when rendered in a template.
+        """
+        value = json.loads(value)
+        value = json.dumps(value, indent=4)
+        return super().format_value(value)


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

This improves the formatting of `JSONFields` in the django admin. Please note this will not work for `Read only` fields as `Django` hardcodes the value.

Before:
<img width="590" alt="Screenshot 2023-11-23 at 8 54 23 PM" src="https://github.com/dj-stripe/dj-stripe/assets/20695449/6e6e14de-c855-460d-8a29-d140b984d2e4">



After:
<img width="985" alt="Screenshot 2023-11-23 at 8 52 32 PM" src="https://github.com/dj-stripe/dj-stripe/assets/20695449/91a74ab8-be66-4aa3-97d6-138bbacb537c">
