### PR TITLE
Require a Django release that has the August 2026 security fixes

### DIFF
--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,6 +70,12 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
+-   The minimum supported Django version is now 5.2.17. The previous
+    `django>=5.2` floor let a fresh install resolve to a 5.2 patch release
+    missing every 2026 Django security release, including CVE-2026-15307 (SSRF
+    and server-side file write via GeoDjango, fixed in 5.2.17 and 6.0.8). Only
+    the minimum has moved; the supported range is unchanged.
+
 -   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
     `Account.get_default_account()` checked the key configured in settings
     rather than the key it was passed, and the sync command dereferenced the

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,12 +70,14 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
--   The minimum supported Django version is now 5.2.17. The previous
-    `django>=5.2` floor let a fresh install resolve to a 5.2 patch release
-    missing every 2026 Django security release, including CVE-2026-15307 (SSRF
-    and server-side file write via GeoDjango, fixed in 5.2.17 and 6.0.8). Only
-    the minimum has moved; the supported range is unchanged.
-
+-   The Django requirement no longer admits releases missing the August 2026
+    security fixes. The previous `django>=5.2` floor let a fresh install resolve
+    to a 5.2 patch release missing every 2026 Django security release, including
+    CVE-2026-15307 (server-side file write and request forgery via spatial
+    lookups, rated high). That fix shipped in both 5.2.17 and 6.0.8, so the
+    requirement is now `>=5.2.17` with 6.0.0 through 6.0.7 excluded — a bare
+    `>=5.2.17` would still resolve to a vulnerable 6.0 release. Only the minimum
+    has moved; the supported range is unchanged.
 -   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
     `Account.get_default_account()` checked the key configured in settings
     rather than the key it was passed, and the sync command dereferenced the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Framework :: Django :: 6.1",
 ]
 dependencies = [
-    "django>=5.2",
+    "django>=5.2.17",
     "stripe>=15.0.1,<16",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ classifiers = [
     "Framework :: Django :: 6.1",
 ]
 dependencies = [
-    "django>=5.2.17",
+    # 6.0.0-6.0.7 carry the CVE-2026-15307 fix only from 6.0.8, so the 5.2.17
+    # floor alone would still admit a vulnerable 6.0 release.
+    "django>=5.2.17,!=6.0.0,!=6.0.1,!=6.0.2,!=6.0.3,!=6.0.4,!=6.0.5,!=6.0.6,!=6.0.7",
     "stripe>=15.0.1,<16",
 ]
 


### PR DESCRIPTION
The `django>=5.2` floor let a fresh install resolve to a 5.2 patch release missing every Django security release published in 2026 — most significantly CVE-2026-15307, server-side file write and request forgery via spatial lookups, rated high. Nothing else in the project pinned a later patch, so a resolver was free to pick 5.2.0 and a user following the install instructions would get it.

That fix shipped in 5.2.17 and 6.0.8, released the same day. Raising the floor to `>=5.2.17` alone is not enough, because dj-stripe supports the 6.0 series and 6.0.0 through 6.0.7 satisfy that specifier while still being vulnerable. The requirement is therefore:

```
django>=5.2.17,!=6.0.0,!=6.0.1,!=6.0.2,!=6.0.3,!=6.0.4,!=6.0.5,!=6.0.6,!=6.0.7
```

6.1 shipped the day after the security release and needs no exclusion.

Only the minimum has moved. The supported range is unchanged: the trove classifiers still list 5.2, 6.0 and 6.1, and `tox.ini` still tests `django52`, `django60`, `django61` and `djangomain`. Nobody currently supported is dropped — 5.2.17 is within the 5.2 LTS series, and anyone tracking security releases already has it.

Verified with `packaging.SpecifierSet` that 5.2, 5.2.16, 6.0 and 6.0.4/6.0.7 are rejected while 5.2.17, 6.0.8 and 6.1 are accepted. Full suite green — 561 passed, 53 skipped, 24 subtests — on Django 5.2.17 / Python 3.11.16, Django 6.1 / Python 3.13.5, and Django main. `ruff check`, `ruff format --check`, `mypy djstripe` and `makemigrations --dry-run --check` all clean, and `uv sync` re-resolves without complaint.

One inconsistency I noticed but did not touch, since it is outside what this PR claims to do: the `tox.ini` factors are still `Django>=5.2,<6.0` and `Django>=6.0,<6.1`, so the test matrix floors and the package floor now differ on paper. In practice pip resolves each factor to the latest patch in its series, so the matrix does test fixed versions. Happy to tighten them here if you would prefer the two read the same.