### PR TITLE
remove dupliacte python version causing an error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ mkdocs:
   configuration: mkdocs.yml
 
 python:
-  version: "3.12"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
> Invalid configuration key: python.version

>Make sure the key name python.version is correct.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
