### PR TITLE
fix(admin): explicit search_fields attribute declaration on StripeModelAdmin

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -75,6 +75,7 @@ class StripeModelAdmin(CustomActionMixin, admin.ModelAdmin):
     change_form_template = "djstripe/admin/change_form.html"
     add_form_template = "djstripe/admin/add_form.html"
     actions = ("_resync_instances", "_sync_all_instances")
+    search_fields = ("id",)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
When you want to reference a dj-stripe model using the `autocomplete_fields` attribute on your own model's ModelAdmin class, you may face a Django error on boot if that dj-stripe model doesn't explicitly declare the `search_fields` in its ModelAdmin.

`<class 'myapp.admin.MyModel'>: (admin.E040) SubscriptionAdmin must define "search_fields", because it's referenced by MyModelAdmin.autocomplete_fields.`

This PR fixes the error by explicitly declaring the `search_fields` attribute on `StripeModelAdmin` base class.

## Summary by Sourcery

Bug Fixes:
- Explicitly declare search_fields on StripeModelAdmin to avoid admin.E040 errors with autocomplete_fields.