### PR TITLE
Allow adding to excluded properties class-specific attributes

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -75,6 +75,7 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
     change_form_template = "djstripe/admin/change_form.html"
     add_form_template = "djstripe/admin/add_form.html"
     actions = ("_resync_instances", "_sync_all_instances")
+    detail_excluded_properties = ["pk"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -98,10 +99,9 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
         if obj is None:
             return self.readonly_fields
 
-        excluded_properties = ["pk"]
         properties = []
         for name in dir(self.model):
-            if name in excluded_properties:
+            if name in self.detail_excluded_properties:
                 continue
             if (
                 isinstance(getattr(self.model, name), property)
@@ -243,7 +243,7 @@ class CustomerAdmin(StripeModelAdmin):
         "coupon",
         "balance",
     )
-
+    detail_excluded_properties = StripeModelAdmin.detail_excluded_properties + ["subscription"]
     list_filter = ("deleted",)
     search_fields = ("email", "description", "deleted")
     inlines = (SubscriptionInline, SubscriptionScheduleInline, TaxIdInline)


### PR DESCRIPTION
Apply to Customer's 'subscription' property

Fixes #2155

## Summary by Sourcery

Allow admin classes to specify properties to be excluded from detail views via a class attribute and apply this to omit the `subscription` property in the Customer admin

Enhancements:
- Introduce `detail_excluded_properties` attribute in `StripeModelAdmin` to list model properties excluded from detail views
- Update `get_readonly_fields` to reference `detail_excluded_properties` instead of a hard-coded list
- Extend `CustomerAdmin` to exclude the `subscription` property by appending it to `detail_excluded_properties`