### PR TITLE
Add missing 'automatic_async' value to CaptureMethod Enum.

### DIFF
--- a/djstripe/enums.py
+++ b/djstripe/enums.py
@@ -266,6 +266,7 @@ class BillingScheme(Enum):
 class CaptureMethod(Enum):
     automatic = _("Automatic")
     manual = _("Manual")
+    automatic_async = _("Automatic Async")
 
 
 class CardCheckResult(Enum):


### PR DESCRIPTION
Add the missing value `automatic_async`

See the Stripe documentation: https://docs.stripe.com/api/payment_intents/update#update_payment_intent-capture_method

Fixes: https://github.com/dj-stripe/dj-stripe/issues/2095 https://github.com/dj-stripe/dj-stripe/issues/2038


<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
