### PR TITLE
Deploy Docs to dj-stripe.github.io repo: Use ssh instead of github pat

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           repository: "${{ env.OWNER }}/${{ env.DOCS_REPO }}"
           path: ./${{ env.DOCS_REPO }}
-          token: ${{ secrets.GH_PAT }}  # Token needed to push site to gh-pages branch
+          # token: ${{ secrets.GH_PAT }}  # Token needed to push site to gh-pages branch
+          ssh-key: ${{ secrets.SSH_KEY }}
 
 
       - uses: ./.github/install_poetry_action


### PR DESCRIPTION
I only have access to add ssh keys to the dj-stripe.github.io repo - so i am using ssh keys

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
