### PR TITLE
feat(docs): add missing custom dir

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ theme:
   font:
     text: Helvetica
   name: material
+  custom_dir: overrides
   static_templates:
     - 404.html
   features:


### PR DESCRIPTION
the `custom_dir` was mistakenly  [removed](https://github.com/dj-stripe/dj-stripe/commit/1baaa69bc69ecff34da9a5ea65c31c227bbf0264#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L21) in this commit
this setting points to the overrides file containing our custom override for the site

https://github.com/dj-stripe/dj-stripe/commit/1baaa69bc69ecff34da9a5ea65c31c227bbf0264#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R11