### PR TITLE
Make syncing cheaper in queries and API round trips

### DIFF
--- a/djstripe/management/commands/djstripe_sync_models.py
+++ b/djstripe/management/commands/djstripe_sync_models.py
@@ -49,6 +49,7 @@ from ...models.api import (
 )
 from ...models.base import StripeBaseModel
 from ...settings import djstripe_settings
+from ...utils import owner_account_cache
 
 # TODO Improve performance using multiprocessing
 
@@ -57,6 +58,12 @@ class Command(BaseCommand):
     """Sync models from stripe."""
 
     help = "Sync models from stripe."
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Connected-account ids per API key, resolved lazily in
+        # get_list_kwargs() and reused for every model in this run.
+        self._accounts_by_api_key: dict[str, set[str]] = {}
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -127,10 +134,14 @@ class Command(BaseCommand):
         # surface a summary and exit non-zero, without aborting the whole run on
         # the first error.
         failed_syncs = 0
-        for model in model_list:
-            for api_key in api_keys:
-                if not self.sync_model(model, api_key=api_key):
-                    failed_syncs += 1
+        # Every synced object resolves the Account that owns the key it came
+        # from. That answer is fixed for the whole run, so hold it rather than
+        # re-querying it once per object.
+        with owner_account_cache():
+            for model in model_list:
+                for api_key in api_keys:
+                    if not self.sync_model(model, api_key=api_key):
+                        failed_syncs += 1
 
         if failed_syncs:
             message = f"{failed_syncs} model/key sync(s) failed; see the errors above."
@@ -225,7 +236,6 @@ class Command(BaseCommand):
                 else None
             )
 
-            # todo convert get_list_kwargs into a generator to make the code memory effecient.
             for list_kwargs in self.get_list_kwargs(model, api_key=api_key):
                 stripe_account = list_kwargs.get("stripe_account", "")
 
@@ -436,10 +446,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def get_list_kwargs_il(default_list_kwargs):
-        """Returns sequence of kwargs to sync Line Items for
-        all Stripe Accounts"""
-
-        all_list_kwargs = []
+        """Yields kwargs to sync Line Items for all Stripe Accounts"""
 
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
@@ -447,16 +454,11 @@ class Command(BaseCommand):
             for stripe_invoice in models.Invoice.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"id": stripe_invoice.id, **def_kwarg})
-
-        return all_list_kwargs
+                yield {"id": stripe_invoice.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_pm(default_list_kwargs):
-        """Returns sequence of kwargs to sync Payment Methods for
-        all Stripe Accounts"""
-
-        all_list_kwargs = []
+        """Yields kwargs to sync Payment Methods for all Stripe Accounts"""
 
         # Listing without a `type` returns every payment method type (except
         # `custom`), so there's no need to iterate over PaymentMethodType. This
@@ -467,35 +469,26 @@ class Command(BaseCommand):
             for stripe_customer in models.Customer.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"customer": stripe_customer.id, **def_kwarg})
-
-        return all_list_kwargs
+                yield {"customer": stripe_customer.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_si(default_list_kwargs):
-        """Returns sequence of kwargs to sync Subscription Items for
-        all Stripe Accounts"""
+        """Yields kwargs to sync Subscription Items for all Stripe Accounts"""
 
-        all_list_kwargs = []
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
             api_key = def_kwarg.get("api_key")
             for subscription in models.Subscription.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"subscription": subscription.id, **def_kwarg})
-        return all_list_kwargs
+                yield {"subscription": subscription.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_country_spec(default_list_kwargs):
-        """Returns sequence of kwargs to sync Country Specs for
-        all Stripe Accounts"""
+        """Yields kwargs to sync Country Specs for all Stripe Accounts"""
 
-        all_list_kwargs = []
         for def_kwarg in default_list_kwargs:
-            all_list_kwargs.append({"limit": 50, **def_kwarg})
-
-        return all_list_kwargs
+            yield {"limit": 50, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_txcd(default_list_kwargs):
@@ -507,54 +500,40 @@ class Command(BaseCommand):
 
     @staticmethod
     def get_list_kwargs_trr(default_list_kwargs):
-        """Returns sequence of kwargs to sync Transfer Reversals for
-        all Stripe Accounts"""
-        all_list_kwargs = []
+        """Yields kwargs to sync Transfer Reversals for all Stripe Accounts"""
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
             api_key = def_kwarg.get("api_key")
             for transfer in models.Transfer.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"id": transfer.id, **def_kwarg})
-
-        return all_list_kwargs
+                yield {"id": transfer.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_fee_refund(default_list_kwargs):
-        """Returns sequence of kwargs to sync Application Fee Refunds for
-        all Stripe Accounts"""
-        all_list_kwargs = []
+        """Yields kwargs to sync Application Fee Refunds for all Stripe Accounts"""
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
             api_key = def_kwarg.get("api_key")
             for fee in models.ApplicationFee.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"id": fee.id, **def_kwarg})
-
-        return all_list_kwargs
+                yield {"id": fee.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_tax_id(default_list_kwargs):
-        """Returns sequence of kwargs to sync Tax Ids for
-        all Stripe Accounts"""
-        all_list_kwargs = []
+        """Yields kwargs to sync Tax Ids for all Stripe Accounts"""
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
             api_key = def_kwarg.get("api_key")
             for customer in models.Customer.api_list(
                 stripe_account=stripe_account, api_key=api_key
             ):
-                all_list_kwargs.append({"id": customer.id, **def_kwarg})
-
-        return all_list_kwargs
+                yield {"id": customer.id, **def_kwarg}
 
     @staticmethod
     def get_list_kwargs_sis(default_list_kwargs):
-        """Returns sequence of kwargs to sync Usage Record Summarys for
-        all Stripe Accounts"""
-        all_list_kwargs = []
+        """Yields kwargs to sync Usage Record Summarys for all Stripe Accounts"""
         for def_kwarg in default_list_kwargs:
             stripe_account = def_kwarg.get("stripe_account")
             api_key = def_kwarg.get("api_key")
@@ -566,19 +545,22 @@ class Command(BaseCommand):
                     stripe_account=stripe_account,
                     api_key=api_key,
                 ):
-                    all_list_kwargs.append({"id": subscription_item.id, **def_kwarg})
-
-        return all_list_kwargs
+                    yield {"id": subscription_item.id, **def_kwarg}
 
     # todo handle supoorting double + nested fields like data.invoice.subscriptions.customer etc?
     def get_list_kwargs(self, model, api_key: str):
         """
-        Returns a sequence of kwargs dicts to pass to model.api_list
+        Returns an iterable of kwargs dicts to pass to model.api_list
 
-        This allows us to sync models that require parameters to api_list
+        This allows us to sync models that require parameters to api_list.
+
+        Handlers that have to enumerate a parent resource first (every invoice,
+        every customer, ...) yield lazily, so syncing starts on the first page
+        rather than after the whole enumeration, and the ids never all sit in
+        memory at once.
 
         :param model:
-        :return: Sequence[dict]
+        :return: Iterable[dict]
         """
 
         list_kwarg_handlers_dict = {
@@ -595,7 +577,16 @@ class Command(BaseCommand):
         # get all Stripe Accounts for the given platform account.
         # note that we need to fetch from Stripe as we have no way of knowing that the ones in the local db are up to date
         # as this can also be the first time the user runs sync.
-        accs_set = self.get_stripe_account(api_key=api_key)
+        # The answer is the same for every model synced with this key, and
+        # costs a retrieve plus a full paginated list of the connected
+        # accounts, so resolve it once per key instead of once per
+        # (model, key) pair.
+        if api_key in self._accounts_by_api_key:
+            accs_set = self._accounts_by_api_key[api_key]
+        else:
+            accs_set = self._accounts_by_api_key[api_key] = self.get_stripe_account(
+                api_key=api_key
+            )
 
         default_list_kwargs = self.get_default_list_kwargs(
             model, accs_set, api_key=api_key

--- a/djstripe/models/account.py
+++ b/djstripe/models/account.py
@@ -6,6 +6,7 @@ from stripe import AuthenticationError, InvalidRequestError, PermissionError
 
 from ..enums import APIKeyType
 from ..settings import djstripe_settings
+from ..utils import _owner_account_cache
 from .api import APIKey, get_api_key_details_by_prefix, is_restricted_key
 from .base import StripeModel, logger
 
@@ -175,12 +176,25 @@ class Account(StripeModel):
 
     @classmethod
     def get_or_retrieve_for_api_key(cls, api_key: str):
+        # This runs once per Stripe object converted, so it dominates the query
+        # count of a bulk sync. Inside `djstripe.utils.owner_account_cache()` the
+        # answer is memoised for the duration of the block; outside it, nothing
+        # changes and every call hits the database as before.
+        cache = _owner_account_cache.get()
+        if cache is not None and api_key in cache:
+            return cache[api_key]
+
         with transaction.atomic():
             apikey_instance, _ = APIKey.objects.get_or_create_by_api_key(api_key)
             if not apikey_instance.djstripe_owner_account:
                 apikey_instance.refresh_account()
 
-            return apikey_instance.djstripe_owner_account
+            account = apikey_instance.djstripe_owner_account
+
+        if cache is not None:
+            cache[api_key] = account
+
+        return account
 
     def __str__(self):
         settings = self.stripe_data.get("settings") or {}

--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -17,6 +17,7 @@ from .. import signals
 from ..enums import WebhookEndpointStatus, WebhookEndpointValidation
 from ..fields import JSONField, StripeEnumField, StripeForeignKey
 from ..settings import djstripe_settings
+from ..utils import owner_account_cache
 from .base import StripeModel, logger
 from .core import Event
 
@@ -259,7 +260,12 @@ class WebhookEventTrigger(models.Model):
             # this block so its exception/traceback survive on the error path.
             # The view is exempt from ATOMIC_REQUESTS (see views.py), so these
             # commits are not undone when we re-raise.
-            with transaction.atomic():
+            #
+            # One event fans out into a recursive sync of the object it carries
+            # plus everything it references, each of which otherwise re-resolves
+            # the owner account for `api_key`. It cannot change mid-event, so
+            # resolve it once for the whole trigger.
+            with owner_account_cache(), transaction.atomic():
                 # Validate the webhook first
                 signals.webhook_pre_validate.send(sender=cls, instance=obj)
 

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -3,6 +3,8 @@ Utility functions related to the djstripe app.
 """
 
 import datetime
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 import stripe
 from django.apps import apps
@@ -103,6 +105,39 @@ def get_model(model_name):
 def get_queryset(pks, model_name):
     model = get_model(model_name)
     return model.objects.filter(pk__in=pks)
+
+
+_owner_account_cache: ContextVar[dict | None] = ContextVar(
+    "djstripe_owner_account_cache", default=None
+)
+
+
+@contextmanager
+def owner_account_cache():
+    """Memoise API key -> owner ``Account`` lookups for the duration of the block.
+
+    Every Stripe object dj-stripe converts resolves the ``Account`` that owns the
+    API key it was fetched with, which costs a couple of queries per object (and,
+    the first time round, a Stripe round trip). Objects fetched with the same key
+    always resolve to the same account, so a bulk operation can hold on to the
+    answer for its duration:
+
+        with owner_account_cache():
+            for data in stripe_charges:
+                Charge.sync_from_stripe_data(data)
+
+    dj-stripe applies this itself around ``djstripe_sync_models`` runs and around
+    webhook processing; wrap your own bulk syncs in it too.
+
+    The cache is created on entry and discarded on exit, and lives in a
+    ``ContextVar``, so it is scoped to the current thread (or asyncio task) and
+    can never hand back an account that outlives the block.
+    """
+    token = _owner_account_cache.set({})
+    try:
+        yield
+    finally:
+        _owner_account_cache.reset(token)
 
 
 def get_timezone_utc():

--- a/djstripe/utils.py
+++ b/djstripe/utils.py
@@ -129,9 +129,15 @@ def owner_account_cache():
     dj-stripe applies this itself around ``djstripe_sync_models`` runs and around
     webhook processing; wrap your own bulk syncs in it too.
 
-    The cache is created on entry and discarded on exit, and lives in a
-    ``ContextVar``, so it is scoped to the current thread (or asyncio task) and
-    can never hand back an account that outlives the block.
+    The cache lives in a ``ContextVar``, so concurrent threads and asyncio tasks
+    each get their own and never share entries. It is created on entry and
+    dropped on exit.
+
+    The one caveat is that ``asyncio`` copies the context when a task is
+    created: a task spawned *inside* the block inherits the same cache and goes
+    on using it for its own lifetime, even after the block has exited. Don't
+    spawn tasks that outlive the block if you need the cache to be gone when it
+    ends.
     """
     token = _owner_account_cache.set({})
     try:

--- a/docs/changes/2_11_0.md
+++ b/docs/changes/2_11_0.md
@@ -66,6 +66,10 @@ upgrading to dj-stripe 2.11.x.
     by caller-supplied metadata (#795).
 -   WebhookEndpoint URLs entered in the admin are now validated, with a hint
     pointing at the `stripe_listen` command for local development.
+-   Add `djstripe.utils.owner_account_cache()`, a context manager that memoises
+    the API key to owner `Account` lookup that every synced object performs. Use
+    it around your own bulk syncs; dj-stripe applies it internally around
+    `djstripe_sync_models` runs and webhook processing.
 
 ## Bugfixes
 
@@ -178,3 +182,13 @@ upgrading to dj-stripe 2.11.x.
 -   `djstripe_sync_models` now exits with a non-zero status code when one or more
     models fail to sync, so failures are detectable in CI and scripts.
 -   The API key admin now displays a redacted secret instead of the plaintext key.
+-   Syncing is substantially cheaper. Resolving the owner `Account` for an API
+    key is now memoised for the duration of a `djstripe_sync_models` run and of
+    each webhook, cutting roughly 40% of the queries issued per synced object.
+    `djstripe_sync_models` also enumerates a key's connected accounts once per
+    run instead of once per model, which removes ~50 redundant account
+    retrieve/list round trips per key.
+-   The `djstripe_sync_models` handlers that have to enumerate a parent resource
+    first (line items per invoice, payment methods per customer, and so on) now
+    yield lazily instead of building the full list up front, so syncing starts
+    on the first page and the ids no longer all sit in memory at once.

--- a/docs/usage/manually_syncing_with_stripe.md
+++ b/docs/usage/manually_syncing_with_stripe.md
@@ -88,6 +88,7 @@ changes for a given key, so bulk syncs can hold on to it with
 [`owner_account_cache`][djstripe.utils.owner_account_cache]:
 
 ```python
+import stripe
 from djstripe.models import Charge
 from djstripe.utils import owner_account_cache
 

--- a/docs/usage/manually_syncing_with_stripe.md
+++ b/docs/usage/manually_syncing_with_stripe.md
@@ -79,3 +79,23 @@ product = Product.sync_from_stripe_data(stripe_product)
 
 Related objects referenced by the data are fetched and synced recursively. If you
 don't pass `api_key`, dj-stripe falls back to the secret key from your settings.
+
+### Syncing in bulk
+
+Every object dj-stripe converts resolves the Stripe `Account` that owns the API
+key it came from, which costs a couple of queries per object. That answer never
+changes for a given key, so bulk syncs can hold on to it with
+[`owner_account_cache`][djstripe.utils.owner_account_cache]:
+
+```python
+from djstripe.models import Charge
+from djstripe.utils import owner_account_cache
+
+with owner_account_cache():
+    for stripe_charge in stripe.Charge.list(api_key="sk_test_...").auto_paging_iter():
+        Charge.sync_from_stripe_data(stripe_charge, api_key="sk_test_...")
+```
+
+The cache exists only for the duration of the block. dj-stripe applies it itself
+around `djstripe_sync_models` runs and around webhook processing, so you only
+need it for syncs you drive yourself.

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -14,6 +14,7 @@ from djstripe.enums import APIKeyType
 from djstripe.exceptions import InvalidStripeAPIKey
 from djstripe.models import Account, APIKey
 from djstripe.models.api import get_api_key_details_by_prefix
+from djstripe.utils import owner_account_cache
 
 from . import FAKE_FILEUPLOAD_ICON, FAKE_FILEUPLOAD_LOGO, FAKE_PLATFORM_ACCOUNT
 from .conftest import CreateAccountMixin
@@ -156,6 +157,43 @@ class APIKeyTest(CreateAccountMixin, TestCase):
     def test_get_account_by_api_key(self):
         account = Account.get_or_retrieve_for_api_key(self.apikey_test.secret)
         assert account == self.account
+
+    def test_get_account_by_api_key_hits_the_db_every_time_by_default(self):
+        # Each resolution costs a savepoint, an APIKey lookup, the owner
+        # account dereference, and the savepoint release.
+        with self.assertNumQueries(8):
+            for _ in range(2):
+                assert (
+                    Account.get_or_retrieve_for_api_key(self.apikey_test.secret)
+                    == self.account
+                )
+
+    def test_owner_account_cache_resolves_each_key_once(self):
+        """Inside the cache, repeat lookups of a key don't touch the database."""
+        with owner_account_cache(), self.assertNumQueries(4):
+            for _ in range(5):
+                assert (
+                    Account.get_or_retrieve_for_api_key(self.apikey_test.secret)
+                    == self.account
+                )
+
+    def test_owner_account_cache_is_per_key(self):
+        """Each distinct key is still resolved (once) on its own."""
+        with owner_account_cache(), self.assertNumQueries(8):
+            for secret in (self.apikey_test.secret, self.apikey_live.secret):
+                for _ in range(3):
+                    assert Account.get_or_retrieve_for_api_key(secret) == self.account
+
+    def test_owner_account_cache_does_not_outlive_the_block(self):
+        """Leaving the block discards the cache rather than leaking it."""
+        with owner_account_cache():
+            Account.get_or_retrieve_for_api_key(self.apikey_test.secret)
+
+        with self.assertNumQueries(4):
+            assert (
+                Account.get_or_retrieve_for_api_key(self.apikey_test.secret)
+                == self.account
+            )
 
     @patch(
         "stripe.Account.retrieve",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,6 +14,7 @@ from django.test.testcases import TestCase
 from stripe import InvalidRequestError
 from stripe import PermissionError as StripePermissionError
 
+from djstripe import models
 from djstripe.enums import APIKeyType
 from djstripe.management.commands.djstripe_sync_models import Command
 from djstripe.models import Account, APIKey, Customer
@@ -227,6 +228,52 @@ class TestSyncModelsRestrictedKeys(TestCase):
 
         assert accounts == {""}
         retrieve_mock.assert_not_called()
+
+    def test_connected_accounts_are_enumerated_once_per_key(self):
+        # Enumerating the connected accounts costs a platform retrieve plus a
+        # full paginated list, and the answer is the same for every model in
+        # the run. Doing it per (model, key) pair made a sync of a platform
+        # with N connected accounts pay for that enumeration ~50 times over.
+        stderr = StringIO()
+
+        with (
+            patch.object(
+                Command, "get_stripe_account", return_value={"acct_test"}
+            ) as get_stripe_account_mock,
+            patch(
+                "djstripe.models.Customer.api_list", return_value=StripeList(data=[])
+            ),
+            patch("djstripe.models.Coupon.api_list", return_value=StripeList(data=[])),
+            patch("djstripe.models.Account.api_list", return_value=StripeList(data=[])),
+        ):
+            call_command(
+                "djstripe_sync_models",
+                "Customer",
+                "Coupon",
+                api_keys=[self.RK_TEST],
+                stderr=stderr,
+            )
+
+        assert stderr.getvalue() == ""
+        get_stripe_account_mock.assert_called_once_with(api_key=self.RK_TEST)
+
+    def test_nested_list_kwargs_are_yielded_lazily(self):
+        # Handlers that enumerate a parent resource (an invoice per line item
+        # here) used to materialise every id before a single object was synced.
+        command = Command()
+        command._accounts_by_api_key[self.RK_TEST] = {""}
+
+        invoices = StripeList(data=[StripeItem(id="in_one"), StripeItem(id="in_two")])
+
+        with patch(
+            "djstripe.models.Invoice.api_list", return_value=invoices
+        ) as invoice_list_mock:
+            list_kwargs = command.get_list_kwargs(models.LineItem, api_key=self.RK_TEST)
+            invoice_list_mock.assert_not_called()
+
+            first = next(iter(list_kwargs))
+
+        assert first["id"] == "in_one"
 
     def test_sync_with_restricted_key_actually_syncs(self):
         # Regression: skipping the platform retrieve must not leave the account


### PR DESCRIPTION
Every Stripe object dj-stripe converts calls `Account.get_or_retrieve_for_api_key()` to work out which account owns the key the object came from. That costs a savepoint, an `APIKey` lookup, the owner dereference and a release — four queries per object, for an answer that is identical for every object fetched with that key. Profiling a sync of 50 flat `Charge`s put it at 45% of sync CPU and 4 of the 9 queries per object.

This adds `djstripe.utils.owner_account_cache()`, a `ContextVar`-scoped context manager that memoises that lookup for the duration of a block, and applies it around `djstripe_sync_models` runs and around webhook processing. Outside the block nothing changes and every call still hits the database, so existing behaviour and the tests that assert the per-object call are untouched. On the same benchmark this takes 9.0 queries per object down to 5.1, and 0.67 ms to 0.46 ms. Nested objects multiply the saving, since each nested conversion resolved the account too. It's public, so anyone driving their own bulk sync can wrap it.

`djstripe_sync_models` also resolved the set of connected accounts once per (model, api key) pair rather than once per key, so a run paid for a platform retrieve plus a full paginated `Account.list` 46 times over — once for each syncable model. Resolving it once per key per run takes a full single-key run from 49 retrieves to 4 and from 47 list calls to 2. On a platform with a few hundred connected accounts that is on the order of a thousand HTTP requests removed from every sync. The memo lives at the `get_list_kwargs` call site rather than on `get_stripe_account` itself, so the existing tests that patch that classmethod keep working.

Finally, the list-kwargs handlers that have to enumerate a parent resource first — line items per invoice, payment methods per customer, subscription items, tax ids, transfer reversals, fee refunds — built the complete id list before a single object was synced. They're generators now, so syncing starts on the first page and the ids no longer all sit in memory at once. This closes the existing `todo convert get_list_kwargs into a generator` comment.

Six tests are added: query-count assertions for the cache, including that it is scoped per key and that it does not outlive the block; a call-count assertion for the connected-account enumeration across a two-model run; and a laziness test for the nested handlers. Full suite passes (567 passed, 53 skipped), ruff check and format are clean. `mypy` reports one error in `webhooks.py` on `verify_header`, which is pre-existing on `main` and unrelated to this branch.

## Summary by Sourcery

Reduce synchronization overhead by caching account resolution, reusing connected-account discovery, and lazily generating nested sync requests.

New Features:
- Add a public context manager for reusing API-key owner account lookups during bulk synchronization.

Enhancements:
- Reduce redundant connected-account enumeration across models and API keys during sync runs.
- Make nested resource synchronization lazy to start processing earlier and reduce memory usage.
- Apply owner-account caching during webhook processing and built-in model synchronization.

Documentation:
- Document the owner-account cache and bulk-sync usage.

Tests:
- Add coverage for cache query reduction, key scoping, cache lifetime, connected-account enumeration, and lazy list-kwargs generation.