### PR TITLE
deploy docs to dj-stripe.github.io with version support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "master"
       # Push events to branches matching "stable/*"
-      - "stable/.+"
+      - "stable/*"
 
   workflow_dispatch: # to trigger manually
 
@@ -13,32 +13,61 @@ env:
   POETRY_VERSION: "1.2.2"
   POETRY_VIRTUALENVS_IN_PROJECT: "1"
   LATEST_STABLE_BRANCH: "stable/2.7"
+  DOCS_REPO: "dj-stripe.github.io"
+  OWNER: "dj-stripe" # if you forked the repo, change this to your gh username
+  SOURCE_REPO: "dj-stripe"
+
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ env.OWNER }}/${{ env.DOCS_REPO }}"
+          path: ./${{ env.DOCS_REPO }}
+          token: ${{ secrets.GH_PAT }}  # Token needed to push site to gh-pages branch
+
 
       - uses: ./.github/install_poetry_action
         with:
             POETRY_VERSION: ${{ env.POETRY_VERSION }}
             python_version: "3.12"
 
+      - name: Copy docs and configuration from source to documentation repo
+        run: |
+          cp -r pyproject.toml mkdocs.yml docs tests ${{ env.DOCS_REPO }}/
+          cd ${{ env.DOCS_REPO }}
+          sed -i 's|name = "dj-stripe"|name = "dj-stripe-docs"|' pyproject.toml
+          sed -i 's|include = "djstripe"|include = "../djstripe"|' pyproject.toml
+          poetry add ../../dj-stripe
+
       - name: Install dependencies
-        run: poetry install --with docs
+        run: |
+            cd ${{ env.DOCS_REPO }}
+            poetry install --with docs
 
       - name: Configure git user to make commit
         run: |
-          git config user.name "dj-stripe commit bot"
-          git config user.email "admin@djstripe.dev"
+          git config --global user.name "dj-stripe commit bot"
+          git config --global user.email "admin@djstripe.dev"
 
       - name: Fetch gh-pages remote changes (if any)
-        run: git fetch origin gh-pages --depth=1
+        run: |
+            cd ${{ env.DOCS_REPO }}
+            git fetch origin gh-pages --depth=1
 
       - name: Deploy (and Update) docs for the branch, ${GITHUB_REF##*/}
-        run: poetry run mike deploy --push "${GITHUB_REF##*/}"
+        run: |
+            cd ${{ env.DOCS_REPO }}
+            poetry run mike deploy --push "${GITHUB_REF##*/}"
 
       - name: Set default docs to ${LATEST_STABLE_BRANCH##*/}
-        run: poetry run mike set-default --push "${LATEST_STABLE_BRANCH##*/}"
+        run: |
+            cd ${{ env.DOCS_REPO }}
+            poetry run mike set-default --push "${LATEST_STABLE_BRANCH##*/}"


### PR DESCRIPTION
This action will now run on push to master and any stable branch it checkouts both repos `dj-stripe` and `dj-stripe.github.io` 

it then runs the steps outlined in the `dj-stripe.github.io` [README](https://github.com/abe-101/dj-stripe.github.io/blob/9ab071206550cac28aabc9ff12a512425a41ecfd/README.md) to build the docs.

it then pushes the result to the `gh-pages` branch in `dj-stripe.github.io` (using a github PAT token)

The token should have `content` permission for `dj-stripe.github.io` repo
and should be store in this repos (dj-stripe) as a secret with the name `GH_PAT`
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
