### PR TITLE
fix(docs): add os build to readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,13 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 mkdocs:
   configuration: mkdocs.yml
 


### PR DESCRIPTION
the build error on message on:
https://beta.readthedocs.org/projects/dj-stripe/builds/24185540/
 is:
> Config file validation error
> Config validation error in build.os. Value build not found.

Per issue:
https://github.com/readthedocs/readthedocs.org/issues/11173 
and the proejct docs:
https://docs.readthedocs.io/en/stable/config-file/v2.html 
the solution should be to add the build step

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
