### PR TITLE
Fix spelling error - jstripe to djstripe

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ STRIPE_LIVE_MODE = False  # Change to True in production
 DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
 ```
 
-_NOTE_: jstripe expects `STRIPE_LIVE_MODE` to be a Boolean Type. In case you use `Bash env vars or equivalent` to inject its value, make sure to convert it to a Boolean type. We highly recommended the library [django-environ](https://django-environ.readthedocs.io/en/latest/)
+_NOTE_: djstripe expects `STRIPE_LIVE_MODE` to be a Boolean Type. In case you use `Bash env vars or equivalent` to inject its value, make sure to convert it to a Boolean type. We highly recommended the library [django-environ](https://django-environ.readthedocs.io/en/latest/)
 
 Sync data from Stripe:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ STRIPE_LIVE_MODE = False  # Change to True in production
 DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
 ```
 
-_NOTE_: djstripe expects `STRIPE_LIVE_MODE` to be a Boolean Type. In case you use `Bash env vars or equivalent` to inject its value, make sure to convert it to a Boolean type. We highly recommended the library [django-environ](https://django-environ.readthedocs.io/en/latest/)
+_NOTE_: djstripe expects `STRIPE_LIVE_MODE` to be a Boolean Type. In case you use `Bash env vars or equivalent` to inject its value, make sure to convert it to a Boolean type. We highly recommend the library [django-environ](https://django-environ.readthedocs.io/en/latest/)
 
 Sync data from Stripe:
 


### PR DESCRIPTION
Add the D :)

## Summary by Sourcery

Documentation:
- Fix a spelling error in the installation docs by changing a reference from jstripe to djstripe.