### PR TITLE
Fix Admin Customer list

### DIFF
--- a/djstripe/admin/admin.py
+++ b/djstripe/admin/admin.py
@@ -245,7 +245,7 @@ class CustomerAdmin(StripeModelAdmin):
         return (
             super()
             .get_queryset(request)
-            .select_related("subscriber", "default_source", "default_payment_method")
+            .select_related("subscriber", "default_payment_method")
         )
 
 

--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -1109,8 +1109,9 @@ class Plan(StripeModel):
         return plan
 
     def __str__(self):
-        if self.product and self.product.name:
-            return f"{self.human_readable_price} for {self.product.name}"
+        if self.product and self.product.get('name'):
+            name = self.product.get('name')
+            return f"{self.human_readable_price} for {name}"
         return self.human_readable_price
 
     @property


### PR DESCRIPTION
* `default_source` is no longer a db field on Customer: breaking the Customer list view in the Admin GUI.
* `product` is no longer a db field on Plan: breaking the Subscription detail view in the Admin GUI.

NOTES:
There are several errors breaking the Django Admin UI for Customer And Subscriptions (and perhaps others?). By looking at the recent database migration (002), these seem to be related to db fields that were recently removed from some of the Model classes. Some of them were moved to `stripe_data` JSON fields.

You can easily reproduce the errors by visiting the Admin List view or Detail views for Customer or Subscription.

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/changes/ folder)

Much appreciated!

-->

## Summary by Sourcery

Bug Fixes:
- Remove default_source from select_related in CustomerAdmin.get_queryset to fix broken admin customer list view