### PR TITLE
Fix StripeObject dict-method compatibility with stripe-python 15 on s…

### DIFF
--- a/djstripe/_stripe_compat.py
+++ b/djstripe/_stripe_compat.py
@@ -8,67 +8,6 @@ across its sync code paths, so we restore them here.
 
 This is a no-op against stripe <15: the inherited ``dict`` methods short-circuit
 the ``hasattr`` checks below.
-"""
-
-from stripe import StripeObject
-
-_MISSING = object()
-
-
-def _get(self, key, default=None):
-    return self[key] if key in self else default
-
-
-def _items(self):
-    return self._data.items()
-
-
-def _keys(self):
-    return self._data.keys()
-
-
-def _values(self):
-    return self._data.values()
-
-
-def _pop(self, key, default=_MISSING):
-    if key in self:
-        value = self[key]
-        del self[key]
-        return value
-    if default is _MISSING:
-        raise KeyError(key)
-    return default
-
-
-def _setdefault(self, key, default=None):
-    if key in self:
-        return self[key]
-    self[key] = default
-    return default
-
-
-for _name, _fn in (
-    ("get", _get),
-    ("items", _items),
-    ("keys", _keys),
-    ("values", _values),
-    ("pop", _pop),
-    ("setdefault", _setdefault),
-):
-    if not hasattr(StripeObject, _name):
-        setattr(StripeObject, _name, _fn)
-
-"""
-Compatibility shim for stripe-python >= 15.
-
-In stripe 15.0.0, ``StripeObject`` stopped inheriting from ``dict`` and the
-mapping-style methods it provided (``get``, ``items``, ``keys``, ``values``,
-``pop``, ``setdefault``) were dropped. dj-stripe relies on those methods
-across its sync code paths, so we restore them here.
-
-This is a no-op against stripe <15: the inherited ``dict`` methods short-circuit
-the ``hasattr`` checks below.
 
 """
 

--- a/djstripe/_stripe_compat.py
+++ b/djstripe/_stripe_compat.py
@@ -58,3 +58,65 @@ for _name, _fn in (
 ):
     if not hasattr(StripeObject, _name):
         setattr(StripeObject, _name, _fn)
+
+"""
+Compatibility shim for stripe-python >= 15.
+
+In stripe 15.0.0, ``StripeObject`` stopped inheriting from ``dict`` and the
+mapping-style methods it provided (``get``, ``items``, ``keys``, ``values``,
+``pop``, ``setdefault``) were dropped. dj-stripe relies on those methods
+across its sync code paths, so we restore them here.
+
+This is a no-op against stripe <15: the inherited ``dict`` methods short-circuit
+the ``hasattr`` checks below.
+
+"""
+
+from stripe import StripeObject
+
+_MISSING = object()
+
+
+def _get(self, key, default=None):
+    return self[key] if key in self else default
+
+
+def _items(self):
+    return self._data.items()
+
+
+def _keys(self):
+    return self._data.keys()
+
+
+def _values(self):
+    return self._data.values()
+
+
+def _pop(self, key, default=_MISSING):
+    if key in self:
+        value = self[key]
+        del self[key]
+        return value
+    if default is _MISSING:
+        raise KeyError(key)
+    return default
+
+
+def _setdefault(self, key, default=None):
+    if key in self:
+        return self[key]
+    self[key] = default
+    return default
+
+
+for _name, _fn in (
+    ("get", _get),
+    ("items", _items),
+    ("keys", _keys),
+    ("values", _values),
+    ("pop", _pop),
+    ("setdefault", _setdefault),
+):
+    if not hasattr(StripeObject, _name):
+        setattr(StripeObject, _name, _fn)

--- a/docs/changes/2_10_x.md
+++ b/docs/changes/2_10_x.md
@@ -1,3 +1,23 @@
+# dj-stripe 2.10.4 (2026-05-27)
+
+-   Restore compatibility with stripe-python 15. In stripe 15, `StripeObject` stopped inheriting from `dict` and lost the mapping-style methods (`get`, `items`, `keys`, `values`, `pop`, `setdefault`) that dj-stripe relies on across its sync paths. A small compatibility shim restores them on stripe >=15 and is a no-op on earlier versions.
+
+# dj-stripe 2.10.3 (2025-10-15)
+
+-   Fix api_key not being passed in PaymentMethod.detach() correctly
+-   Fix churn() calculations
+-   Add VerificationSession.client_reference_id property
+-   Fix customer retrieval on payment method attachment
+
+# dj-stripe 2.10.2 (2025-10-13)
+
+-   Update supported signals with `invoice.overpaid`, `invoice_payment.paid` and `terminal.reader.action_updated`
+-   Fix various admin crashes
+-   Fix a crash in product definition
+-   Fix a crash in invoice expansion
+-   Fix issues with entitlements webhooks not correctly syncing
+-   Fix documentation rendering issues and update some outdated references
+
 # dj-stripe 2.10.1 (2025-08-29)
 
 -   Fix customer balance lookups and related tests

--- a/tests/test_stripe_compat.py
+++ b/tests/test_stripe_compat.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+from stripe import StripeObject
+import djstripe._stripe_compat
+
+
+class TestStripeObjectCompat(TestCase):
+    def test_stripe_object_dict_compatibility(self):
+        # Verify the mapping-style methods are present on the StripeObject class
+        for method_name in ("get", "items", "keys", "values", "pop", "setdefault"):
+            self.assertTrue(
+                hasattr(StripeObject, method_name),
+                f"StripeObject should have method {method_name}",
+            )
+            self.assertTrue(
+                callable(getattr(StripeObject, method_name)),
+                f"StripeObject.{method_name} should be callable",
+            )
+
+        # Construct a StripeObject using construct_from to test instance behavior
+        obj = StripeObject.construct_from({"id": "test_id", "foo": "bar"}, "test_key")
+
+        # Test .get()
+        self.assertEqual(obj.get("foo"), "bar")
+        self.assertEqual(obj.get("id"), "test_id")
+        self.assertEqual(obj.get("nonexistent"), None)
+        self.assertEqual(obj.get("nonexistent", "default"), "default")
+
+        # Test .keys()
+        self.assertIn("foo", obj.keys())
+        self.assertIn("id", obj.keys())
+
+        # Test .values()
+        self.assertIn("bar", obj.values())
+        self.assertIn("test_id", obj.values())
+
+        # Test .items()
+        items = dict(obj.items())
+        self.assertEqual(items["foo"], "bar")
+        self.assertEqual(items["id"], "test_id")
+
+        # Test .setdefault()
+        self.assertEqual(obj.setdefault("foo", "new_val"), "bar")  # existing key
+        self.assertEqual(obj.setdefault("new_key", "new_val"), "new_val")  # new key
+        self.assertEqual(obj.get("new_key"), "new_val")
+
+        # Test .pop()
+        self.assertEqual(obj.pop("foo"), "bar")
+        self.assertNotIn("foo", obj.keys())
+        self.assertEqual(obj.pop("nonexistent", "default_pop"), "default_pop")
+        with self.assertRaises(KeyError):
+            obj.pop("nonexistent")


### PR DESCRIPTION
Fix StripeObject dict-method compatibility with stripe-python 15

In stripe-python 15.0.0, StripeObject stopped inheriting from dict,
removing mapping-style methods (get, items, keys, values, pop, setdefault)
that dj-stripe relies on across its sync code paths.

This change backports the compatibility shim from the main branch to
the stable/2.10 branch. It injects the missing dictionary methods onto
StripeObject at runtime. The shim is a safe no-op when running against
stripe-python versions below 15.

Key changes:

Created djstripe/_stripe_compat.py to restore mapping methods.
Registered the patch on app startup in djstripe/apps.py ready().
Added full test coverage for all shimmed methods in
tests/test_stripe_compat.py.
Documented the change in docs/changes/2_10_x.md.
Fixes https://github.com/dj-stripe/dj-stripe/issues/2224 (Backport of https://github.com/dj-stripe/dj-stripe/issues/2221)

## Summary by Sourcery

Restore compatibility with stripe-python 15 by shimming missing dict-like methods onto StripeObject at runtime.

New Features:
- Expose dict-style helper methods (get, items, keys, values, pop, setdefault) on StripeObject instances when they are not provided by stripe-python.

Tests:
- Add tests ensuring StripeObject exposes the expected dict-like methods and that they behave consistently for typical usage scenarios.