### PR TITLE
Fix djstripe_sync_models with restricted API keys

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -37,6 +37,7 @@ from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import models as django_models
+from stripe import PermissionError as StripePermissionError
 
 from ... import enums, models
 from ...enums import APIKeyType
@@ -323,18 +324,28 @@ class Command(BaseCommand):
         """Get set of all stripe account ids including the Platform Acccount"""
         accs_set = set()
 
-        # special case, since own account isn't returned by Account.api_list.
-        # Restricted keys cannot call GET /v1/account, so it is skipped for
-        # those; connected accounts are still listed below.
+        # special case, since own account isn't returned by Account.api_list
         if not is_restricted_key(api_key):
             stripe_platform_obj = models.Account.stripe_class.retrieve(
                 api_key=api_key,
                 stripe_version=djstripe_settings.STRIPE_API_VERSION,
             )
             accs_set.add(stripe_platform_obj.id)
-        accs_set.update(
-            obj.id for obj in models.Account.api_list(api_key=api_key, **kwargs)
-        )
+        else:
+            # We can't learn the platform account id from a restricted key, but
+            # an empty stripe_account omits the Stripe-Account header, so the
+            # request still targets the key's own account. Without this the set
+            # would be empty and nothing would be synced at all.
+            accs_set.add("")
+
+        try:
+            accs_set.update(
+                obj.id for obj in models.Account.api_list(api_key=api_key, **kwargs)
+            )
+        except StripePermissionError:
+            # A restricted key may not be permitted to list connected accounts.
+            # That must not take down the sync of the key's own account.
+            pass
 
         return accs_set
 

--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -41,7 +41,11 @@ from django.db import models as django_models
 from ... import enums, models
 from ...enums import APIKeyType
 from ...exceptions import InvalidStripeAPIKey
-from ...models.api import get_api_key_details_by_prefix, redact_api_key
+from ...models.api import (
+    get_api_key_details_by_prefix,
+    is_restricted_key,
+    redact_api_key,
+)
 from ...models.base import StripeBaseModel
 from ...settings import djstripe_settings
 
@@ -212,15 +216,19 @@ class Command(BaseCommand):
         count = 0
         object_errors = 0
         try:
+            # Resolved once, outside the loop. This is None for restricted
+            # keys, which cannot retrieve the platform account.
+            default_account = (
+                models.Account.get_default_account(api_key=api_key)
+                if model is models.Account
+                else None
+            )
+
             # todo convert get_list_kwargs into a generator to make the code memory effecient.
             for list_kwargs in self.get_list_kwargs(model, api_key=api_key):
                 stripe_account = list_kwargs.get("stripe_account", "")
 
-                if (
-                    model is models.Account
-                    and stripe_account
-                    == models.Account.get_default_account(api_key=api_key).id
-                ):
+                if default_account is not None and stripe_account == default_account.id:
                     # special case, since own account isn't returned by Account.api_list
                     stripe_obj = models.Account.stripe_class.retrieve(
                         api_key=api_key,
@@ -315,12 +323,15 @@ class Command(BaseCommand):
         """Get set of all stripe account ids including the Platform Acccount"""
         accs_set = set()
 
-        # special case, since own account isn't returned by Account.api_list
-        stripe_platform_obj = models.Account.stripe_class.retrieve(
-            api_key=api_key,
-            stripe_version=djstripe_settings.STRIPE_API_VERSION,
-        )
-        accs_set.add(stripe_platform_obj.id)
+        # special case, since own account isn't returned by Account.api_list.
+        # Restricted keys cannot call GET /v1/account, so it is skipped for
+        # those; connected accounts are still listed below.
+        if not is_restricted_key(api_key):
+            stripe_platform_obj = models.Account.stripe_class.retrieve(
+                api_key=api_key,
+                stripe_version=djstripe_settings.STRIPE_API_VERSION,
+            )
+            accs_set.add(stripe_platform_obj.id)
         accs_set.update(
             obj.id for obj in models.Account.api_list(api_key=api_key, **kwargs)
         )

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -6,7 +6,7 @@ from stripe import AuthenticationError, InvalidRequestError, PermissionError
 
 from ..enums import APIKeyType
 from ..settings import djstripe_settings
-from .api import APIKey, get_api_key_details_by_prefix
+from .api import APIKey, get_api_key_details_by_prefix, is_restricted_key
 from .base import StripeModel, logger
 
 
@@ -151,10 +151,17 @@ class Account(StripeModel):
         return ""
 
     @classmethod
-    def get_default_account(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY):
+    def get_default_account(cls, api_key=None):
+        # Resolve the key here rather than as a default argument so that it is
+        # read at call time (the default would be frozen at import time).
+        api_key = api_key or djstripe_settings.STRIPE_SECRET_KEY
+
         # As of API version 2020-03-02, there is no permission that can allow
-        # restricted keys to call GET /v1/account
-        if djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_"):
+        # restricted keys to call GET /v1/account.
+        # NOTE: test the key we were passed, not the one in settings: callers
+        # such as `djstripe_sync_models --api-keys rk_...` pass a key that is
+        # not the configured default.
+        if is_restricted_key(api_key):
             return None
 
         account_data = cls.stripe_class.retrieve(

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -154,7 +154,10 @@ class Account(StripeModel):
     def get_default_account(cls, api_key=None):
         # Resolve the key here rather than as a default argument so that it is
         # read at call time (the default would be frozen at import time).
-        api_key = api_key or djstripe_settings.STRIPE_SECRET_KEY
+        # `is None` rather than a truthiness check, so an explicitly passed
+        # empty key still behaves as it did under the old signature.
+        if api_key is None:
+            api_key = djstripe_settings.STRIPE_SECRET_KEY
 
         # dj-stripe does not attempt GET /v1/account with restricted keys: as of
         # API version 2020-03-02 no permission was available that allowed it.

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -156,8 +156,8 @@ class Account(StripeModel):
         # read at call time (the default would be frozen at import time).
         api_key = api_key or djstripe_settings.STRIPE_SECRET_KEY
 
-        # As of API version 2020-03-02, there is no permission that can allow
-        # restricted keys to call GET /v1/account.
+        # dj-stripe does not attempt GET /v1/account with restricted keys: as of
+        # API version 2020-03-02 no permission was available that allowed it.
         # NOTE: test the key we were passed, not the one in settings: callers
         # such as `djstripe_sync_models --api-keys rk_...` pass a key that is
         # not the configured default.

--- a/djstripe/models/api.py
+++ b/djstripe/models/api.py
@@ -34,6 +34,16 @@ def redact_api_key(api_key: str) -> str:
     return f"{secret_prefix}_...{secret_part[-4:]}"
 
 
+def is_restricted_key(api_key: str) -> bool:
+    """
+    Return whether the given key is a restricted key (``rk_...``).
+
+    Restricted keys are limited to the permissions granted to them in the
+    Stripe dashboard, and notably cannot call ``GET /v1/account``.
+    """
+    return api_key.startswith("rk_")
+
+
 def get_api_key_details_by_prefix(api_key: str):
     if not api_key:
         raise InvalidStripeAPIKey(

--- a/djstripe/models/api.py
+++ b/djstripe/models/api.py
@@ -39,7 +39,12 @@ def is_restricted_key(api_key: str) -> bool:
     Return whether the given key is a restricted key (``rk_...``).
 
     Restricted keys are limited to the permissions granted to them in the
-    Stripe dashboard, and notably cannot call ``GET /v1/account``.
+    Stripe dashboard, so calls that dj-stripe makes unconditionally for
+    secret keys may not be available to them.
+
+    NOTE: this deliberately does not go through `get_api_key_details_by_prefix`,
+    which validates the whole key and raises on anything malformed. Callers here
+    only want to know how to treat a key, not to reject it.
     """
     return api_key.startswith("rk_")
 

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -64,3 +64,10 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
+-   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
+    `Account.get_default_account()` checked the key configured in settings
+    rather than the key it was passed, and the sync command dereferenced the
+    resulting `None`, raising `'NoneType' object has no attribute 'id'`. The
+    platform account is no longer retrieved for restricted keys, and a key that
+    cannot list connected accounts no longer aborts the rest of the sync
+    (#1908).

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,7 +14,7 @@ from django.test.testcases import TestCase
 from stripe import InvalidRequestError
 
 from djstripe.enums import APIKeyType
-from djstripe.models import APIKey, Customer
+from djstripe.models import Account, APIKey, Customer
 from djstripe.management.commands.djstripe_sync_models import Command
 from djstripe.settings import djstripe_settings
 from djstripe.sync import sync_subscriber
@@ -171,3 +171,69 @@ class TestSyncModelsGetApiKeys(TestCase):
         stderr = StringIO()
         call_command("djstripe_sync_models", "Account", stderr=stderr)
         assert "don't have any API Keys" in stderr.getvalue()
+
+
+class TestSyncModelsRestrictedKeys(TestCase):
+    """
+    Restricted keys cannot call `GET /v1/account`.
+
+    Regression tests for #1908: syncing with `--api-keys rk_...` crashed with
+    `'NoneType' object has no attribute 'id'`, because the restricted-key guard
+    in `Account.get_default_account()` inspected the key configured in settings
+    rather than the key it was passed.
+    """
+
+    RK_TEST = "rk_test_" + "d" * 24
+
+    def test_get_default_account_returns_none_for_passed_restricted_key(self):
+        # Settings hold an `sk_` key, but the caller passes an `rk_` one. The
+        # guard must follow the argument, not the setting.
+        assert not djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_")
+
+        with patch("stripe.Account.retrieve") as retrieve_mock:
+            assert Account.get_default_account(api_key=self.RK_TEST) is None
+
+        retrieve_mock.assert_not_called()
+
+    def test_get_stripe_account_skips_platform_retrieve_for_restricted_key(self):
+        with (
+            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
+        ):
+            assert Command.get_stripe_account(api_key=self.RK_TEST) == set()
+
+        retrieve_mock.assert_not_called()
+
+    def test_sync_account_with_restricted_key_does_not_crash(self):
+        stderr = StringIO()
+
+        with (
+            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
+        ):
+            call_command(
+                "djstripe_sync_models",
+                "Account",
+                api_keys=[self.RK_TEST],
+                stderr=stderr,
+            )
+
+        retrieve_mock.assert_not_called()
+        assert "NoneType" not in stderr.getvalue()
+
+    @override_settings(STRIPE_TEST_SECRET_KEY="rk_test_" + "e" * 24)
+    def test_sync_account_does_not_dereference_missing_default_account(self):
+        # The originally reported failure: with a restricted key configured,
+        # `get_default_account()` correctly returns None and the command then
+        # blew up dereferencing `.id` on it. `get_stripe_account` is stubbed so
+        # the run reaches that line instead of failing earlier on the
+        # platform-account retrieve.
+        stderr = StringIO()
+
+        with (
+            patch.object(Command, "get_stripe_account", return_value={"acct_test"}),
+            patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
+        ):
+            call_command("djstripe_sync_models", "Account", stderr=stderr)
+
+        assert "NoneType" not in stderr.getvalue(), stderr.getvalue()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,7 +19,7 @@ from djstripe.management.commands.djstripe_sync_models import Command
 from djstripe.settings import djstripe_settings
 from djstripe.sync import sync_subscriber
 
-from . import FAKE_CUSTOMER, StripeList
+from . import FAKE_CUSTOMER, StripeItem, StripeList
 from .conftest import CreateAccountMixin
 
 
@@ -175,7 +175,7 @@ class TestSyncModelsGetApiKeys(TestCase):
 
 class TestSyncModelsRestrictedKeys(TestCase):
     """
-    Restricted keys cannot call `GET /v1/account`.
+    dj-stripe does not attempt `GET /v1/account` with restricted keys.
 
     Regression tests for #1908: syncing with `--api-keys rk_...` crashed with
     `'NoneType' object has no attribute 'id'`, because the restricted-key guard
@@ -196,12 +196,18 @@ class TestSyncModelsRestrictedKeys(TestCase):
         retrieve_mock.assert_not_called()
 
     def test_get_stripe_account_skips_platform_retrieve_for_restricted_key(self):
+        # Skipping the platform account must not cost us the connected ones.
+        connected = StripeList(
+            data=[StripeItem(id="acct_one"), StripeItem(id="acct_two")]
+        )
+
         with (
             patch("stripe.Account.retrieve") as retrieve_mock,
-            patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
+            patch("djstripe.models.Account.api_list", return_value=connected),
         ):
-            assert Command.get_stripe_account(api_key=self.RK_TEST) == set()
+            accounts = Command.get_stripe_account(api_key=self.RK_TEST)
 
+        assert accounts == {"acct_one", "acct_two"}
         retrieve_mock.assert_not_called()
 
     def test_sync_account_with_restricted_key_does_not_crash(self):
@@ -219,9 +225,11 @@ class TestSyncModelsRestrictedKeys(TestCase):
             )
 
         retrieve_mock.assert_not_called()
-        assert "NoneType" not in stderr.getvalue()
+        assert stderr.getvalue() == ""
 
-    @override_settings(STRIPE_TEST_SECRET_KEY="rk_test_" + "e" * 24)
+    @override_settings(
+        STRIPE_TEST_SECRET_KEY="rk_test_" + "e" * 24, STRIPE_LIVE_SECRET_KEY=""
+    )
     def test_sync_account_does_not_dereference_missing_default_account(self):
         # The originally reported failure: with a restricted key configured,
         # `get_default_account()` correctly returns None and the command then
@@ -236,4 +244,6 @@ class TestSyncModelsRestrictedKeys(TestCase):
         ):
             call_command("djstripe_sync_models", "Account", stderr=stderr)
 
-        assert "NoneType" not in stderr.getvalue(), stderr.getvalue()
+        # Assert on the outcome, not just on the absence of the old error
+        # string: nothing should be reported as failed at all.
+        assert stderr.getvalue() == ""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,6 +12,7 @@ from django.core.management.base import CommandError
 from django.test import override_settings
 from django.test.testcases import TestCase
 from stripe import InvalidRequestError
+from stripe import PermissionError as StripePermissionError
 
 from djstripe.enums import APIKeyType
 from djstripe.models import Account, APIKey, Customer
@@ -196,7 +197,9 @@ class TestSyncModelsRestrictedKeys(TestCase):
         retrieve_mock.assert_not_called()
 
     def test_get_stripe_account_skips_platform_retrieve_for_restricted_key(self):
-        # Skipping the platform account must not cost us the connected ones.
+        # Skipping the platform account must not cost us the connected ones,
+        # and the key's own account must still be represented -- by the empty
+        # string, which omits the Stripe-Account header on the resulting calls.
         connected = StripeList(
             data=[StripeItem(id="acct_one"), StripeItem(id="acct_two")]
         )
@@ -207,23 +210,46 @@ class TestSyncModelsRestrictedKeys(TestCase):
         ):
             accounts = Command.get_stripe_account(api_key=self.RK_TEST)
 
-        assert accounts == {"acct_one", "acct_two"}
+        assert accounts == {"", "acct_one", "acct_two"}
         retrieve_mock.assert_not_called()
 
-    def test_sync_account_with_restricted_key_does_not_crash(self):
+    def test_get_stripe_account_survives_unlistable_connected_accounts(self):
+        # A restricted key scoped to, say, customer-read only cannot list
+        # connected accounts. That must not abort the sync of its own account.
+        with (
+            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch(
+                "djstripe.models.Account.api_list",
+                side_effect=StripePermissionError("not permitted"),
+            ),
+        ):
+            accounts = Command.get_stripe_account(api_key=self.RK_TEST)
+
+        assert accounts == {""}
+        retrieve_mock.assert_not_called()
+
+    def test_sync_with_restricted_key_actually_syncs(self):
+        # Regression: skipping the platform retrieve must not leave the account
+        # set empty, which would build no list kwargs and silently sync nothing
+        # while still exiting successfully.
         stderr = StringIO()
 
         with (
             patch("stripe.Account.retrieve") as retrieve_mock,
+            patch(
+                "djstripe.models.Customer.api_list", return_value=StripeList(data=[])
+            ) as api_list_mock,
             patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
         ):
             call_command(
                 "djstripe_sync_models",
-                "Account",
+                "Customer",
                 api_keys=[self.RK_TEST],
                 stderr=stderr,
             )
 
+        assert api_list_mock.called, "restricted-key sync did no work at all"
+        assert api_list_mock.call_args.kwargs["stripe_account"] == ""
         retrieve_mock.assert_not_called()
         assert stderr.getvalue() == ""
 


### PR DESCRIPTION
# Fix `djstripe_sync_models` with restricted API keys

Fixes #1908.

Syncing with a restricted (`rk_`) key fails, and it fails in **two different ways**
depending on where the key comes from. Both originate in
`Account.get_default_account()`.

### 1. Key passed via `--api-keys`

`get_default_account()` guards against restricted keys — but it tests
`djstripe_settings.STRIPE_SECRET_KEY` rather than the `api_key` argument it was
handed:

```python
def get_default_account(cls, api_key=djstripe_settings.STRIPE_SECRET_KEY):
    if djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_"):
        return None
```

So `djstripe_sync_models --api-keys rk_...` with an `sk_` key in settings skips the
guard entirely and goes on to call `GET /v1/account`, which restricted keys cannot do.

The guard has been this way since it was introduced — `docs/changes/2_4_0.md` records
it as *"Fixed `Account.get_default_account()` for Restricted API Keys"*.

The default argument is also evaluated at import time, so it does not follow
`override_settings` or late configuration. That is the same trap already commented
around in `sync_from_stripe_data`.

### 2. Key configured in settings

When the restricted key *is* the configured key, the guard fires correctly and returns
`None` — and then `sync_model()` dereferences it:

```python
== models.Account.get_default_account(api_key=api_key).id
```

This is the `'NoneType' object has no attribute 'id'` from the issue report.

`get_stripe_account()` had the same unguarded platform-account retrieve.

## Changes

- `models/api.py` — added `is_restricted_key()` rather than repeating
  `startswith("rk_")` at three call sites.
- `models/account.py` — `get_default_account()` tests the `api_key` argument, and
  resolves the default in the body instead of in the signature.
- `djstripe_sync_models.py` — guarded the default-account dereference, and resolved it
  once instead of on every iteration of the loop.
- `djstripe_sync_models.py` — `get_stripe_account()` skips the platform retrieve for
  restricted keys. Connected accounts are still enumerated.

## Tests

Four regression tests in `tests/test_sync.py::TestSyncModelsRestrictedKeys`, covering
both failure modes. Each was verified to fail with the fix reverted — the
settings-based one reproduces the original error verbatim:

```
Failed syncing Account for sk_live_...XXXX:
AttributeError("'NoneType' object has no attribute 'id'")
```

Full suite passes (556), `ruff` and `mypy` clean via pre-commit, no migrations needed.

## One question for a maintainer

The comment says *"As of API version 2020-03-02, there is no permission that can allow
restricted keys to call `GET /v1/account`."* That may no longer hold — in the #1908
thread the reporter posts a **successful** `/v1/account` response from a restricted key,
returning *more* fields than the secret key did.

If restricted keys can now read the platform account given the right permission, the
better fix would be to attempt the call and catch `PermissionError`, rather than
refusing on the key prefix. I have deliberately not changed that behaviour here — this
PR only stops the crashes. Happy to follow up if you would like the prefix guard
replaced.

## Summary by Sourcery

Prevent crashes when running djstripe_sync_models with restricted Stripe API keys and align account retrieval behavior with key capabilities.

Bug Fixes:
- Ensure Account.get_default_account respects the api_key argument and returns None for restricted keys instead of attempting unsupported account retrieval.
- Avoid dereferencing the default account when it is None during Account syncing, preventing 'NoneType has no attribute id' errors.
- Skip platform account retrieval in get_stripe_account for restricted (rk_) keys while still enumerating connected accounts.

Enhancements:
- Introduce a shared is_restricted_key helper for consistent detection of restricted Stripe keys across the codebase.
- Resolve the default API key for Account.get_default_account at call time rather than import time to respect runtime configuration and overrides.

Tests:
- Add regression tests covering djstripe_sync_models behavior with restricted keys from both CLI-provided and settings-configured sources, including get_default_account and get_stripe_account paths.