### PR TITLE
Remove non-existent fields from admins

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -395,7 +395,7 @@ class SetupIntentAdmin(StripeModelAdmin):
 @admin.register(models.Session)
 class SessionAdmin(StripeModelAdmin):
     list_display = ("customer", "customer_email", "subscription")
-    list_filter = ("customer", "mode")
+    list_filter = ("customer",)
     search_fields = ("customer__id", "customer_email")
 
     def get_queryset(self, request):

--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -512,7 +512,7 @@ class ProductAdmin(StripeModelAdmin):
 @admin.register(models.PromotionCode)
 class PromotionCodeAdmin(StripeModelAdmin):
     list_display = ("code", "created", "times_redeemed", "max_redemptions")
-    search_fields = ("code",)
+    search_fields = ("id",)
     list_filter = ("created",)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Cleaned up admin list filters and search fields for Session and PromotionCode models to remove non-existent or incorrect field references