### PR TITLE
Remove nargs=1 from stripe_listen arg parser.

### DIFF
--- a/djstripe/management/commands/stripe_listen.py
+++ b/djstripe/management/commands/stripe_listen.py
@@ -24,7 +24,6 @@ class Command(BaseCommand):
         parser.add_argument(
             "--host",
             metavar="host",
-            nargs=1,
             default="localhost",
             type=str,
             help="The host on which Django is running (defaults to localhost).",
@@ -32,7 +31,6 @@ class Command(BaseCommand):
         parser.add_argument(
             "--port",
             metavar="port",
-            nargs=1,
             default=8000,
             type=int,
             help="The port on which Django is running (defaults to 8000).",


### PR DESCRIPTION
Passing `--host` and/or `--port` to the `stripe_listen` command caused the values to be wrapped in square brackets due to `nargs=1` creating a malformed webhook URLs.

For example the command:
`python manage.py stripe_listen --port 8080` 
would set the webhook url to: 
`http://localhost:[8080]/stripe/webhook/...`

It was because argparse was returning a list. I removed nargs=1 from the arg parser and it fixed it.

## Summary by Sourcery

Bug Fixes:
- Correct handling of --host and --port options in the stripe_listen command so they are parsed as scalar values instead of single-item lists, preventing bracketed values in generated webhook URLs.