### PR TITLE
Add Coupon.valid property to compute validity on-the-fly

### DIFF
--- a/djstripe/models/billing.py
+++ b/djstripe/models/billing.py
@@ -80,6 +80,31 @@ class Coupon(StripeModel):
     def times_redeemed(self):
         return self.stripe_data.get("times_redeemed", 0)
 
+    @property
+    def valid(self) -> bool:
+        """
+        Whether the coupon is still valid.
+
+        Stripe does not send a webhook event when a coupon expires (either by
+        reaching its ``redeem_by`` date or by being redeemed the maximum number
+        of times), so the ``valid`` field from the Stripe API response can
+        become stale.  This property is computed on-the-fly from the coupon's
+        underlying data so it always reflects the current state.
+
+        See https://github.com/dj-stripe/dj-stripe/issues/717
+        """
+        redeem_by = self.redeem_by
+        if redeem_by:
+            redeem_by_dt = convert_tstamp(redeem_by)
+            if redeem_by_dt is not None and redeem_by_dt < timezone.now():
+                return False
+
+        max_redemptions = self.max_redemptions
+        if max_redemptions and self.times_redeemed >= max_redemptions:
+            return False
+
+        return True
+
     class Meta(StripeModel.Meta):
         unique_together = ("id", "livemode")
 

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytest
 from django.test.testcases import TestCase
@@ -121,6 +122,24 @@ class CouponTest(TestCase):
             redeem_by=future_ts,
         )
         self.assertTrue(coupon.valid)
+
+    def test_valid_redeem_by_is_now(self):
+        """A coupon whose redeem_by equals the current time is valid.
+
+        Uses ``<`` (strict less-than), so a coupon expiring exactly now
+        is still considered valid.
+        """
+        now = timezone.now().replace(microsecond=0)
+        now_ts = int(now.timestamp())
+        coupon = _make_coupon(
+            "coupon-test-redeem-by-now",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            redeem_by=now_ts,
+        )
+        with patch("djstripe.models.billing.timezone.now", return_value=now):
+            self.assertTrue(coupon.valid)
 
     def test_valid_past_redeem_by(self):
         """A coupon with a past redeem_by date is invalid (expired)."""

--- a/tests/test_coupon.py
+++ b/tests/test_coupon.py
@@ -1,5 +1,8 @@
+import datetime
+
 import pytest
 from django.test.testcases import TestCase
+from django.utils import timezone
 
 from djstripe.models import Coupon
 
@@ -94,3 +97,78 @@ class CouponTest(TestCase):
         )
         self.assertEqual(coupon.human_readable, "10% off forever")
         self.assertEqual(str(coupon), coupon.human_readable)
+
+    # --- valid property tests (issue #717) ---
+
+    def test_valid_no_restrictions(self):
+        """A coupon with no redeem_by or max_redemptions is always valid."""
+        coupon = _make_coupon(
+            "coupon-test-valid",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+        )
+        self.assertTrue(coupon.valid)
+
+    def test_valid_future_redeem_by(self):
+        """A coupon with a future redeem_by date is valid."""
+        future_ts = int((timezone.now() + datetime.timedelta(days=30)).timestamp())
+        coupon = _make_coupon(
+            "coupon-test-future-redeem-by",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            redeem_by=future_ts,
+        )
+        self.assertTrue(coupon.valid)
+
+    def test_valid_past_redeem_by(self):
+        """A coupon with a past redeem_by date is invalid (expired)."""
+        past_ts = int((timezone.now() - datetime.timedelta(days=1)).timestamp())
+        coupon = _make_coupon(
+            "coupon-test-past-redeem-by",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            redeem_by=past_ts,
+        )
+        self.assertFalse(coupon.valid)
+
+    def test_valid_max_redemptions_not_reached(self):
+        """A coupon that hasn't reached max_redemptions is valid."""
+        coupon = _make_coupon(
+            "coupon-test-max-redemptions-active",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            max_redemptions=100,
+            times_redeemed=50,
+        )
+        self.assertTrue(coupon.valid)
+
+    def test_valid_max_redemptions_reached(self):
+        """A coupon that has reached max_redemptions is invalid (exhausted)."""
+        coupon = _make_coupon(
+            "coupon-test-max-redemptions-exhausted",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            max_redemptions=100,
+            times_redeemed=100,
+        )
+        self.assertFalse(coupon.valid)
+
+    def test_valid_both_expired_and_exhausted(self):
+        """When both redeem_by and max_redemptions indicate invalid, the
+        coupon is invalid."""
+        past_ts = int((timezone.now() - datetime.timedelta(days=1)).timestamp())
+        coupon = _make_coupon(
+            "coupon-test-both-invalid",
+            percent_off=10,
+            currency="usd",
+            duration="forever",
+            redeem_by=past_ts,
+            max_redemptions=10,
+            times_redeemed=10,
+        )
+        self.assertFalse(coupon.valid)


### PR DESCRIPTION
## Summary

This adds a computed `valid` property to the `Coupon` model, addressing the request in #717.

Stripe does not send a webhook event when a coupon expires (either by reaching its `redeem_by` date or by exhausting its `max_redemptions`), so the `valid` field from the Stripe API response becomes stale in the local database. This property is computed on-the-fly from the underlying coupon data and always reflects the current state.

The implementation follows the approach suggested by @jleclanche in the issue discussion.

### Logic

- Returns `False` if `redeem_by` is set and the expiry date has passed
- Returns `False` if `max_redemptions` is set and `times_redeemed >= max_redemptions`
- Returns `True` otherwise

### Why a property instead of syncing the field?

As noted in the issue, Stripe does not broadcast an event when a coupon expires at its `redeem_by` date, so a synced `valid` field would be incorrect. A computed property is always accurate.

## Test plan

Added 6 new test cases covering all branches:

- `test_valid_no_restrictions` — always-valid coupon
- `test_valid_future_redeem_by` — future expiry → valid
- `test_valid_past_redeem_by` — past expiry → invalid
- `test_valid_max_redemptions_not_reached` — under limit → valid
- `test_valid_max_redemptions_reached` — at limit → invalid
- `test_valid_both_expired_and_exhausted` — both conditions → invalid

```
DJSTRIPE_TEST_DB_VENDOR=sqlite uv run pytest tests/test_coupon.py -v --reuse-db

14 passed, 1 warning in 38.75s
```

Pre-commit checks (ruff, mypy, pyupgrade, django-upgrade, check-migrations) all pass.

Closes #717

## Summary by Sourcery

Add a computed validity indicator to coupons so their active/expired state is always derived from current data instead of relying on stale Stripe fields.

New Features:
- Introduce a Coupon.valid property that determines coupon validity based on redeem_by and max_redemptions constraints.

Tests:
- Add test cases covering all combinations of redeem_by and max_redemptions to validate the Coupon.valid property behavior.