### PR TITLE
stable/2.9: add missing migraion

### DIFF
--- a/djstripe/migrations/0013_2_9.py
+++ b/djstripe/migrations/0013_2_9.py
@@ -931,6 +931,16 @@ class Migration(migrations.Migration):
                 enum=djstripe.enums.WebhookEndpointStatus, max_length=255
             ),
         ),
+        migrations.AlterField(
+            model_name="webhookendpoint",
+            name="api_version",
+            field=models.CharField(
+                blank=True,
+                default="2024-04-10",
+                help_text="The API version events are rendered as for this webhook endpoint. Defaults to the configured Stripe API Version.",
+                max_length=64,
+            ),
+        ),
         migrations.DeleteModel(
             name="Order",
         ),


### PR DESCRIPTION
When testing stable/2.9 from pypi and locally from the `stable/2.9` branch i get a missing migrations warning:

>   Your models in app(s): 'djstripe' have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.


running `python manage.py makemigrations` creates the migrations in this PR
<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
