### PR TITLE
Fix/stripe-version-compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ exclude = ["manage.py"]
 [tool.poetry.dependencies]
 python = "^3.10.0"
 django = ">=4.2"
-stripe = ">=8.0.0"
+stripe = "^11.3.0"
 psycopg = { version = "^3.2.3", optional = true }
 mysqlclient = { version = ">=1.4.0", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ exclude = ["manage.py"]
 [tool.poetry.dependencies]
 python = "^3.10.0"
 django = ">=4.2"
-stripe = "^11.3.0"
+stripe = ">=8.0.0,<12.0.0"
 psycopg = { version = "^3.2.3", optional = true }
 mysqlclient = { version = ">=1.4.0", optional = true }
 


### PR DESCRIPTION
Stripe v12.0.0 introduced breaking changes that are incompatible with dj-stripe v2.9.0. This update restricts the stripe dependency to `>=8.0.0,<12.0.0` to ensure compatibility and stability.

Relates dj-stripe/dj-stripe#2151

## Summary by Sourcery

Bug Fixes:
- Resolved compatibility issues with Stripe v12.0.0 by pinning the Stripe dependency to a compatible version