### PR TITLE
Ask Stripe whether a key can read the platform account

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -42,11 +42,7 @@ from stripe import PermissionError as StripePermissionError
 from ... import enums, models
 from ...enums import APIKeyType
 from ...exceptions import InvalidStripeAPIKey
-from ...models.api import (
-    get_api_key_details_by_prefix,
-    is_restricted_key,
-    redact_api_key,
-)
+from ...models.api import get_api_key_details_by_prefix, redact_api_key
 from ...models.base import StripeBaseModel
 from ...settings import djstripe_settings
 
@@ -319,23 +315,42 @@ class Command(BaseCommand):
 
         return object_errors == 0
 
+    def get_stripe_account_cached(self, api_key: str, *args, **kwargs):
+        """
+        `get_stripe_account` memoised for the lifetime of one command run.
+
+        `get_list_kwargs` calls this once per model, so a full sync asked Stripe
+        for the same account list around 45 times. That was merely wasteful when
+        the platform account was skipped on the key prefix; now that we ask and
+        let Stripe answer, an unpermitted key would pay 45 rejected round-trips.
+        """
+        if not hasattr(self, "_stripe_account_cache"):
+            self._stripe_account_cache: dict[str, set[str]] = {}
+
+        if api_key not in self._stripe_account_cache:
+            self._stripe_account_cache[api_key] = self.get_stripe_account(
+                api_key, *args, **kwargs
+            )
+
+        return self._stripe_account_cache[api_key]
+
     @classmethod
     def get_stripe_account(cls, api_key: str, *args, **kwargs):
         """Get set of all stripe account ids including the Platform Acccount"""
         accs_set = set()
 
         # special case, since own account isn't returned by Account.api_list
-        if not is_restricted_key(api_key):
+        try:
             stripe_platform_obj = models.Account.stripe_class.retrieve(
                 api_key=api_key,
                 stripe_version=djstripe_settings.STRIPE_API_VERSION,
             )
             accs_set.add(stripe_platform_obj.id)
-        else:
-            # We can't learn the platform account id from a restricted key, but
-            # an empty stripe_account omits the Stripe-Account header, so the
-            # request still targets the key's own account. Without this the set
-            # would be empty and nothing would be synced at all.
+        except StripePermissionError:
+            # This key may not read the platform account, so we cannot learn its
+            # id. An empty stripe_account omits the Stripe-Account header, so
+            # requests still target the key's own account. Without this entry
+            # the set would be empty and nothing would be synced at all.
             accs_set.add("")
 
         try:
@@ -595,7 +610,7 @@ class Command(BaseCommand):
         # get all Stripe Accounts for the given platform account.
         # note that we need to fetch from Stripe as we have no way of knowing that the ones in the local db are up to date
         # as this can also be the first time the user runs sync.
-        accs_set = self.get_stripe_account(api_key=api_key)
+        accs_set = self.get_stripe_account_cached(api_key=api_key)
 
         default_list_kwargs = self.get_default_list_kwargs(
             model, accs_set, api_key=api_key

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -6,7 +6,7 @@ from stripe import AuthenticationError, InvalidRequestError, PermissionError
 
 from ..enums import APIKeyType
 from ..settings import djstripe_settings
-from .api import APIKey, get_api_key_details_by_prefix, is_restricted_key
+from .api import APIKey, get_api_key_details_by_prefix
 from .base import StripeModel, logger
 
 
@@ -159,17 +159,17 @@ class Account(StripeModel):
         if api_key is None:
             api_key = djstripe_settings.STRIPE_SECRET_KEY
 
-        # dj-stripe does not attempt GET /v1/account with restricted keys: as of
-        # API version 2020-03-02 no permission was available that allowed it.
-        # NOTE: test the key we were passed, not the one in settings: callers
-        # such as `djstripe_sync_models --api-keys rk_...` pass a key that is
-        # not the configured default.
-        if is_restricted_key(api_key):
+        # Ask, rather than guess from the key prefix. Restricted keys were once
+        # categorically unable to call GET /v1/account, but that is no longer
+        # true: a restricted key granted the permission can read it, and a
+        # prefix check would deny those unnecessarily. A key without the
+        # permission answers with PermissionError, which is the real signal.
+        try:
+            account_data = cls.stripe_class.retrieve(
+                api_key=api_key, stripe_version=djstripe_settings.STRIPE_API_VERSION
+            )
+        except PermissionError:
             return None
-
-        account_data = cls.stripe_class.retrieve(
-            api_key=api_key, stripe_version=djstripe_settings.STRIPE_API_VERSION
-        )
 
         return cls._get_or_create_from_stripe_object(account_data, api_key=api_key)[0]
 

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -2,7 +2,8 @@ import datetime
 
 import stripe
 from django.db import transaction
-from stripe import AuthenticationError, InvalidRequestError, PermissionError
+from stripe import AuthenticationError, InvalidRequestError
+from stripe import PermissionError as StripePermissionError
 
 from ..enums import APIKeyType
 from ..settings import djstripe_settings
@@ -168,7 +169,7 @@ class Account(StripeModel):
             account_data = cls.stripe_class.retrieve(
                 api_key=api_key, stripe_version=djstripe_settings.STRIPE_API_VERSION
             )
-        except PermissionError:
+        except StripePermissionError:
             return None
 
         return cls._get_or_create_from_stripe_object(account_data, api_key=api_key)[0]
@@ -311,7 +312,7 @@ class Account(StripeModel):
                         file_data,
                         api_key=api_key,
                     )
-                except PermissionError:
+                except StripePermissionError:
                     # No permission to retrieve the data with the key
                     logger.warning(
                         f"Cannot retrieve business branding {field} for acct"

--- a/djstripe/models/api.py
+++ b/djstripe/models/api.py
@@ -34,21 +34,6 @@ def redact_api_key(api_key: str) -> str:
     return f"{secret_prefix}_...{secret_part[-4:]}"
 
 
-def is_restricted_key(api_key: str) -> bool:
-    """
-    Return whether the given key is a restricted key (``rk_...``).
-
-    Restricted keys are limited to the permissions granted to them in the
-    Stripe dashboard, so calls that dj-stripe makes unconditionally for
-    secret keys may not be available to them.
-
-    NOTE: this deliberately does not go through `get_api_key_details_by_prefix`,
-    which validates the whole key and raises on anything malformed. Callers here
-    only want to know how to treat a key, not to reject it.
-    """
-    return api_key.startswith("rk_")
-
-
 def get_api_key_details_by_prefix(api_key: str):
     if not api_key:
         raise InvalidStripeAPIKey(

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -71,3 +71,8 @@
     platform account is no longer retrieved for restricted keys, and a key that
     cannot list connected accounts no longer aborts the rest of the sync
     (#1908).
+-   Whether a key can read the platform account is now decided by Stripe's
+    response rather than by the `rk_` prefix, so a restricted key granted that
+    permission is no longer refused. `djstripe_sync_models` also resolves the
+    account set once per key instead of once per model, cutting a full sync from
+    46 `GET /v1/account` calls to 2.

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -458,6 +458,27 @@ class TestAccountRestrictedKeys(TestCase):
         assert account is None
         account_retrieve_mock.assert_called_once()
 
+    @override_settings(
+        STRIPE_TEST_SECRET_KEY="rk_test_" + "b" * 24,
+        STRIPE_TEST_PUBLIC_KEY="pk_test_foo",
+        STRIPE_LIVE_MODE=False,
+    )
+    @patch("stripe.Account.retrieve", autospec=True)
+    def test_account_restricted_key_with_permission_returns_the_account(
+        self, account_retrieve_mock
+    ):
+        """
+        A restricted key that *may* read the platform account gets it.
+
+        This is the case the old `rk_` prefix guard refused outright.
+        """
+        account_retrieve_mock.return_value = deepcopy(FAKE_ACCOUNT)
+
+        account = Account.get_default_account()
+
+        assert account is not None
+        assert account.id == FAKE_ACCOUNT["id"]
+
 
 @pytest.mark.parametrize(
     "mock_account_id, other_mock_account_id, expected_stripe_account",

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -445,14 +445,18 @@ class TestAccountRestrictedKeys(TestCase):
     @patch("stripe.Account.retrieve", autospec=True)
     def test_account_str_restricted_key(self, account_retrieve_mock):
         """
-        Test that we do not attempt to retrieve account ID with restricted keys.
+        A key that may not read the platform account resolves to None.
+
+        The decision comes from Stripe's response, not from the key prefix: a
+        restricted key granted the permission is expected to work.
         """
         assert djstripe_settings.STRIPE_SECRET_KEY == "rk_test_blah"
+        account_retrieve_mock.side_effect = stripe.PermissionError("not permitted")
 
         account = Account.get_default_account()
 
         assert account is None
-        account_retrieve_mock.assert_not_called()
+        account_retrieve_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -196,17 +196,6 @@ class TestSyncModelsRestrictedKeys(TestCase):
         # The call is attempted: Stripe decides, the key prefix does not.
         retrieve_mock.assert_called_once()
 
-    def test_get_default_account_is_returned_when_a_restricted_key_may_read_it(self):
-        # A restricted key granted the permission must not be denied on its
-        # prefix -- this is what the old guard got wrong.
-        account_data = StripeItem(id="acct_permitted", object="account", livemode=False)
-
-        with patch("stripe.Account.retrieve", return_value=account_data):
-            account = Account.get_default_account(api_key=self.RK_TEST)
-
-        assert account is not None
-        assert account.id == "acct_permitted"
-
     def test_get_stripe_account_falls_back_when_the_platform_account_is_denied(self):
         # Losing the platform account id must not cost us the connected ones,
         # and the key's own account must still be represented -- by the empty
@@ -283,6 +272,23 @@ class TestSyncModelsRestrictedKeys(TestCase):
                 assert command.get_stripe_account_cached(self.RK_TEST) is sentinel
 
         get_mock.assert_called_once()
+
+    def test_the_account_cache_is_keyed_by_api_key(self):
+        # A cache shared across keys would hand one key another key's accounts.
+        command = Command()
+        other_key = "rk_test_" + "f" * 24
+
+        with patch.object(
+            Command, "get_stripe_account", side_effect=[{"acct_a"}, {"acct_b"}]
+        ) as get_mock:
+            first = command.get_stripe_account_cached(self.RK_TEST)
+            second = command.get_stripe_account_cached(other_key)
+            # ...and repeats still come from the cache.
+            assert command.get_stripe_account_cached(self.RK_TEST) == first
+
+        assert first == {"acct_a"}
+        assert second == {"acct_b"}
+        assert get_mock.call_count == 2
 
     @override_settings(
         STRIPE_TEST_SECRET_KEY="rk_test_" + "e" * 24, STRIPE_LIVE_SECRET_KEY=""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -176,7 +176,7 @@ class TestSyncModelsGetApiKeys(TestCase):
 
 class TestSyncModelsRestrictedKeys(TestCase):
     """
-    dj-stripe does not attempt `GET /v1/account` with restricted keys.
+    Restricted keys are handled by asking Stripe, not by sniffing the prefix.
 
     Regression tests for #1908: syncing with `--api-keys rk_...` crashed with
     `'NoneType' object has no attribute 'id'`, because the restricted-key guard
@@ -186,18 +186,29 @@ class TestSyncModelsRestrictedKeys(TestCase):
 
     RK_TEST = "rk_test_" + "d" * 24
 
-    def test_get_default_account_returns_none_for_passed_restricted_key(self):
-        # Settings hold an `sk_` key, but the caller passes an `rk_` one. The
-        # guard must follow the argument, not the setting.
-        assert not djstripe_settings.STRIPE_SECRET_KEY.startswith("rk_")
-
-        with patch("stripe.Account.retrieve") as retrieve_mock:
+    def test_get_default_account_is_none_when_the_account_is_not_permitted(self):
+        with patch(
+            "stripe.Account.retrieve",
+            side_effect=StripePermissionError("not permitted"),
+        ) as retrieve_mock:
             assert Account.get_default_account(api_key=self.RK_TEST) is None
 
-        retrieve_mock.assert_not_called()
+        # The call is attempted: Stripe decides, the key prefix does not.
+        retrieve_mock.assert_called_once()
 
-    def test_get_stripe_account_skips_platform_retrieve_for_restricted_key(self):
-        # Skipping the platform account must not cost us the connected ones,
+    def test_get_default_account_is_returned_when_a_restricted_key_may_read_it(self):
+        # A restricted key granted the permission must not be denied on its
+        # prefix -- this is what the old guard got wrong.
+        account_data = StripeItem(id="acct_permitted", object="account", livemode=False)
+
+        with patch("stripe.Account.retrieve", return_value=account_data):
+            account = Account.get_default_account(api_key=self.RK_TEST)
+
+        assert account is not None
+        assert account.id == "acct_permitted"
+
+    def test_get_stripe_account_falls_back_when_the_platform_account_is_denied(self):
+        # Losing the platform account id must not cost us the connected ones,
         # and the key's own account must still be represented -- by the empty
         # string, which omits the Stripe-Account header on the resulting calls.
         connected = StripeList(
@@ -205,19 +216,24 @@ class TestSyncModelsRestrictedKeys(TestCase):
         )
 
         with (
-            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch(
+                "stripe.Account.retrieve",
+                side_effect=StripePermissionError("not permitted"),
+            ),
             patch("djstripe.models.Account.api_list", return_value=connected),
         ):
             accounts = Command.get_stripe_account(api_key=self.RK_TEST)
 
         assert accounts == {"", "acct_one", "acct_two"}
-        retrieve_mock.assert_not_called()
 
     def test_get_stripe_account_survives_unlistable_connected_accounts(self):
         # A restricted key scoped to, say, customer-read only cannot list
         # connected accounts. That must not abort the sync of its own account.
         with (
-            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch(
+                "stripe.Account.retrieve",
+                side_effect=StripePermissionError("not permitted"),
+            ),
             patch(
                 "djstripe.models.Account.api_list",
                 side_effect=StripePermissionError("not permitted"),
@@ -226,16 +242,18 @@ class TestSyncModelsRestrictedKeys(TestCase):
             accounts = Command.get_stripe_account(api_key=self.RK_TEST)
 
         assert accounts == {""}
-        retrieve_mock.assert_not_called()
 
     def test_sync_with_restricted_key_actually_syncs(self):
-        # Regression: skipping the platform retrieve must not leave the account
+        # Regression: losing the platform retrieve must not leave the account
         # set empty, which would build no list kwargs and silently sync nothing
         # while still exiting successfully.
         stderr = StringIO()
 
         with (
-            patch("stripe.Account.retrieve") as retrieve_mock,
+            patch(
+                "stripe.Account.retrieve",
+                side_effect=StripePermissionError("not permitted"),
+            ),
             patch(
                 "djstripe.models.Customer.api_list", return_value=StripeList(data=[])
             ) as api_list_mock,
@@ -250,22 +268,38 @@ class TestSyncModelsRestrictedKeys(TestCase):
 
         assert api_list_mock.called, "restricted-key sync did no work at all"
         assert api_list_mock.call_args.kwargs["stripe_account"] == ""
-        retrieve_mock.assert_not_called()
         assert stderr.getvalue() == ""
+
+    def test_the_account_set_is_resolved_once_per_key(self):
+        # get_list_kwargs asks per model, so without memoisation a full sync
+        # pays one rejected round-trip per model rather than one per key.
+        command = Command()
+        sentinel = {""}
+
+        with patch.object(
+            Command, "get_stripe_account", return_value=sentinel
+        ) as get_mock:
+            for _ in range(5):
+                assert command.get_stripe_account_cached(self.RK_TEST) is sentinel
+
+        get_mock.assert_called_once()
 
     @override_settings(
         STRIPE_TEST_SECRET_KEY="rk_test_" + "e" * 24, STRIPE_LIVE_SECRET_KEY=""
     )
     def test_sync_account_does_not_dereference_missing_default_account(self):
         # The originally reported failure: with a restricted key configured,
-        # `get_default_account()` correctly returns None and the command then
-        # blew up dereferencing `.id` on it. `get_stripe_account` is stubbed so
-        # the run reaches that line instead of failing earlier on the
-        # platform-account retrieve.
+        # `get_default_account()` returns None and the command then blew up
+        # dereferencing `.id` on it. `get_stripe_account` is stubbed so the run
+        # reaches that line instead of failing earlier on the platform retrieve.
         stderr = StringIO()
 
         with (
             patch.object(Command, "get_stripe_account", return_value={"acct_test"}),
+            patch(
+                "stripe.Account.retrieve",
+                side_effect=StripePermissionError("not permitted"),
+            ),
             patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
         ):
             call_command("djstripe_sync_models", "Account", stderr=stderr)


### PR DESCRIPTION
Follow-up to #2234, which you asked for there: replace the `rk_` prefix guard with attempting the call and catching `PermissionError`.

## The stale claim

`Account.get_default_account()` refused to call `GET /v1/account` for any `rk_` key, on the basis that "as of API version 2020-03-02, there is no permission that can allow restricted keys to call GET /v1/account". That is no longer true — the #1908 thread itself contains a **successful** `/v1/account` response from a restricted key, returning more fields than the secret key did. So the guard denied keys that would have worked.

Both sites now attempt the call and treat `PermissionError` as the answer: `get_default_account()` returns `None`, and the sync command falls back to the `""` account entry. `is_restricted_key()` has no callers left and is removed.

## The cost this would have added, and the fix for it

`get_list_kwargs()` resolves the account set once per model, so a full sync already made one `GET /v1/account` per model. Measured on `main`:

```
get_stripe_account calls: 45
GET /v1/account:          46
```

Merely wasteful while the prefix short-circuited them for restricted keys — but asking Stripe instead would have turned that into ~45 *rejected* round-trips for an unpermitted key. So the command now memoises the account set per key for the run:

```
full sync, restricted key: 2 GET /v1/account   (was 45 rejected)
full sync, secret key:     2 GET /v1/account   (was 46)
```

That is a straight improvement for secret keys too. If you would rather have the memoisation as its own PR, it is a self-contained commit and I am happy to split it — but I did not want to land the `PermissionError` change while it made restricted-key syncs measurably worse.

## Test changes

`test_account_str_restricted_key` asserted the old contract — "Test that we do not attempt to retrieve account ID with restricted keys", `assert_not_called()`. It now asserts the call *is* made and that the denial is what produces `None`. Flagging it because it is a deliberate inversion of an existing assertion, not an incidental edit.

New coverage: a restricted key that *may* read the platform account now gets it (the case the old guard broke), the denied-and-fall-back path, and one asserting the account set is resolved once per key rather than once per model.

## Verified

`tox -e django52-py312-sqlite` and `django60-py312-sqlite`: 560 passed each. I ran the matrix rather than just my local interpreter this time, having been caught by a Django-version difference on #2236.

## Summary by Sourcery

Determine platform account accessibility by invoking Stripe and handling permission errors, and optimize sync account resolution per API key.

Bug Fixes:
- Allow restricted API keys with platform-account read permission to retrieve the default account instead of being rejected by prefix checks.
- Ensure sync commands gracefully handle denied platform-account access by falling back to an empty stripe_account entry without aborting work.
- Prevent crashes when the default account is None by consistently treating permission-denied platform-account lookups as an absent account.

Enhancements:
- Memoize Stripe account set resolution per API key during sync runs, reducing repeated GET /v1/account calls from once per model to once per key.
- Remove prefix-based restricted key detection in favor of relying on Stripe responses to determine permissions.

Documentation:
- Document the new behavior for platform-account access decisions and the reduced number of GET /v1/account calls in the 3.0.0 changelog.

Tests:
- Update restricted-key tests to expect platform-account access decisions based on Stripe PermissionError responses rather than rk_ prefix checks.
- Add coverage for restricted keys that can read the platform account, denial-and-fallback handling in sync, and memoized account set resolution.