### PR TITLE
Fix installation link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The full documentation is available [on Read the Docs](https://dj-stripe.github.
 
 ## Installation
 
-See [installation](https://dj-stripe.dev/docs/latest/installation/) instructions.
+See [installation](https://dj-stripe.dev/docs/latest/installation) instructions.
 
 ## Changelog
 


### PR DESCRIPTION
The old URL with the trailing slash returned a 404 instead of a redirect.

## Summary by Sourcery

Documentation:
- Remove trailing slash from the installation URL in docs/README.md to correct the link