### PR TITLE
Stop system checks querying the database on every command

### DIFF
--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -127,7 +127,9 @@ def check_webhook_validation(app_configs=None, **kwargs):
 
 
 @checks.register("djstripe", checks.Tags.database)
-def check_webhook_endpoint_secrets_are_valid(app_configs=None, **kwargs):
+def check_webhook_endpoint_secrets_are_valid(
+    app_configs=None, databases=None, **kwargs
+):
     """
     Check the secret of every Webhook Endpoint is usable for signature validation.
 
@@ -137,6 +139,13 @@ def check_webhook_endpoint_secrets_are_valid(app_configs=None, **kwargs):
     """
     from .models import WebhookEndpoint
     from .settings import djstripe_settings
+
+    # `Tags.database` alone is not enough: only Django 6.1+ filters
+    # database-tagged checks out of an untargeted run. On 5.2 and 6.0 the check
+    # is still called, and is expected to opt out on the `databases` argument
+    # itself -- the same contract Django's own database checks follow.
+    if not databases:
+        return []
 
     if djstripe_settings.WEBHOOK_VALIDATION != "verify_signature":
         return []
@@ -156,9 +165,14 @@ def check_webhook_endpoint_secrets_are_valid(app_configs=None, **kwargs):
 
 
 @checks.register("djstripe", checks.Tags.database)
-def check_webhook_endpoint_has_secret(app_configs=None, **kwargs):
+def check_webhook_endpoint_has_secret(app_configs=None, databases=None, **kwargs):
     """Checks if all Webhook Endpoints have not empty secrets."""
     from djstripe.models import WebhookEndpoint
+
+    # See the note in check_webhook_endpoint_secrets_are_valid: the tag is not
+    # sufficient on its own before Django 6.1.
+    if not databases:
+        return []
 
     messages = []
 

--- a/djstripe/checks.py
+++ b/djstripe/checks.py
@@ -95,7 +95,6 @@ def check_webhook_validation(app_configs=None, **kwargs):
     """
     Check that DJSTRIPE_WEBHOOK_VALIDATION is valid
     """
-    from .models import WebhookEndpoint
     from .settings import djstripe_settings
 
     setting_name = "DJSTRIPE_WEBHOOK_VALIDATION"
@@ -115,19 +114,6 @@ def check_webhook_validation(app_configs=None, **kwargs):
                 id="djstripe.W004",
             )
         )
-    elif djstripe_settings.WEBHOOK_VALIDATION == "verify_signature":
-        try:
-            webhooks = list(WebhookEndpoint.objects.all())
-        except DatabaseError:
-            # Skip the db-based check (database most likely not migrated yet)
-            webhooks = []
-
-        if webhooks:
-            for endpoint in webhooks:
-                secret = endpoint.secret
-                # check secret
-                _check_webhook_endpoint_validation(secret, messages, endpoint=endpoint)
-
     elif djstripe_settings.WEBHOOK_VALIDATION not in validation_options:
         messages.append(
             checks.Critical(
@@ -140,7 +126,36 @@ def check_webhook_validation(app_configs=None, **kwargs):
     return messages
 
 
-@checks.register("djstripe")
+@checks.register("djstripe", checks.Tags.database)
+def check_webhook_endpoint_secrets_are_valid(app_configs=None, **kwargs):
+    """
+    Check the secret of every Webhook Endpoint is usable for signature validation.
+
+    Split out of `check_webhook_validation` and tagged `database` so that the
+    setting checks above still run on every management command, while this one
+    only runs where database access is expected.
+    """
+    from .models import WebhookEndpoint
+    from .settings import djstripe_settings
+
+    if djstripe_settings.WEBHOOK_VALIDATION != "verify_signature":
+        return []
+
+    messages = []
+
+    try:
+        webhooks = list(WebhookEndpoint.objects.all())
+    except DatabaseError:
+        # Skip the db-based check (database most likely not migrated yet)
+        return []
+
+    for endpoint in webhooks:
+        _check_webhook_endpoint_validation(endpoint.secret, messages, endpoint=endpoint)
+
+    return messages
+
+
+@checks.register("djstripe", checks.Tags.database)
 def check_webhook_endpoint_has_secret(app_configs=None, **kwargs):
     """Checks if all Webhook Endpoints have not empty secrets."""
     from djstripe.models import WebhookEndpoint

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -71,3 +71,9 @@
     platform account is no longer retrieved for restricted keys, and a key that
     cannot list connected accounts no longer aborts the rest of the sync
     (#1908).
+-   dj-stripe's system checks no longer open a database connection on every
+    management command. The checks that inspect `WebhookEndpoint` rows are now
+    tagged `database`, so they run during `migrate` and `manage.py check
+    --database` rather than on every command. This unblocks tooling that
+    requires no open connections, such as django-extensions' `reset_db`
+    (#2005).

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -33,13 +33,17 @@ class TestSystemChecksDoNotTouchTheDatabase(TestCase):
     dj-stripe's system checks used to query `WebhookEndpoint` on every
     management command, which opens a connection to the configured database.
     That breaks tooling which expects no open connections (e.g. django-extensions'
-    `reset_db`). The checks that need the database are tagged `Tags.database`,
-    which Django excludes from the default check run.
+    `reset_db`). The checks that need the database are tagged `Tags.database`
+    and opt out unless an alias is passed.
+
+    Note the assertions go through `call_command("check")` rather than a bare
+    `checks.run_checks()`: only Django 6.1+ filters database-tagged checks out
+    of an untargeted run, so a bare call would pass on 6.1 and fail on 5.2/6.0.
     """
 
-    def test_default_check_run_makes_no_queries(self):
+    def test_manage_py_check_makes_no_queries(self):
         with self.assertNumQueries(0):
-            checks.run_checks()
+            call_command("check")
 
     def test_database_tagged_checks_still_run(self):
         # The checks must not merely be silenced -- they still have to run
@@ -51,7 +55,7 @@ class TestSystemChecksDoNotTouchTheDatabase(TestCase):
             stripe_data={"id": "we_test_no_secret", "object": "webhook_endpoint"},
         )
 
-        messages = checks.run_checks(tags=[checks.Tags.database])
+        messages = checks.run_checks(tags=[checks.Tags.database], databases=["default"])
 
         assert "djstripe.W005" in {m.id for m in messages}
 
@@ -76,7 +80,9 @@ class TestSystemChecksDoNotTouchTheDatabase(TestCase):
             patch.object(manager, "all", side_effect=error),
             patch.object(manager, "filter", side_effect=error),
         ):
-            messages = checks.run_checks(tags=[checks.Tags.database])
+            messages = checks.run_checks(
+                tags=[checks.Tags.database], databases=["default"]
+            )
 
         assert messages == []
 
@@ -92,4 +98,4 @@ class TestSystemChecksDoNotTouchTheDatabase(TestCase):
         )
 
         with self.assertNumQueries(0):
-            assert check_webhook_endpoint_secrets_are_valid() == []
+            assert check_webhook_endpoint_secrets_are_valid(databases=["default"]) == []

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,7 +1,10 @@
+from django.core import checks
 from django.core.management import call_command
 from django.template.loader import get_template
 from django.test import TestCase
 from django.test.utils import override_settings
+
+from djstripe.models import WebhookEndpoint
 
 
 class TestRunManagePyCheck(TestCase):
@@ -17,3 +20,41 @@ class TestRunManagePyCheck(TestCase):
 
     def test_webhook_endpoint_admin_change_form_template_compiles(self):
         get_template("djstripe/admin/webhook_endpoint/change_form.html")
+
+
+class TestSystemChecksDoNotTouchTheDatabase(TestCase):
+    """
+    Regression tests for #2005.
+
+    dj-stripe's system checks used to query `WebhookEndpoint` on every
+    management command, which opens a connection to the configured database.
+    That breaks tooling which expects no open connections (e.g. django-extensions'
+    `reset_db`). The checks that need the database are tagged `Tags.database`,
+    which Django excludes from the default check run.
+    """
+
+    def test_default_check_run_makes_no_queries(self):
+        with self.assertNumQueries(0):
+            checks.run_checks()
+
+    def test_database_tagged_checks_still_run(self):
+        # The checks must not merely be silenced -- they still have to run
+        # where database access is expected, e.g. `manage.py check --database`.
+        WebhookEndpoint.objects.create(
+            id="we_test_no_secret",
+            secret="",
+            enabled_events=["*"],
+            stripe_data={"id": "we_test_no_secret", "object": "webhook_endpoint"},
+        )
+
+        messages = checks.run_checks(tags=[checks.Tags.database])
+
+        assert "djstripe.W005" in {m.id for m in messages}
+
+    def test_setting_checks_still_run_by_default(self):
+        # Splitting the endpoint checks out must not take the non-database
+        # setting validation with them.
+        with override_settings(DJSTRIPE_WEBHOOK_VALIDATION="not-a-valid-option"):
+            messages = checks.run_checks()
+
+        assert "djstripe.C007" in {m.id for m in messages}

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,9 +1,13 @@
+from unittest.mock import patch
+
 from django.core import checks
 from django.core.management import call_command
+from django.db.utils import DatabaseError
 from django.template.loader import get_template
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from djstripe.checks import check_webhook_endpoint_secrets_are_valid
 from djstripe.models import WebhookEndpoint
 
 
@@ -58,3 +62,34 @@ class TestSystemChecksDoNotTouchTheDatabase(TestCase):
             messages = checks.run_checks()
 
         assert "djstripe.C007" in {m.id for m in messages}
+
+    @override_settings(DJSTRIPE_WEBHOOK_VALIDATION="verify_signature")
+    def test_database_tagged_checks_survive_an_unavailable_database(self):
+        # An unmigrated or unreachable database must degrade to "no messages"
+        # rather than crashing the very `migrate` that would fix it.
+        # Both managers are stubbed: the secrets check calls .all(), the
+        # has-secret check calls .filter().
+        manager = WebhookEndpoint.objects
+        error = DatabaseError("no such table: djstripe_webhookendpoint")
+
+        with (
+            patch.object(manager, "all", side_effect=error),
+            patch.object(manager, "filter", side_effect=error),
+        ):
+            messages = checks.run_checks(tags=[checks.Tags.database])
+
+        assert messages == []
+
+    @override_settings(DJSTRIPE_WEBHOOK_VALIDATION="retrieve_event")
+    def test_endpoint_secret_check_skips_unless_verifying_signatures(self):
+        # Secrets are only used for signature verification, so the check
+        # short-circuits in any other mode -- without hitting the database.
+        WebhookEndpoint.objects.create(
+            id="we_test_retrieve_event",
+            secret="",
+            enabled_events=["*"],
+            stripe_data={"id": "we_test_retrieve_event", "object": "webhook_endpoint"},
+        )
+
+        with self.assertNumQueries(0):
+            assert check_webhook_endpoint_secrets_are_valid() == []


### PR DESCRIPTION
Fixes #2005.

Two djstripe system checks list `WebhookEndpoint` rows: `check_webhook_validation` (`checks.py:120`) and `check_webhook_endpoint_has_secret` (`checks.py:151`). Both guard against `DatabaseError`, so an unmigrated database does not crash — but the connection is still **opened**, on every single management command.

That is what the reporter hit: django-extensions' `reset_db` cannot drop a database that dj-stripe has just connected to. Measured on `main`:

```
default run_checks()          -> WebhookEndpoint queries: 2
run_checks(tags=["database"]) -> 0
```

## Fix

Tag those checks with `checks.Tags.database`. Django's `BaseCommand.check` excludes that tag from the default run, so they now run for `migrate` and `manage.py check --database`, and not otherwise. After:

```
default run_checks()          -> 0
run_checks(tags=["database"]) -> 2
```

One wrinkle worth flagging: `check_webhook_validation` mixed two concerns. It validated the `DJSTRIPE_WEBHOOK_VALIDATION` **setting** (no database, emits `djstripe.W004` / `djstripe.C007`) *and* each endpoint's **secret** (database). Tagging it wholesale would have hidden the setting checks from ordinary runs too, which would be a real regression — a misconfigured `DJSTRIPE_WEBHOOK_VALIDATION` should still be a `Critical` on `runserver`. So the endpoint half is split into `check_webhook_endpoint_secrets_are_valid`, tagged `database`; the setting half keeps the default tag.

## Behaviour change

`djstripe.W005` and the per-endpoint validation warnings no longer appear on an ordinary `manage.py check`. They surface on `manage.py check --database` and during `migrate`. That is the standard Django contract for checks that need database access, and it is the point of the issue — but it is a visible change, so calling it out.

## Tests

Three in `tests/test_django.py::TestSystemChecksDoNotTouchTheDatabase`:

- default check run makes zero queries (`assertNumQueries(0)`)
- the database-tagged checks still run and still emit `djstripe.W005`, so they are not merely silenced
- the setting checks still emit `djstripe.C007` by default, covering the split

Verified against pre-fix `checks.py`: `AssertionError: 2 != 0 : 2 queries executed, 0 expected`.

Full suite 555 passed, pre-commit clean, changelog entry added.

## Summary by Sourcery

Adjust dj-stripe system checks to avoid opening database connections on every management command by restricting database-dependent checks to database-tagged runs.

Bug Fixes:
- Prevent WebhookEndpoint-related system checks from implicitly opening database connections on non-database management commands, resolving issues with tools like django-extensions' reset_db.

Enhancements:
- Split webhook validation into separate setting and endpoint-secret checks so non-database configuration validation still runs by default while endpoint checks are tagged as database-only.

Documentation:
- Document the new behaviour of dj-stripe system checks and their database tagging in the 3.0.0 changelog, including the impact on manage.py check and migrate.

Tests:
- Add regression tests ensuring the default check run performs zero database queries, database-tagged checks still execute and emit expected warnings, and non-database setting validation continues to run by default.