### PR TITLE
Fix Sync failure due to deleted Subscription Items

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -775,6 +775,12 @@ class StripeModel(StripeBaseModel):
                         # but still present during sync. For example, if a refund is
                         # issued on a charge whose payment method has been deleted.
                         return None, False
+                    elif "Invalid subscription_item id" in str(e):
+                        # subscription items can be irretrievably deleted but still
+                        # be present during sync. For example, if a line item of type subscription is
+                        # removed from the subscription, the invoice generated for that billing period
+                        # will still contain the deleted subscription_item.
+                        return None, False
                     else:
                         raise
                 should_expand = False


### PR DESCRIPTION
Ignored Invalid Subscription Item errors. This was done because in case a Subscription line item is removed the invoice for that billing cycle will still refer to those now deleted SubscriptionItems.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->



Fix: #2007
