### PR TITLE
feat: introduce PaymentMethod.last4 property and add last4 to __str__

### DIFF
--- a/djstripe/models/payment_methods.py
+++ b/djstripe/models/payment_methods.py
@@ -1130,11 +1130,16 @@ class PaymentMethod(StripeModel):
         help_text="Additional information for payment methods of type `wechat_pay`",
     )
 
+    @property
+    def last4(self):
+        pm_data = getattr(self, self.type, {})
+        return pm_data.get("last4", "Unknown")
+
     def __str__(self):
         if self.customer:
-            return f"{enums.PaymentMethodType.humanize(self.type)} for {self.customer}"
+            return f"{enums.PaymentMethodType.humanize(self.type)} ending in {self.last4} for {self.customer}"
         return (
-            f"{enums.PaymentMethodType.humanize(self.type)} is not associated with any"
+            f"{enums.PaymentMethodType.humanize(self.type)} ending in {self.last4} is not associated with any"
             " customer"
         )
 

--- a/tests/test_payment_method.py
+++ b/tests/test_payment_method.py
@@ -44,8 +44,9 @@ class TestPaymentMethod(CreateAccountMixin):
             pm = models.PaymentMethod.sync_from_stripe_data(fake_payment_method_data)
             customer = None
             assert (
-                f"{enums.PaymentMethodType.humanize(fake_payment_method_data['type'])} is"
-                " not associated with any customer" == str(pm)
+                f"{enums.PaymentMethodType.humanize(fake_payment_method_data['type'])}"
+                f"ending in {fake_payment_method_data['card']['last4']} is not associated with any customer"
+                == str(pm)
             )
 
         else:
@@ -54,8 +55,9 @@ class TestPaymentMethod(CreateAccountMixin):
                 id=fake_payment_method_data["customer"]
             )
             assert (
-                f"{enums.PaymentMethodType.humanize(fake_payment_method_data['type'])} for"
-                f" {customer}" == str(pm)
+                f"{enums.PaymentMethodType.humanize(fake_payment_method_data['type'])}"
+                f"ending in {fake_payment_method_data['card']['last4']} for {customer}"
+                == str(pm)
             )
 
     @pytest.mark.parametrize("customer_exists", [True, False])


### PR DESCRIPTION
This PR adds a new property to retrieve the last 4 digits of a payment method. This is very convenient when associating a payment method in a ForeignKey attribute from the admin dashboard. Otherwise when there are multiple Payment methods associated to a customer, you never know which one you are choosing.

Before:

![image](https://github.com/dj-stripe/dj-stripe/assets/73274/c669c6f9-b63e-420e-89ec-6c0ddb153897)

After:

![image](https://github.com/dj-stripe/dj-stripe/assets/73274/48b0afad-c9db-41c5-81dc-0b7d4094f131)
