### PR TITLE
Temporarily remove migration pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,11 @@ repos:
       - id: django-upgrade
         args: [--target-version, "3.2"]
 
-  - repo: local
-    hooks:
-      - id: check-migrations
-        name: check-migrations
-        entry: poetry run python manage.py makemigrations --dry-run --check
-        types: [ python ]
-        pass_filenames: false
-        language: system
+#  - repo: local
+#    hooks:
+#      - id: check-migrations
+#        name: check-migrations
+#        entry: poetry run python manage.py makemigrations --dry-run --check
+#        types: [ python ]
+#        pass_filenames: false
+#        language: system

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -204,6 +204,7 @@ class Coupon(StripeModel):
             duration = self.duration
         return f"{self.human_readable_amount} {duration}"
 
+
 class PromotionCode(StripeModel):
     """
     This is an object representing a Promotion Code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,7 @@ theme:
 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
-      scheme: light 
+      scheme: light
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -95,14 +95,14 @@ plugins:
       canonical_version: "2.8"
 
 nav:
-  - Documentation: 
-    - Getting Started: 
+  - Documentation:
+    - Getting Started:
       - Installation: installation.md
       - Managing Stripe API Keys: api_keys.md
       - A note on Stripe API Versions: api_versions.md
       - Upgrade dj-stripe: upgrade_dj_stripe.md
       - Integrating Stripe Elements: stripe_elements_js.md
-    - Usage: 
+    - Usage:
       - Using Stripe Webhooks: usage/webhooks.md
       - Local Webhook Testing: usage/local_webhook_testing.md
       - Subscribing a customer to a plan: usage/subscribing_customers.md
@@ -113,22 +113,22 @@ nav:
       - Creating Usage Records: usage/creating_usage_record.md
       - Using Stripe Checkout: usage/using_stripe_checkout.md
       - Using with Docker: usage/using_with_docker.md
-    - Project: 
+    - Project:
       - Contributing: project/contributing.md
       - Test Fixtures: project/test_fixtures.md
       - Credits: project/authors.md
       - Support: project/support.md
       - Release Process: project/release_process.md
-    - Reference: 
+    - Reference:
       - Enumerations: reference/enums.md
       - Managers: reference/managers.md
       - Models: reference/models.md
       - Settings: reference/settings.md
       - Utilities: reference/utils.md
       - Tests: reference/project.md
-  - Sponsors: 
+  - Sponsors:
     - Our Sponsors: project/sponsors.md
-  - History: 
+  - History:
     - dj-stripe 3.0 release notes: history/3_0_0.md
     - dj-stripe 2.9 release notes: history/2_9_0.md
     - dj-stripe 2.8 release notes: history/2_8_x.md
@@ -140,5 +140,3 @@ nav:
     - dj-stripe 2.0 ~ 2.3 release notes: history/2_x.md
     - dj-stripe 1.x release notes: history/1_x.md
     - dj-stripe 0.x release notes: history/0_x.md
-
-


### PR DESCRIPTION
With the master branch restart the projects migrations this hook is causing the action to fail
but as a side affect we are ignoring the other hooks (linting)

Would be best to disable just the migration hook until we re-create the migrations

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
