### PR TITLE
Keep ruff and its pre-commit hook on the same version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,20 @@ updates:
       - "update"
       - "action dependencies"
 
+  # Update pre-commit hooks. Without this the hook revs rot in place while the
+  # matching pip dependencies move, which is how ruff drifted out of lockstep.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      # Prefix all commit messages with "[pre-commit] " (no colon, but a trailing whitespace)
+      prefix: "[pre-commit] "
+    # Labels on pull requests for version updates only
+    labels:
+      - "update"
+      - "pip dependencies"
+
   # Update python packages
   - package-ecosystem: "pip"
     directory: "/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.4"
+    rev: "v0.16.5"
     hooks:
       - id: ruff-check
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.2"
+    rev: "v0.16.4"
     hooks:
       - id: ruff-check
       - id: ruff-format

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,11 +70,13 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
--   The `ruff-pre-commit` hook is pinned to v0.16.4, matching the ruff version
-    the `ruff>=0.16.2,<0.17` development dependency resolves to. The two had
-    drifted apart, so pre-commit and `uv run ruff` could run different
-    versions. No findings change.
-
+-   `pre-commit` and `uv run ruff` can no longer run different versions of ruff.
+    The `ruff-pre-commit` hook rev and the ruff development dependency had
+    drifted apart, because the hook was pinned exactly while the dependency was
+    an open `>=0.16.2,<0.17` range that kept resolving forward. Both are now
+    fixed at 0.16.5, and Dependabot has been given a `pre-commit` ecosystem so
+    the hook revs are updated alongside the pip dependencies instead of rotting
+    in place. No findings change.
 -   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
     `Account.get_default_account()` checked the key configured in settings
     rather than the key it was passed, and the sync command dereferenced the

--- a/docs/changes/3_0_0.md
+++ b/docs/changes/3_0_0.md
@@ -70,6 +70,11 @@
 -   `Price.create()` now passes `unit_amount` to Stripe unchanged, using Stripe's
     minor currency units instead of incorrectly multiplying the value by 100
     (#1941).
+-   The `ruff-pre-commit` hook is pinned to v0.16.4, matching the ruff version
+    the `ruff>=0.16.2,<0.17` development dependency resolves to. The two had
+    drifted apart, so pre-commit and `uv run ruff` could run different
+    versions. No findings change.
+
 -   `djstripe_sync_models` now works with restricted (`rk_`) API keys.
     `Account.get_default_account()` checked the key configured in settings
     rather than the key it was passed, and the sync command dereferenced the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dev = [
     "pytest>=9.1.1,<10",
     "pytest-django>=4.12.0,<5",
     "pytest-dotenv>=0.5.2,<0.6",
-    "ruff>=0.16.2,<0.17",
+    # Kept exact and in lockstep with the ruff-pre-commit rev in
+    # .pre-commit-config.yaml, so pre-commit and `uv run ruff` cannot disagree.
+    "ruff==0.16.5",
 ]
 ci = [
     "coverage[toml]>=7.14.1,<8",


### PR DESCRIPTION
`pre-commit` and `uv run ruff` could run different versions of ruff. The hook was pinned exactly at `v0.16.2` while the development dependency was an open `ruff>=0.16.2,<0.17` range that kept resolving forward, so the two drifted apart and a contributor could get clean hooks locally and a lint failure in CI, or the reverse.

Pinning only the hook does not fix this — it re-drifts on the next ruff release. `uv sync` on a fresh checkout today installs ruff 0.16.5, so a hook pinned at 0.16.4 is already behind. Both ends are now fixed at 0.16.5.

The underlying reason the rev rotted is that nothing was updating it: `.github/dependabot.yml` covers `github-actions` and `pip` but not `pre-commit`, so hook revs sit still while the pip dependencies move. This adds a `pre-commit` ecosystem on the same monthly cadence as the pip updates, which keeps them together without anyone having to remember.

No findings change. `pre-commit run --all-files` passes end to end, including `mypy` and `check-migrations`; `ruff check` and `ruff format --check` are clean across 183 files.

If you would rather keep this to the one-line rev bump, say so and I will split the Dependabot change into its own PR.