### PR TITLE
Add Prices inline to products

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -18,7 +18,8 @@ from .admin_inline import (
     SubscriptionInline,
     SubscriptionItemInline,
     SubscriptionScheduleInline,
-    TaxIdInline, PriceInline,
+    TaxIdInline,
+    PriceInline,
 )
 from .forms import (
     APIKeyAdminCreateForm,
@@ -243,7 +244,9 @@ class CustomerAdmin(StripeModelAdmin):
         "coupon",
         "balance",
     )
-    detail_excluded_properties = StripeModelAdmin.detail_excluded_properties + ["subscription"]
+    detail_excluded_properties = StripeModelAdmin.detail_excluded_properties + [
+        "subscription"
+    ]
     list_filter = ("deleted",)
     search_fields = ("email", "description", "deleted")
     inlines = (SubscriptionInline, SubscriptionScheduleInline, TaxIdInline)
@@ -505,6 +508,7 @@ class ProductAdmin(StripeModelAdmin):
     list_filter = ("type", "active", "shippable")
     search_fields = ("name", "statement_descriptor")
     inlines = (PriceInline,)
+
     def get_queryset(self, request):
         return super().get_queryset(request).prefetch_related("prices")
 

--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -2,7 +2,7 @@
 Django Administration interface definitions
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from django.contrib import admin
 from django.db import IntegrityError, transaction
@@ -762,7 +762,7 @@ class WebhookEndpointAdmin(CustomActionMixin, admin.ModelAdmin):
             ),
         ]
 
-    def get_changeform_initial_data(self, request) -> Dict[str, str]:
+    def get_changeform_initial_data(self, request) -> dict[str, str]:
         ret = super().get_changeform_initial_data(request)
         base_url = f"{request.scheme}://{request.get_host()}"
         ret.setdefault("base_url", base_url)

--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -18,7 +18,7 @@ from .admin_inline import (
     SubscriptionInline,
     SubscriptionItemInline,
     SubscriptionScheduleInline,
-    TaxIdInline,
+    TaxIdInline, PriceInline,
 )
 from .forms import (
     APIKeyAdminCreateForm,
@@ -482,7 +482,7 @@ class PriceAdmin(StripeModelAdmin):
     raw_id_fields = ("product",)
     search_fields = ("nickname",)
     radio_fields = {"type": admin.HORIZONTAL}
-
+    inlines = (PriceInline, )
     def get_queryset(self, request):
         return (
             super()

--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -75,6 +75,7 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
     change_form_template = "djstripe/admin/change_form.html"
     add_form_template = "djstripe/admin/add_form.html"
     actions = ("_resync_instances", "_sync_all_instances")
+    detail_excluded_properties = ["pk"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -98,10 +99,9 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
         if obj is None:
             return self.readonly_fields
 
-        excluded_properties = ["pk"]
         properties = []
         for name in dir(self.model):
-            if name in excluded_properties:
+            if name in self.detail_excluded_properties:
                 continue
             if (
                 isinstance(getattr(self.model, name), property)
@@ -243,7 +243,7 @@ class CustomerAdmin(StripeModelAdmin):
         "coupon",
         "balance",
     )
-
+    detail_excluded_properties = StripeModelAdmin.detail_excluded_properties + ["subscription"]
     list_filter = ("deleted",)
     search_fields = ("email", "description", "deleted")
     inlines = (SubscriptionInline, SubscriptionScheduleInline, TaxIdInline)

--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -482,7 +482,7 @@ class PriceAdmin(StripeModelAdmin):
     raw_id_fields = ("product",)
     search_fields = ("nickname",)
     radio_fields = {"type": admin.HORIZONTAL}
-    inlines = (PriceInline, )
+
     def get_queryset(self, request):
         return (
             super()
@@ -504,7 +504,7 @@ class ProductAdmin(StripeModelAdmin):
     )
     list_filter = ("type", "active", "shippable")
     search_fields = ("name", "statement_descriptor")
-
+    inlines = (PriceInline,)
     def get_queryset(self, request):
         return super().get_queryset(request).prefetch_related("prices")
 

--- a/djstripe/admin/admin_inline.py
+++ b/djstripe/admin/admin_inline.py
@@ -86,6 +86,7 @@ class LineItemInline(admin.StackedInline):
 
 class PriceInline(admin.StackedInline):
     """A TabularInline for Price."""
+
     model = models.Price
     extra = 0
     readonly_fields = ("id", "created", "djstripe_owner_account")

--- a/djstripe/admin/admin_inline.py
+++ b/djstripe/admin/admin_inline.py
@@ -82,3 +82,12 @@ class LineItemInline(admin.StackedInline):
     readonly_fields = ("id", "created", "djstripe_owner_account")
     raw_id_fields = get_forward_relation_fields_for_model(model)
     show_change_link = True
+
+
+class PriceInline(admin.StackedInline):
+    """A TabularInline for Price."""
+    model = models.Price
+    extra = 0
+    readonly_fields = ("id", "created", "djstripe_owner_account")
+    raw_id_fields = get_forward_relation_fields_for_model(model)
+    show_change_link = True

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -26,8 +26,6 @@ Invoke like so:
         python manage.py djstripe_sync_models Account Charge --api-keys sk_test_XXX sk_test_YYY
 """
 
-import typing
-
 from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -65,10 +65,10 @@ class Command(BaseCommand):
             help="Specify the api_keys you would like to perform this sync for.",
         )
 
-    def handle(self, *args, api_keys: typing.List[str], **options):
+    def handle(self, *args, api_keys: list[str], **options):
         app_label = "djstripe"
         app_config = apps.get_app_config(app_label)
-        model_list: typing.List[models.StripeModel] = []
+        model_list: list[models.StripeModel] = []
 
         if args:
             for model_label in args:

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import timedelta
-from typing import Dict, List, Optional, Type
+from typing import Optional, Type
 
 from django.db import IntegrityError, models, transaction
 from django.utils import dateformat, timezone
@@ -89,7 +89,7 @@ class StripeBaseModel(models.Model):
 class StripeModel(StripeBaseModel):
     # This must be defined in descendants of this model/mixin
     # e.g. Event, Charge, Customer, etc.
-    expand_fields: List[str] = []
+    expand_fields: list[str] = []
     stripe_dashboard_item_name = ""
 
     objects = models.Manager()
@@ -362,7 +362,7 @@ class StripeModel(StripeBaseModel):
         pending_relations: list = None,
         stripe_account: str = None,
         api_key=djstripe_settings.STRIPE_SECRET_KEY,
-    ) -> Dict:
+    ) -> dict:
         """
         This takes an object, as it is formatted in Stripe's current API for our object
         type. In return, it provides a dict. The dict can be used to create a record or

--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import timedelta
-from typing import Optional, Type
+from typing import Optional
 
 from django.db import IntegrityError, models, transaction
 from django.utils import dateformat, timezone
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class StripeBaseModel(models.Model):
-    stripe_class: Type[APIResource] = APIResource
+    stripe_class: type[APIResource] = APIResource
 
     djstripe_created = models.DateTimeField(auto_now_add=True, editable=False)
     djstripe_updated = models.DateTimeField(auto_now=True, editable=False)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -134,7 +134,7 @@ class StripeItem(dict):
         base = self.class_url()
         return f"{base}/{id}"
 
-    def request(self, method, url, params) -> Dict:
+    def request(self, method, url, params) -> dict:
         """Superficial mock that emulates request method."""
         assert method == "post"
         for key, value in params.items():


### PR DESCRIPTION
To ease the administration, I propose to add the Prices inline to the Products. It also allow the Product view to match the Stripe Product interface in the dashboard.

## Summary by Sourcery

Introduce PriceInline in the Django admin to enable inline display and editing of Price records alongside related models.

Enhancements:
- Add a PriceInline stacked inline for the Price model with readonly ID, created timestamp, and owner fields
- Include PriceInline in the admin inlines configuration for the PriceAdmin class