### PR TITLE
stripe_account will always get populated

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from datetime import timedelta
 from typing import Dict, List, Optional, Type
-
+from stripe.stripe_object import StripeObject
 from django.db import IntegrityError, models, transaction
 from django.utils import dateformat, timezone
 from stripe.api_resources.abstract.api_resource import APIResource
@@ -727,7 +727,8 @@ class StripeModel(StripeBaseModel):
         field = data.get(field_name)
         is_nested_data = field_name != "id"
         should_expand = False
-
+        if not stripe_account and isinstance(data, StripeObject):
+            stripe_account = data.stripe_account
         if pending_relations is None:
             pending_relations = []
 


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->

A lot of the issues in syncing were happening because `stripe_account` was passed around as `None` and while that is okay most of the times as the stripe api assumed the request is for the platform account, that is not always the case.