### PR TITLE
Fall back to dj-stripe's own default Stripe API version

### DIFF
--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -125,7 +125,7 @@ class DjstripeSettings:
         """
         Get the desired API version to use for Stripe requests.
         """
-        version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
+        version = getattr(settings, "STRIPE_API_VERSION", None)
         return version or self.DEFAULT_STRIPE_API_VERSION
 
     def get_callback_function(self, setting_name, default=None):

--- a/djstripe/settings.py
+++ b/djstripe/settings.py
@@ -17,7 +17,7 @@ class DjstripeSettings:
 
     """
 
-    DEFAULT_STRIPE_API_VERSION = "2026-05-27.dahlia"
+    DEFAULT_STRIPE_API_VERSION = "2026-07-29.dahlia"
 
     ZERO_DECIMAL_CURRENCIES = {
         "bif",

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,6 +70,9 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
+-   The default Stripe API version is now `2026-07-29.dahlia` (was
+    `2026-05-27.dahlia`), matching the version pinned by stripe-python 15.5.1.
+
 -   dj-stripe now falls back to its own `DEFAULT_STRIPE_API_VERSION` when the
     `STRIPE_API_VERSION` setting is not configured. It previously fell back to
     `stripe.api_version`, which modern versions of stripe-python always set, so

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,6 +70,13 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
+-   dj-stripe now falls back to its own `DEFAULT_STRIPE_API_VERSION` when the
+    `STRIPE_API_VERSION` setting is not configured. It previously fell back to
+    `stripe.api_version`, which modern versions of stripe-python always set, so
+    the default was dead code and dj-stripe synced against whatever API version
+    the installed SDK happened to pin rather than the one its models are
+    written against.
+
 -   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
     `Account.get_default_account()` checked the key configured in settings
     rather than the key it was passed, and the sync command dereferenced the

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,7 @@ dj-stripe Settings Tests.
 from unittest.mock import patch
 
 import stripe
+from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
 from django.test import TestCase
@@ -127,5 +128,28 @@ class TestGetStripeApiVersion(TestCase):
     def test_with_override(self):
         self.assertEqual(
             "2016-03-07",
+            settings.djstripe_settings.STRIPE_API_VERSION,
+        )
+
+
+class TestStripeApiVersionUnset(TestCase):
+    """
+    With no STRIPE_API_VERSION in the project's settings at all, dj-stripe must
+    fall back to its own DEFAULT_STRIPE_API_VERSION, not to whatever version
+    the installed stripe-python happens to pin.
+
+    TestGetStripeApiVersion cannot catch this: it is decorated with
+    ``@override_settings(STRIPE_API_VERSION=None)``, which makes the setting
+    present and falsy rather than absent, so ``getattr``'s default is never
+    reached.
+    """
+
+    def test_setting_is_genuinely_absent(self):
+        self.assertFalse(hasattr(django_settings, "STRIPE_API_VERSION"))
+
+    @patch.object(stripe, "api_version", "1999-01-01.sdk-pin")
+    def test_falls_back_to_djstripe_default(self):
+        self.assertEqual(
+            settings.djstripe_settings.DEFAULT_STRIPE_API_VERSION,
             settings.djstripe_settings.STRIPE_API_VERSION,
         )


### PR DESCRIPTION
## What changed

```diff
-version = getattr(settings, "STRIPE_API_VERSION", stripe.api_version)
+version = getattr(settings, "STRIPE_API_VERSION", None)
```

`DjstripeSettings.STRIPE_API_VERSION` fell back to `stripe.api_version` when the
setting was unset. Modern stripe-python always sets that attribute, so the
`version or self.DEFAULT_STRIPE_API_VERSION` line below it was unreachable:
`DEFAULT_STRIPE_API_VERSION` was dead code, and a project that had not
configured `STRIPE_API_VERSION` synced against whatever API version the
installed SDK happened to pin rather than the one dj-stripe's models are written
against.

That is the opposite of what `docs/api_versions.md` documents:

> dj-stripe will always use `STRIPE_API_VERSION` in its requests regardless of
> what `stripe.api_version` is set to.

In practice the consequence is that upgrading stripe-python silently changes the
API version dj-stripe syncs with, which is exactly the coupling the setting
exists to prevent.

## Why the existing tests did not catch it

`TestGetStripeApiVersion` is decorated `@override_settings(STRIPE_API_VERSION=None)`.
That makes the setting *present and falsy* rather than absent, so `getattr`'s
default is never reached and `version or self.DEFAULT_STRIPE_API_VERSION` covers
for the bug. The class asserts the right thing and passes for the wrong reason.

The new `TestStripeApiVersionUnset` avoids the decorator entirely: it asserts
the setting is genuinely absent from `django.conf.settings`, patches
`stripe.api_version` to a sentinel, and requires dj-stripe to return its own
default. It fails on `main` with
`AssertionError: '2026-05-27.dahlia' != '1999-01-01.sdk-pin'`.

## Two commits

1.  **Fall back to dj-stripe's own default API version** — the fix and its test.
2.  **Bump the default Stripe API version to 2026-07-29.dahlia** — separate so
    it can be dropped without losing the fix.

The second is deliberately separable. `2026-07-29.dahlia` is the version
stripe-python 15.5.1 pins, so for anyone on that SDK it is what dj-stripe was
already using before commit 1 made the default reachable — which means commit 1
alone would be a behaviour change for them, and commit 1 plus commit 2 is not.
If you would rather move the default on your own schedule, drop commit 2 and the
fix still stands.

## Verification

Full suite (563 passed, 53 skipped, 24 subtests) at both commits on:

-   Django 5.2.17 / Python 3.11.16
-   Django 6.1 / Python 3.13.5
-   Django main (6.2.dev) / Python 3.13.5

Plus `ruff check`, `ruff format --check`, `mypy djstripe` and
`makemigrations --dry-run --check`, all clean.

## Summary by Sourcery

Decouple dj-stripe’s default Stripe API version from the installed stripe-python SDK and update the project default.

Bug Fixes:
- Ensure unconfigured Stripe API requests use dj-stripe’s own default version instead of the installed stripe-python SDK’s version.

Enhancements:
- Update dj-stripe’s default Stripe API version to 2026-07-29.dahlia.

Documentation:
- Document the updated default API version and the fallback behavior for unconfigured projects.

Tests:
- Add coverage verifying that an absent STRIPE_API_VERSION setting ignores stripe-python’s pinned API version.
