### PR TITLE
Refuse webhook verification without a signature header

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -322,6 +322,9 @@ class WebhookEventTrigger(models.Model):
 
         # HTTP headers are case-insensitive, but we store them as a dict.
         signature = CaseInsensitiveMapping(self.headers).get("stripe-signature")
+        if not signature:
+            logger.error("Missing stripe-signature header")
+            return False
 
         try:
             stripe.WebhookSignature.verify_header(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -236,6 +236,17 @@ class TestWebhookEventTrigger(CreateAccountMixin, TestCase):
         self.assertFalse(Event.objects.filter(id="evt_invalid").exists())
         event_retrieve_mock.assert_not_called()
 
+    def test_verify_signature_without_a_signature_header(self):
+        # A request with no Stripe-Signature header cannot be verified. Stripe's
+        # verify_header is typed to require the header, so we refuse before
+        # calling it rather than handing it None.
+        trigger = WebhookEventTrigger(headers={}, body="{}")
+
+        with patch("stripe.WebhookSignature.verify_header") as verify_header_mock:
+            assert trigger.verify_signature("whsec_XXXXX", tolerance=300) is False
+
+        verify_header_mock.assert_not_called()
+
     @staticmethod
     def _stripe_signature_header(payload: str, secret: str, timestamp: int) -> str:
         """Compute a real Stripe-Signature header for the given payload.


### PR DESCRIPTION
CI `linting` is currently failing on every pull request, including test-only ones. This unblocks it.

## Cause

`stripe` 15.5.0 — inside the existing `>=15.0.1,<16` range, so it arrived without a lockfile change — types `WebhookSignature.verify_header`'s `header` argument as `str`:

```
(payload: Union[bytes, str], header: str, secret: str, tolerance=None)
```

`webhooks.py:328` passes `CaseInsensitiveMapping(self.headers).get("stripe-signature")`, which is `str | None`:

```
djstripe/models/webhooks.py:328: error: Argument 2 to "verify_header" of
"WebhookSignature" has incompatible type "Any | None"; expected "str"  [arg-type]
```

`main` and every open PR fail `linting` on this. It reproduces locally only after upgrading stripe 15.4.0 → 15.5.0, which is why it appeared without anyone changing that file.

## Fix

Refuse explicitly when the header is absent, rather than handing `None` to Stripe.

**Behaviour is unchanged.** A missing header already worked out to `False` — `verify_header(body, None, ...)` raises `SignatureVerificationError("Unable to extract timestamp and signatures from header")`, which the existing `except` catches. The guard makes that path deliberate rather than incidental, satisfies the type contract, and logs a reason of our own instead of one from inside Stripe.

One test, at the model level, asserting `verify_signature` returns `False` and that `verify_header` is never called. Verified non-vacuous: removing the guard fails it with `assert True is False`.

Full suite 559 passed.

## Summary by Sourcery

Guard webhook signature verification when the Stripe-Signature header is missing to satisfy updated Stripe type expectations and keep CI linting passing.

Bug Fixes:
- Prevent passing a missing Stripe-Signature header into Stripe's webhook verification by explicitly refusing verification when the header is absent.

Tests:
- Add a webhook trigger test ensuring verification fails and Stripe's verify_header is not called when the Stripe-Signature header is missing.